### PR TITLE
Make code pass mypy type checks.

### DIFF
--- a/python/.pre-commit-config.yaml
+++ b/python/.pre-commit-config.yaml
@@ -23,3 +23,19 @@ repos:
     hooks:
       - id: ruff
         name: ruff
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.5.1
+    hooks:
+        - id: mypy
+          args: [--ignore-missing-imports]
+
+  - repo: local
+    hooks:
+      - id: pytest-check
+        name: pytest-check
+        # Needed because otherwise it seems to always run pytest in the git root.
+        entry: bash -c 'cd python && poetry run pytest sycamore/tests/unit'
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -41,6 +41,10 @@ line-length = 120
 [tool.black]
 line-length = 120
 
+[tool.mypy]
+exclude = ["notebooks"]
+ignore_missing_imports = true
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/python/sycamore/context.py
+++ b/python/sycamore/context.py
@@ -1,5 +1,5 @@
 import threading
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import ray
 
@@ -7,9 +7,12 @@ from sycamore.execution import Rule
 
 
 class Context:
-    def __init__(self, ray_args: Dict[str, Any] = None):
+    def __init__(self, ray_args: Optional[dict[str, Any]] = None):
+        if ray_args is None:
+            ray_args = {}
+
         ray.init(**ray_args)
-        self.extension_rules: List[Rule] = []
+        self.extension_rules: list[Rule] = []
         self._internal_lock = threading.Lock()
 
     @property
@@ -22,7 +25,7 @@ class Context:
         with self._internal_lock:
             self.extension_rules.append(rule)
 
-    def get_extension_rule(self) -> List[Rule]:
+    def get_extension_rule(self) -> list[Rule]:
         with self._internal_lock:
             copied = self.extension_rules.copy()
         return copied
@@ -36,7 +39,7 @@ _context_lock = threading.Lock()
 _global_context: Optional[Context] = None
 
 
-def init(ray_args: Dict[str, Any] = None) -> Optional[Context]:
+def init(ray_args: Optional[dict[str, Any]] = None) -> Optional[Context]:
     global _global_context
     with _context_lock:
         if _global_context is None:

--- a/python/sycamore/data/document.py
+++ b/python/sycamore/data/document.py
@@ -1,5 +1,5 @@
 from collections import UserDict
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 
 class Element(UserDict):
@@ -60,19 +60,26 @@ class Element(UserDict):
             self.data["content"]["text"] = content
 
     @property
-    def properties(self) -> Optional[Dict[str, Any]]:
+    def properties(self) -> dict[str, Any]:
         return self.data["properties"]
 
     @properties.deleter
     def properties(self) -> None:
         self.data["properties"] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return self.data
 
 
 class TableElement(Element):
-    def __init__(self, element=None, title: str = None, columns: List[str] = None, rows: List[Any] = None, **kwargs):
+    def __init__(
+        self,
+        element=None,
+        title: Optional[str] = None,
+        columns: Optional[list[str]] = None,
+        rows: Optional[list[Any]] = None,
+        **kwargs,
+    ):
         super().__init__(element, **kwargs)
         self.data["type"] = "table"
         self.data["properties"]["title"] = title
@@ -80,23 +87,19 @@ class TableElement(Element):
         self.data["properties"]["rows"] = rows
 
     @property
-    def type(self) -> Optional[str]:
-        return "table"
-
-    @property
-    def rows(self) -> Optional[List[Any]]:
+    def rows(self) -> Optional[list[Any]]:
         return self.data["properties"]["rows"]
 
     @rows.setter
-    def rows(self, rows: List[Any] = None) -> None:
+    def rows(self, rows: Optional[list[Any]] = None) -> None:
         self.data["properties"]["rows"] = rows
 
     @property
-    def columns(self) -> Optional[List[str]]:
+    def columns(self) -> Optional[list[str]]:
         return self.data["properties"]["columns"]
 
     @columns.setter
-    def columns(self, columns: List[str] = None) -> None:
+    def columns(self, columns: Optional[list[str]] = None) -> None:
         self.data["properties"]["columns"] = columns
 
 
@@ -174,11 +177,11 @@ class Document(UserDict):
             self.data["content"]["text"] = content
 
     @property
-    def elements(self) -> Optional[List[Element]]:
+    def elements(self) -> list[Element]:
         return self.data["elements"]["array"]
 
     @elements.setter
-    def elements(self, elements: List[Element]):
+    def elements(self, elements: list[Element]):
         self.data["elements"] = {"array": elements}
 
     @elements.deleter
@@ -186,11 +189,11 @@ class Document(UserDict):
         self.data["elements"] = {"array": []}
 
     @property
-    def embedding(self) -> Dict[None, List[List[float]]]:
+    def embedding(self) -> dict[None, list[list[float]]]:
         return self.data["embedding"]
 
     @embedding.setter
-    def embedding(self, embedding: List[List[float]]) -> None:
+    def embedding(self, embedding: list[list[float]]) -> None:
         self.data["embedding"] = embedding
 
     @property
@@ -202,14 +205,14 @@ class Document(UserDict):
         self.data["parent_id"] = value
 
     @property
-    def properties(self) -> Optional[Dict[str, Any]]:
+    def properties(self) -> dict[str, Any]:
         return self.data["properties"]
 
     @properties.deleter
     def properties(self) -> None:
         self.data["properties"] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         dicts = [element.to_dict() for element in self.data["elements"]["array"]]
         self.data["elements"]["array"] = dicts
         return self.data

--- a/python/sycamore/execution/basics.py
+++ b/python/sycamore/execution/basics.py
@@ -1,28 +1,27 @@
 from abc import ABC, abstractmethod
-from typing import Callable, List, TypeVar
+from typing import Callable
 
 from ray.data import Dataset
 
 
 class Node(ABC):
-    def __init__(self, children: List["Node"], **resource_args):
+    def __init__(self, children: list["Node"], **resource_args):
         self.children = children
         self.resource_args = resource_args
 
     def __str__(self):
         return "node"
 
-    def execute(self) -> "Dataset":
+    @abstractmethod
+    def execute(self) -> Dataset:
         pass
 
-    T = TypeVar("T", bound="Node", covariant=True)
-
-    def traverse_down(self, f: Callable[[T], T]) -> T:
+    def traverse_down(self, f: Callable[["Node"], "Node"]) -> "Node":
         f(self)
         self.children = [c.traverse_down(f) for c in self.children]
         return self
 
-    def traverse_up(self, f: Callable[[T], T]) -> T:
+    def traverse_up(self, f: Callable[["Node"], "Node"]) -> "Node":
         self.children = [c.traverse_up(f) for c in self.children]
         f(self)
         return self

--- a/python/sycamore/execution/functions/chunker.py
+++ b/python/sycamore/execution/functions/chunker.py
@@ -1,8 +1,10 @@
-from typing import List, Any
+from abc import abstractmethod
+from typing import Any
 
 
 class Chunker:
-    def chunk(self, tokens: List[Any]) -> List[Any]:
+    @abstractmethod
+    def chunk(self, tokens: list[Any]) -> list[Any]:
         pass
 
 
@@ -14,7 +16,7 @@ class TokenOverlapChunker(Chunker):
         self._chunk_token_count = chunk_token_count
         self._chunk_overlap_token_count = chunk_overlap_token_count
 
-    def chunk(self, tokens: List[Any]) -> List[Any]:
+    def chunk(self, tokens: list[Any]) -> list[Any]:
         return [
             tokens[a : a + self._chunk_token_count]
             for a in range(0, len(tokens), self._chunk_token_count - self._chunk_overlap_token_count)

--- a/python/sycamore/execution/rewriter.py
+++ b/python/sycamore/execution/rewriter.py
@@ -1,11 +1,9 @@
-from typing import List
-
 from sycamore.execution import Node, Rule
 from sycamore.execution.rules import OptimizeResourceArgs, EnforceResourceUsage
 
 
 class Rewriter:
-    def __init__(self, extension_rules: List[Rule]):
+    def __init__(self, extension_rules: list[Rule]):
         self.rules = [EnforceResourceUsage(), OptimizeResourceArgs(), *extension_rules]
 
     def rewrite(self, plan: Node) -> None:

--- a/python/sycamore/execution/scans/file_scan.py
+++ b/python/sycamore/execution/scans/file_scan.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 from pyarrow.filesystem import FileSystem
 from ray.data import Dataset, read_binary_files, read_json
@@ -8,7 +8,7 @@ from sycamore.data import Document
 from sycamore.execution import Scan
 
 
-def _set_id(doc: Dict[str, Any]) -> Dict[str, Any]:
+def _set_id(doc: dict[str, Any]) -> dict[str, Any]:
     import uuid
 
     doc["doc_id"] = str(uuid.uuid1())
@@ -18,7 +18,7 @@ def _set_id(doc: Dict[str, Any]) -> Dict[str, Any]:
 class FileScan(Scan):
     """A base scan class for file based data"""
 
-    def __init__(self, paths: Union[str, List[str]], *, parallelism: Optional[int] = None, **resource_args):
+    def __init__(self, paths: Union[str, list[str]], *, parallelism: Optional[int] = None, **resource_args):
         super().__init__(**resource_args)
         self._paths = paths
         self.parallelism = parallelism
@@ -35,7 +35,7 @@ class BinaryScan(FileScan):
 
     def __init__(
         self,
-        paths: Union[str, List[str]],
+        paths: Union[str, list[str]],
         *,
         binary_format: str,
         parallelism: Optional[int] = None,
@@ -48,7 +48,7 @@ class BinaryScan(FileScan):
         self._binary_format = binary_format
         self._filesystem = filesystem
 
-    def _to_document(self, dict: Dict[str, Any]) -> Dict[str, Any]:
+    def _to_document(self, dict: dict[str, Any]) -> dict[str, Any]:
         document = Document()
         import uuid
 
@@ -89,7 +89,7 @@ class BinaryScan(FileScan):
 
 
 class JsonScan(FileScan):
-    def __init__(self, paths: Union[str, List[str]], *, parallelism: Optional[int] = None, **resource_args):
+    def __init__(self, paths: Union[str, list[str]], *, parallelism: Optional[int] = None, **resource_args):
         super().__init__(paths, parallelism=parallelism, **resource_args)
         self.parallelism = -1 if parallelism is None else parallelism
 

--- a/python/sycamore/execution/scans/materialized_scan.py
+++ b/python/sycamore/execution/scans/materialized_scan.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import Union
 
 from pandas import DataFrame
 from pyarrow import Table
@@ -19,11 +19,11 @@ class MaterializedScan(Scan):
 
 
 class ArrowScan(MaterializedScan):
-    def __init__(self, tables: Union["Table", bytes, List[Union["Table", bytes]]], **resource_args):
+    def __init__(self, tables: Union["Table", bytes, list[Union[Table, bytes]]], **resource_args):
         super().__init__(**resource_args)
         self._tables = tables
 
-    def execute(self) -> "Dataset":
+    def execute(self) -> Dataset:
         return from_arrow(tables=self._tables).map(lambda dict: Document(dict))
 
     def format(self):
@@ -31,11 +31,11 @@ class ArrowScan(MaterializedScan):
 
 
 class DocScan(MaterializedScan):
-    def __init__(self, docs: List[Document], **resource_args):
+    def __init__(self, docs: list[Document], **resource_args):
         super().__init__(**resource_args)
         self._dicts = docs
 
-    def execute(self) -> "Dataset":
+    def execute(self) -> Dataset:
         return from_items(items=self._dicts)
 
     def format(self):
@@ -43,11 +43,11 @@ class DocScan(MaterializedScan):
 
 
 class PandasScan(MaterializedScan):
-    def __init__(self, dfs: Union["DataFrame", List["DataFrame"]], **resource_args):
+    def __init__(self, dfs: Union[DataFrame, list[DataFrame]], **resource_args):
         super().__init__(**resource_args)
         self._dfs = dfs
 
-    def execute(self) -> "Dataset":
+    def execute(self) -> Dataset:
         return from_pandas(dfs=self._dfs).map(lambda dict: Document(dict))
 
     def format(self):

--- a/python/sycamore/execution/transforms/embedding.py
+++ b/python/sycamore/execution/transforms/embedding.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Optional
 import math
 
 import numpy as np
@@ -12,7 +12,15 @@ from sycamore.execution import Node, Transform
 class SentenceTransformerEmbedding(Transform):
     """Embedding based on HuggingFace Sentence Transformer"""
 
-    def __init__(self, child: Node, model_name: str, batch_size: int = None, device: str = None, **resource_args):
+    def __init__(
+        self,
+        child: Node,
+        model_name: str,
+        batch_size: Optional[int] = None,
+        model_batch_size: int = 100,
+        device: Optional[str] = None,
+        **resource_args
+    ):
         super().__init__(child, **resource_args)
         self.type = type
         self.model_name = model_name
@@ -23,15 +31,16 @@ class SentenceTransformerEmbedding(Transform):
         else:
             self.device = device
         self.batch_size = batch_size
+        self.model_batch_size = model_batch_size
 
     class SentenceTransformer:
-        def __init__(self, model_name: str, batch_size: int = 100, device: str = None):
+        def __init__(self, model_name: str, batch_size: int = 100, device: Optional[str] = None):
             self._transformer = SentenceTransformer(model_name)
             self._batch_size = batch_size
             self._device = device
 
         # TODO, embedding should consider entity type
-        def __call__(self, doc_batch: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
+        def __call__(self, doc_batch: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
             text_batch = doc_batch["text_representation"].tolist()
             embeddings = self._transformer.encode(text_batch, batch_size=self._batch_size, device=self._device)
             doc_batch.update({"embedding": embeddings.tolist()})
@@ -53,7 +62,7 @@ class SentenceTransformerEmbedding(Transform):
                 compute=ActorPoolStrategy(min_size=1, max_size=math.ceil(gpus / gpu_per_task)),
                 fn_constructor_kwargs={
                     "model_name": self.model_name,
-                    "batch_size": self.batch_size,
+                    "batch_size": self.model_batch_size,
                     "device": self.device,
                 },
                 num_gpus=gpu_per_task,
@@ -62,7 +71,7 @@ class SentenceTransformerEmbedding(Transform):
         else:
             # in case of no gpu required, we use tasks to make it easier
             # to be fusible
-            embedder = self.SentenceTransformer(self.model_name, self.batch_size)
+            embedder = self.SentenceTransformer(self.model_name, self.model_batch_size)
             output = dataset.map_batches(embedder.__call__, batch_size=self.batch_size, **self.resource_args)
 
         return output

--- a/python/sycamore/execution/transforms/entity_extraction.py
+++ b/python/sycamore/execution/transforms/entity_extraction.py
@@ -1,4 +1,4 @@
-from typing import Dict, Callable, List, Union, Optional
+from typing import Callable, Union, Optional
 
 from ray.data import Dataset
 
@@ -8,15 +8,22 @@ from sycamore.execution.transforms.llms import LLM
 from sycamore.execution import Node, Transform
 
 
+def element_list_formatter(elements: list[Element]) -> str:
+    query = ""
+    for i in range(len(elements)):
+        query += f"ELEMENT {i + 1}: {elements[i]['content']['text']}\n"
+    return query
+
+
 class LLMExtractEntity(Transform):
     def __init__(
         self,
         child: Node,
-        entity_to_extract: Union[str, Dict],
+        entity_to_extract: Union[str, dict],
         num_of_elements: int,
         llm: LLM,
         prompt_template: str,
-        prompt_formatter: Callable[[List[Element]], str],
+        prompt_formatter: Callable[[list[Element]], str],
         entity_extractor: Optional[EntityExtractor],
         **resource_args,
     ):

--- a/python/sycamore/execution/transforms/explode.py
+++ b/python/sycamore/execution/transforms/explode.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any
 
 from ray.data import Dataset
 
@@ -12,7 +12,7 @@ class Explode(SingleThreadUser, NonGPUUser, Transform):
 
     class ExplodeCallable:
         @staticmethod
-        def explode(dict: Dict[str, Any]) -> List[Dict[str, Any]]:
+        def explode(dict: dict[str, Any]) -> list[dict[str, Any]]:
             parent = Document(dict)
             documents = [parent]
 
@@ -26,7 +26,7 @@ class Explode(SingleThreadUser, NonGPUUser, Transform):
             del parent.elements
             return [document.to_dict() for document in documents]
 
-    def execute(self) -> "Dataset":
+    def execute(self) -> Dataset:
         dataset = self.child().execute()
         exploder = Explode.ExplodeCallable()
         return dataset.flat_map(exploder.explode)

--- a/python/sycamore/execution/transforms/llms/llms.py
+++ b/python/sycamore/execution/transforms/llms/llms.py
@@ -2,7 +2,7 @@ import os
 import re
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Dict, Any
+from typing import Any, Optional
 
 import openai
 from tenacity import retry, stop_after_attempt, wait_random, retry_if_exception_type
@@ -19,7 +19,7 @@ class LLM(ABC):
         self._kwargs = kwargs
 
     @abstractmethod
-    def generate(self, *, prompt_kwargs: Dict, llm_kwargs: Dict) -> Any:
+    def generate(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> Any:
         pass
 
     def is_chat_mode(self):
@@ -42,7 +42,7 @@ class OpenAI(LLM):
         )
         self._api_key = api_key
 
-    def generate(self, *, prompt_kwargs: Dict, llm_kwargs: Dict = None) -> Any:
+    def generate(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> Any:
         if llm_kwargs is not None:
             return self._generate_using_openai(prompt_kwargs, llm_kwargs)
 

--- a/python/sycamore/execution/transforms/mapping.py
+++ b/python/sycamore/execution/transforms/mapping.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Iterable, List, Optional, Type
+from typing import Any, Callable, Iterable, Optional, Type
 
 from pyarrow import Table
 from ray.data import ActorPoolStrategy, Dataset
@@ -7,19 +7,19 @@ from sycamore.execution import Node, UnaryNode
 from sycamore.data import Document
 
 
-def generate_map_function(f: Callable[[Document], Document]) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
-    def ray_callable(input_dict: Dict[str, Any]) -> Dict[str, Any]:
+def generate_map_function(f: Callable[[Document], Document]) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    def ray_callable(input_dict: dict[str, Any]) -> dict[str, Any]:
         document = f(Document(input_dict))
         return document.data
 
     return ray_callable
 
 
-def generate_map_class(c: Type[Callable[[Document], Document]]) -> Type[Callable[[Dict[str, Any]], Dict[str, Any]]]:
+def generate_map_class(c: Type[Callable[[Document], Document]]) -> Type[Callable[[dict[str, Any]], dict[str, Any]]]:
     def ray_init(self):
         self.base = c()
 
-    def ray_callable(self, input_dict: Dict[str, Any]) -> Dict[str, Any]:
+    def ray_callable(self, input_dict: dict[str, Any]) -> dict[str, Any]:
         document = self.base(Document(input_dict))
         return document.data
 
@@ -28,9 +28,9 @@ def generate_map_class(c: Type[Callable[[Document], Document]]) -> Type[Callable
 
 
 def generate_flat_map_function(
-    f: Callable[[Document], List[Document]]
-) -> Callable[[Dict[str, Any]], List[Dict[str, Any]]]:
-    def ray_callable(input_dict: Dict[str, Any]) -> List[Dict[str, Any]]:
+    f: Callable[[Document], list[Document]]
+) -> Callable[[dict[str, Any]], list[dict[str, Any]]]:
+    def ray_callable(input_dict: dict[str, Any]) -> list[dict[str, Any]]:
         documents = f(Document(input_dict))
         return [document.data for document in documents]
 
@@ -38,12 +38,12 @@ def generate_flat_map_function(
 
 
 def generate_flat_map_class(
-    c: Type[Callable[[Document], List[Document]]]
-) -> Type[Callable[[Dict[str, Any]], List[Dict[str, Any]]]]:
+    c: Type[Callable[[Document], list[Document]]]
+) -> Type[Callable[[dict[str, Any]], list[dict[str, Any]]]]:
     def ray_init(self):
         self.base = c()
 
-    def ray_callable(self, input_dict: Dict[str, Any]) -> List[Dict[str, Any]]:
+    def ray_callable(self, input_dict: dict[str, Any]) -> list[dict[str, Any]]:
         documents = self.base(Document(input_dict))
         return [document.data for document in documents]
 
@@ -51,7 +51,7 @@ def generate_flat_map_class(
     return new_class
 
 
-def generate_map_batch_function(f: Callable[[List[Document]], List[Document]]) -> Callable[[Table], Table]:
+def generate_map_batch_function(f: Callable[[list[Document]], list[Document]]) -> Callable[[Table], Table]:
     def ray_callable(input_table: Table) -> Table:
         input_docs = [Document(t) for t in input_table.to_pylist()]
         output_docs = f(input_docs)
@@ -66,12 +66,12 @@ def generate_map_batch_function(f: Callable[[List[Document]], List[Document]]) -
 
 
 def generate_map_batch_class(
-    c: Type[Callable[[List[Document]], List[Document]]],
+    c: Type[Callable[[list[Document]], list[Document]]],
     f_args: Optional[Iterable[Any]] = None,
-    f_kwargs: Optional[Dict[str, Any]] = None,
+    f_kwargs: Optional[dict[str, Any]] = None,
     f_constructor_args: Optional[Iterable[Any]] = None,
-    f_constructor_kwargs: Optional[Dict[str, Any]] = None,
-) -> Type[Callable[[List[Dict[str, Any]]], List[Dict[str, Any]]]]:
+    f_constructor_kwargs: Optional[dict[str, Any]] = None,
+) -> Type[Callable[[list[dict[str, Any]]], list[dict[str, Any]]]]:
     if f_constructor_args is None:
         f_constructor_args = tuple()
     if f_constructor_kwargs is None:
@@ -114,7 +114,7 @@ class Map(UnaryNode):
 
 
 class FlatMap(UnaryNode):
-    def __init__(self, child: Node, *, f: Callable[[Document], List[Document]], **resource_args):
+    def __init__(self, child: Node, *, f: Callable[[Document], list[Document]], **resource_args):
         super().__init__(child, **resource_args)
         self._f = f
 
@@ -133,11 +133,11 @@ class MapBatch(UnaryNode):
         self,
         child: Node,
         *,
-        f: Callable[[List[Document]], List[Document]],
+        f: Callable[[list[Document]], list[Document]],
         f_args: Optional[Iterable[Any]] = None,
-        f_kwargs: Optional[Dict[str, Any]] = None,
+        f_kwargs: Optional[dict[str, Any]] = None,
         f_constructor_args: Optional[Iterable[Any]] = None,
-        f_constructor_kwargs: Optional[Dict[str, Any]] = None,
+        f_constructor_kwargs: Optional[dict[str, Any]] = None,
         **resource_args
     ):
         super().__init__(child, **resource_args)

--- a/python/sycamore/execution/transforms/table_extraction.py
+++ b/python/sycamore/execution/transforms/table_extraction.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Optional
 
 from ray.data import Dataset
 from textractor import Textractor
@@ -11,12 +11,12 @@ from sycamore.execution.basics import NonCPUUser, Node, Transform
 
 
 class TextractorTableExtractor:
-    def __init__(self, profile_name: str = None, region_name: str = None, kms_key_id: str = ""):
+    def __init__(self, profile_name: Optional[str] = None, region_name: Optional[str] = None, kms_key_id: str = ""):
         self._profile_name = profile_name
         self._region_name = region_name
         self._kms_key_id: str = kms_key_id
 
-    def _extract_tables(self, document: Document) -> List[Element]:
+    def _extract_tables(self, document: Document) -> list[Element]:
         # https://docs.aws.amazon.com/textract/latest/dg/API_BoundingBox.html
         def bbox_to_coord(bbox):
             return [bbox.x, bbox.y, bbox.x + bbox.width, bbox.y + bbox.height]
@@ -48,7 +48,7 @@ class TextractorTableExtractor:
 
         return all_tables
 
-    def extract(self, dict: Dict[str, Any]) -> Dict[str, Any]:
+    def extract(self, dict: dict[str, Any]) -> dict[str, Any]:
         document = Document(dict)
         tables = self._extract_tables(document)
         document.elements.extend(tables)
@@ -57,7 +57,12 @@ class TextractorTableExtractor:
 
 class TableExtraction(NonCPUUser, NonGPUUser, Transform):
     def __init__(
-        self, child: Node, profile_name: str = None, region_name: str = None, kms_key_id: str = "", **resource_args
+        self,
+        child: Node,
+        profile_name: Optional[str] = None,
+        region_name: Optional[str] = None,
+        kms_key_id: str = "",
+        **resource_args
     ):
         super().__init__(child, **resource_args)
         self._table_extractor = TextractorTableExtractor(profile_name, region_name, kms_key_id)

--- a/python/sycamore/reader.py
+++ b/python/sycamore/reader.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from pandas import DataFrame
 from pyarrow import Table
@@ -15,22 +15,22 @@ class DocSetReader:
 
     def binary(
         self,
-        paths: Union[str, List[str]],
+        paths: Union[str, list[str]],
         binary_format: str,
         parallelism: Optional[int] = None,
-        filesystem: Optional["FileSystem"] = None,
+        filesystem: Optional[FileSystem] = None,
     ) -> DocSet:
         scan = BinaryScan(paths, binary_format=binary_format, parallelism=parallelism, filesystem=filesystem)
         return DocSet(self._context, scan)
 
-    def arrow(self, tables: Union["Table", bytes, List[Union["Table", bytes]]]) -> DocSet:
+    def arrow(self, tables: Union[Table, bytes, list[Union[Table, bytes]]]) -> DocSet:
         scan = ArrowScan(tables)
         return DocSet(self._context, scan)
 
-    def document(self, docs: List[Document]) -> DocSet:
+    def document(self, docs: list[Document]) -> DocSet:
         scan = DocScan(docs)
         return DocSet(self._context, scan)
 
-    def pandas(self, dfs: Union["DataFrame", List["DataFrame"]]) -> DocSet:
+    def pandas(self, dfs: Union[DataFrame, list[DataFrame]]) -> DocSet:
         scan = PandasScan(dfs)
         return DocSet(self._context, scan)

--- a/python/sycamore/tests/integration/test_pdf_to_opensearch.py
+++ b/python/sycamore/tests/integration/test_pdf_to_opensearch.py
@@ -1,7 +1,6 @@
-from typing import List
+from sycamore.execution.transforms.entity_extraction import element_list_formatter
 
 import sycamore
-from sycamore.data import Element
 from sycamore.execution.transforms import PdfPartitionerOptions
 from sycamore.execution.transforms.llms.llms import OpenAIModels, OpenAI
 from sycamore.tests.config import TEST_DIR
@@ -88,12 +87,6 @@ def test_pdf_to_opensearch():
 
         """
 
-    def prompt_formatter(elements: List[Element]) -> str:
-        query = ""
-        for i in range(len(elements)):
-            query += f"ELEMENT {i + 1}: {elements[i].get('content').get('text')}\n"
-        return query
-
     paths = str(TEST_DIR / "resources/data/pdfs/")
 
     openai_llm = OpenAI(OpenAIModels.TEXT_DAVINCI.value)
@@ -106,13 +99,13 @@ def test_pdf_to_opensearch():
             entity_to_extract="title",
             llm=openai_llm,
             prompt_template=title_context_template,
-            prompt_formatter=prompt_formatter,
+            prompt_formatter=element_list_formatter,
         )
         .llm_extract_entity(
             entity_to_extract="authors",
             llm=openai_llm,
             prompt_template=author_context_template,
-            prompt_formatter=prompt_formatter,
+            prompt_formatter=element_list_formatter,
             model_name=OpenAIModels.TEXT_DAVINCI.value,
         )
         .explode()

--- a/python/sycamore/tests/unit/execution/test_node.py
+++ b/python/sycamore/tests/unit/execution/test_node.py
@@ -8,8 +8,11 @@ class MockNode(Node):
         super().__init__([], **kwargs)
         self.value = 0
 
+    def execute(self):
+        pass
 
-def set_value_function(node: Node) -> None:
+
+def set_value_function(node: MockNode) -> None:
     node.value = 1
 
 
@@ -17,7 +20,7 @@ class SetValueClass:
     def __init__(self):
         self.value = 0
 
-    def set_value(self, node: Node) -> None:
+    def set_value(self, node: MockNode) -> None:
         node.value = 1
         self.value += 1
 

--- a/python/sycamore/tests/unit/execution/transforms/test_partition.py
+++ b/python/sycamore/tests/unit/execution/transforms/test_partition.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Callable
 
 import pytest
@@ -10,7 +11,7 @@ from sycamore.execution.transforms.partition import Partitioner, PdfPartitioner,
 from sycamore.tests.config import TEST_DIR
 
 
-def _make_scan_executor(path, format) -> Callable[[], Dataset]:
+def _make_scan_executor(path: Path, format: str) -> Callable[[], Dataset]:
     def do_scan() -> Dataset:
         return BinaryScan(str(path), binary_format=format).execute()
 
@@ -101,7 +102,7 @@ class TestPartition:
         assert expected_table_count == table_count
 
     @pytest.mark.parametrize("path, partition_count", [(TEST_DIR / "resources/data/pdfs/Transformer.pdf", 254)])
-    def test_partition_pdf(self, mocker, path, partition_count):
+    def test_partition_pdf(self, mocker, path, partition_count) -> None:
         scan = mocker.Mock(spec=BinaryScan)
         options = PdfPartitionerOptions()
         partition = Partition(scan, options)
@@ -114,7 +115,7 @@ class TestPartition:
     @pytest.mark.parametrize(
         "path, partition_count", [(TEST_DIR / "resources/data/htmls/wikipedia_binary_search.html", 76)]
     )
-    def test_partition_html(self, mocker, path, partition_count):
+    def test_partition_html(self, mocker, path, partition_count) -> None:
         scan = mocker.Mock(spec=BinaryScan)
         options = HtmlPartitionerOptions()
         partition = Partition(scan, options)

--- a/python/sycamore/tests/unit/test_docset.py
+++ b/python/sycamore/tests/unit/test_docset.py
@@ -35,7 +35,7 @@ class TestDocSet:
         node = mocker.Mock(spec=Node)
         llm = mocker.Mock(spec=LLM)
         docset = DocSet(context, node)
-        docset = docset.llm_extract_entity(entity_to_extract="title", llm=llm)
+        docset = docset.llm_extract_entity(entity_to_extract="title", llm=llm, prompt_template="")
         assert isinstance(docset.lineage(), LLMExtractEntity)
 
     def test_map(self, mocker):

--- a/python/sycamore/tests/unit/test_writer.py
+++ b/python/sycamore/tests/unit/test_writer.py
@@ -6,7 +6,7 @@ from sycamore.execution.writes import OpenSearchWriter
 class TestDocSetWriter:
     def test_opensearch(self, mocker):
         context = mocker.Mock(spec=Context)
-        docset = DocSet(context, Node([mocker.Mock()]))
+        docset = DocSet(context, mocker.Mock(spec=Node))
         execute = mocker.patch.object(OpenSearchWriter, "execute")
         docset.write.opensearch(os_client_args={}, index_name="index")
         execute.assert_called_once()

--- a/python/sycamore/writer.py
+++ b/python/sycamore/writer.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Optional
 
 from sycamore import Context
 from sycamore.execution import Node
@@ -10,7 +10,7 @@ class DocSetWriter:
         self.plan = plan
         self.resource_args = resource_args
 
-    def opensearch(self, *, os_client_args: Dict, index_name: str, index_settings: Dict = None) -> None:
+    def opensearch(self, *, os_client_args: dict, index_name: str, index_settings: Optional[dict] = None) -> None:
         from sycamore.execution.writes import OpenSearchWriter
 
         os = OpenSearchWriter(


### PR DESCRIPTION
These changes make

      poetry run mypy .

run cleanly. Strict mode still fails because there are some functions that are not annotated with types, but that's something we can address over time.

Many of these changes were straightforward and mechanical, but several required behavior changes, so it is worth reviewing them carefully.