### PR TITLE
Enforce resource usage in builtin operators

### DIFF
--- a/python/sycamore/execution/__init__.py
+++ b/python/sycamore/execution/__init__.py
@@ -1,13 +1,16 @@
 from sycamore.execution.basics import (
-    LeafNode, Node, Rule, Scan, Transform, UnaryNode, Write)
+    LeafNode, Node, NonGPUUser, Rule, Scan, SingleThreadUser,
+    Transform, UnaryNode, Write)
 from sycamore.execution.rewriter import Rewriter
 
 __all__ = [
     "LeafNode",
     "Node",
+    "NonGPUUser",
     "Rewriter",
     "Rule",
     "Scan",
+    "SingleThreadUser",
     "Transform",
     "UnaryNode",
     "Write"

--- a/python/sycamore/execution/functions/elements.py
+++ b/python/sycamore/execution/functions/elements.py
@@ -1,7 +1,7 @@
 import functools
 from typing import Callable
 
-from data import Document, Element
+from sycamore.data import Document, Element
 
 
 def reorder_elements(

--- a/python/sycamore/execution/rewriter.py
+++ b/python/sycamore/execution/rewriter.py
@@ -1,14 +1,18 @@
 from typing import List
 
 from sycamore.execution import (Node, Rule)
-from sycamore.execution.rules import OptimizeResourceArgs
+from sycamore.execution.rules import (
+    OptimizeResourceArgs, EnforceResourceUsage)
 
 
 class Rewriter:
 
     def __init__(self, extension_rules: List[Rule]):
-        self.rules = [OptimizeResourceArgs(), *extension_rules]
+        self.rules = [
+            EnforceResourceUsage(),
+            OptimizeResourceArgs(),
+            *extension_rules]
 
     def rewrite(self, plan: Node) -> None:
         for rule in self.rules:
-            rule(plan)
+            plan.traverse_down(rule)

--- a/python/sycamore/execution/rules/__init__.py
+++ b/python/sycamore/execution/rules/__init__.py
@@ -1,6 +1,7 @@
 from sycamore.execution.rules.optimize_resource_args import \
-    OptimizeResourceArgs
+    (EnforceResourceUsage, OptimizeResourceArgs)
 
 __all__ = [
+    "EnforceResourceUsage",
     "OptimizeResourceArgs"
 ]

--- a/python/sycamore/execution/rules/optimize_resource_args.py
+++ b/python/sycamore/execution/rules/optimize_resource_args.py
@@ -1,6 +1,17 @@
-from sycamore.execution import (Node, Rule)
+from sycamore.execution import (
+    Node, NonGPUUser, Rule, SingleThreadUser)
+
+
+class EnforceResourceUsage(Rule):
+    def __call__(self, plan: Node) -> Node:
+        if isinstance(plan, SingleThreadUser):
+            plan.resource_args["num_cpus"] = 1
+
+        if isinstance(plan, NonGPUUser):
+            plan.resource_args["num_gpus"] = 0
+        return plan
 
 
 class OptimizeResourceArgs(Rule):
     def __call__(self, plan: Node) -> Node:
-        pass
+        return plan

--- a/python/sycamore/execution/scans/file_scan.py
+++ b/python/sycamore/execution/scans/file_scan.py
@@ -63,7 +63,7 @@ class BinaryScan(FileScan):
             parallelism=self.parallelism,
             partition_filter=partition_filter,
             ray_remote_args=self.resource_args)
-        return files.map(self._to_document)
+        return files.map(self._to_document, **self.resource_args)
 
     def format(self):
         return self._binary_format

--- a/python/sycamore/execution/transforms/__init__.py
+++ b/python/sycamore/execution/transforms/__init__.py
@@ -2,13 +2,16 @@ from sycamore.execution.transforms.embedding import \
     SentenceTransformerEmbedding
 from sycamore.execution.transforms.explode import Explode
 from sycamore.execution.transforms.mapping import (Map, FlatMap, MapBatch)
-from sycamore.execution.transforms.partition import UnstructuredPartition
+from sycamore.execution.transforms.partition import (
+    PartitionerOptions, PdfPartitionerOptions, UnstructuredPartition)
 
 __all__ = [
     "Explode",
     "FlatMap",
     "Map",
     "MapBatch",
+    "PartitionerOptions",
+    "PdfPartitionerOptions",
     "SentenceTransformerEmbedding",
     "UnstructuredPartition"
 ]

--- a/python/sycamore/execution/transforms/explode.py
+++ b/python/sycamore/execution/transforms/explode.py
@@ -3,12 +3,13 @@ from typing import (Any, Dict, List)
 from ray.data import Dataset
 
 from sycamore.data import Document
-from sycamore.execution import (Node, Transform)
+from sycamore.execution import (
+    Node, Transform, SingleThreadUser, NonGPUUser)
 
 
-class Explode(Transform):
-    def __init__(self, child: Node):
-        super().__init__(child)
+class Explode(SingleThreadUser, NonGPUUser, Transform):
+    def __init__(self, child: Node, **resource_args):
+        super().__init__(child, **resource_args)
 
     class ExplodeCallable:
         @staticmethod

--- a/python/sycamore/tests/unit/execution/functions/test_elements.py
+++ b/python/sycamore/tests/unit/execution/functions/test_elements.py
@@ -1,6 +1,7 @@
-from data import Document, Element
-from execution.functions import reorder_elements
-from execution.transforms.partition import _elements_reorder_comparator
+from sycamore.data import Document, Element
+from sycamore.execution.functions import reorder_elements
+from sycamore.execution.transforms.partition import \
+    _elements_reorder_comparator
 
 
 class TestElementFunctions:

--- a/python/sycamore/tests/unit/execution/test_node.py
+++ b/python/sycamore/tests/unit/execution/test_node.py
@@ -5,7 +5,7 @@ from sycamore.execution import Node
 
 class MockNode(Node):
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__([], **kwargs)
         self.value = 0
 
 
@@ -27,12 +27,11 @@ def mock_a_dag(mocker):
     root_node, inter_node1, inter_node2, leaf_node1, leaf_node2 = \
         MockNode(), MockNode(), MockNode(), MockNode(), MockNode()
 
-    mocker.patch.object(
-        root_node, "child", new=lambda: [inter_node1, inter_node2])
-    mocker.patch.object(inter_node1, "child", new=lambda: leaf_node1)
-    mocker.patch.object(inter_node2, "child", new=lambda: leaf_node2)
-    mocker.patch.object(leaf_node1, "child", new=lambda: None)
-    mocker.patch.object(leaf_node2, "child", new=lambda: None)
+    mocker.patch.object(root_node, "children", [inter_node1, inter_node2])
+    mocker.patch.object(inter_node1, "children", [leaf_node1])
+    mocker.patch.object(inter_node2, "children", [leaf_node2])
+    mocker.patch.object(leaf_node1, "children", [])
+    mocker.patch.object(leaf_node2, "children", [])
 
     return root_node, inter_node1, inter_node2, leaf_node1, leaf_node2
 

--- a/python/sycamore/tests/unit/execution/test_rewriter.py
+++ b/python/sycamore/tests/unit/execution/test_rewriter.py
@@ -1,0 +1,25 @@
+from sycamore.execution.rules import EnforceResourceUsage
+from sycamore.execution.scans import BinaryScan
+from sycamore.execution.transforms import (
+    UnstructuredPartition, Explode, PdfPartitionerOptions)
+from sycamore.execution.writes import OpenSearchWriter
+
+
+class TestRewriter:
+    def test_enforce_resource_usage(self):
+        scan = BinaryScan("path", binary_format="pdf")
+        partition = UnstructuredPartition(scan, PdfPartitionerOptions())
+        explode = Explode(partition)
+        writer = OpenSearchWriter(
+                explode, "test", os_client_args={"a": 1, "b": "str"})
+
+        rule = EnforceResourceUsage()
+        writer.traverse_down(rule)
+        assert (scan.resource_args["num_cpus"] == 1 and
+                scan.resource_args["num_gpus"] == 0)
+        assert (partition.resource_args["num_cpus"] == 1 and
+                partition.resource_args["num_gpus"] == 0)
+        assert (explode.resource_args["num_cpus"] == 1 and
+                explode.resource_args["num_gpus"] == 0)
+        assert (writer.resource_args["num_cpus"] == 1 and
+                writer.resource_args["num_gpus"] == 0)

--- a/python/sycamore/tests/unit/test_docset.py
+++ b/python/sycamore/tests/unit/test_docset.py
@@ -3,7 +3,7 @@ from sycamore.execution import Node
 from sycamore.execution.scans import BinaryScan
 from sycamore.execution.transforms import (
     SentenceTransformerEmbedding, FlatMap, Map, MapBatch,
-    UnstructuredPartition)
+    UnstructuredPartition, PdfPartitionerOptions)
 
 
 class TestDocSet:
@@ -12,7 +12,7 @@ class TestDocSet:
         context = mocker.Mock(spec=Context)
         scan = mocker.Mock(spec=BinaryScan)
         docset = DocSet(context, scan)
-        docset = docset.unstructured_partition(col_name="bytes")
+        docset = docset.unstructured_partition(PdfPartitionerOptions())
         assert (isinstance(docset.lineage(), UnstructuredPartition))
 
     def test_sentence_transformer_embedding(self, mocker):

--- a/python/sycamore/tests/unit/test_writer.py
+++ b/python/sycamore/tests/unit/test_writer.py
@@ -6,7 +6,7 @@ from sycamore.execution.writes import OpenSearchWriter
 class TestDocSetWriter:
     def test_opensearch(self, mocker):
         context = mocker.Mock(spec=Context)
-        docset = DocSet(context, Node())
+        docset = DocSet(context, Node([mocker.Mock()]))
         execute = mocker.patch.object(OpenSearchWriter, "execute")
         docset.write.opensearch(os_client_args={}, index_name="index")
         execute.assert_called_once()

--- a/python/sycamore/writer.py
+++ b/python/sycamore/writer.py
@@ -5,9 +5,10 @@ from sycamore.execution import Node
 
 
 class DocSetWriter:
-    def __init__(self, context: Context, plan: Node):
+    def __init__(self, context: Context, plan: Node, **resource_args):
         self.context = context
         self.plan = plan
+        self.resource_args = resource_args
 
     def opensearch(
             self,
@@ -20,5 +21,6 @@ class DocSetWriter:
             self.plan,
             index_name,
             os_client_args=os_client_args,
-            index_settings=index_settings)
+            index_settings=index_settings,
+            **self.resource_args)
         os.execute()


### PR DESCRIPTION
This helps ray be clear about resource usage so multiple jobs could be scheduled in same cluster more reasonablly, also avoids unintentional setting of resources by users.