### PR TITLE
Use sycamore.document id as opensearch _id

### DIFF
--- a/python/sycamore/docset.py
+++ b/python/sycamore/docset.py
@@ -34,6 +34,13 @@ class DocSet:
         for row in dataset.take(limit):
             print(row)
 
+    def count(self) -> int:
+        from sycamore import Execution
+        execution = Execution(self.context, self.plan)
+        dataset = execution.execute(self.plan)
+        return dataset.count()
+
+
     @staticmethod
     def schema() -> "Schema":
         # TODO, enforce schema for document, also properties need to be

--- a/python/sycamore/execution/writes/opensearch.py
+++ b/python/sycamore/execution/writes/opensearch.py
@@ -108,11 +108,11 @@ class OSDataSource(Datasource):
 
         def create_actions():
             for i, row in enumerate(block):
-
+                doc = OSDataSource.extract_os_document(row)
                 action = {
                     "_index": index_name,
-                    "_id": i,
-                    "_source": OSDataSource.extract_os_document(row)
+                    "_id": doc["doc_id"],
+                    "_source": doc
                 }
                 yield action
 


### PR DESCRIPTION
Tested with benchmarking demo and looking at count of docs in os index