### PR TITLE
Remove test data from linguist config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+sycamore/tests/resources/data/* -linguist-detectable


### PR DESCRIPTION
Linguist is what Github uses to determine the language used in a repo. Previously it was picking up the HTML files in our test data, and classifying sycamore as >80% HTML. This change just removes the test data from classification.

This should have no impact to sycamore exection -- it just helps make sure the repo is better classified by Github.