### PR TITLE
Fix multiple bugs discovered in benchmark

### DIFF
--- a/sycamore/execution/transforms/__init__.py
+++ b/sycamore/execution/transforms/__init__.py
@@ -1,4 +1,5 @@
 from sycamore.execution.transforms.embedding import Embed, Embedder
+from sycamore.execution.transforms.basics import Limit
 from sycamore.execution.transforms.entity_extraction import ExtractEntity, EntityExtractor
 from sycamore.execution.transforms.explode import Explode
 from sycamore.execution.transforms.mapping import Map, FlatMap, MapBatch
@@ -9,6 +10,7 @@ from sycamore.execution.transforms.summarize import Summarize
 __all__ = [
     "Explode",
     "FlatMap",
+    "Limit",
     "Map",
     "MapBatch",
     "Partitioner",

--- a/sycamore/execution/transforms/basics.py
+++ b/sycamore/execution/transforms/basics.py
@@ -1,0 +1,15 @@
+from ray.data import Dataset
+
+from sycamore.execution import Node
+from sycamore.execution import NonCPUUser, NonGPUUser
+from sycamore.execution import Transform
+
+
+class Limit(NonCPUUser, NonGPUUser, Transform):
+    def __init__(self, child: Node, limit: int):
+        super().__init__(child)
+        self._limit = limit
+
+    def execute(self) -> "Dataset":
+        dataset = self.child().execute()
+        return dataset.limit(self._limit)

--- a/sycamore/execution/transforms/explode.py
+++ b/sycamore/execution/transforms/explode.py
@@ -29,4 +29,4 @@ class Explode(SingleThreadUser, NonGPUUser, Transform):
     def execute(self) -> Dataset:
         dataset = self.child().execute()
         exploder = Explode.ExplodeCallable()
-        return dataset.flat_map(exploder.explode)
+        return dataset.flat_map(exploder.explode, **self.resource_args)

--- a/sycamore/execution/transforms/partition.py
+++ b/sycamore/execution/transforms/partition.py
@@ -51,6 +51,14 @@ class Partitioner(ABC):
         element.text_representation = str(element.binary_representation)
         element.properties.update(dict.pop("metadata"))
         element.properties.update(dict)
+
+        # TODO, we need handle cases of different types for same column
+        if element.properties.get("coordinates") is not None:
+            coordinates = element.properties["coordinates"]
+            if coordinates.get("layout_height") is not None:
+                coordinates["layout_height"] = float(coordinates["layout_height"])
+            if coordinates.get("layout_width") is not None:
+                coordinates["layout_width"] = float(coordinates["layout_width"])
         return element
 
     @abstractmethod
@@ -188,7 +196,7 @@ class Partition(SingleThreadUser, NonGPUUser, Transform):
 
     def execute(self) -> Dataset:
         input_dataset = self.child().execute()
-        dataset = input_dataset.map(self._partitioner.partition)
+        dataset = input_dataset.map(self._partitioner.partition, **self.resource_args)
         if self._table_extractor:
             dataset = dataset.map(self._table_extractor.extract_tables)
         return dataset

--- a/sycamore/execution/writes/opensearch.py
+++ b/sycamore/execution/writes/opensearch.py
@@ -43,7 +43,6 @@ class OpenSearchWriter(Write):
                     client.indices.create(self.index_name)
 
         except Exception as e:
-            log.error("Exception occurred while creating an index:", e)
             raise RuntimeError("Exception occurred while creating an index", e)
 
         dataset.write_datasource(

--- a/sycamore/reader.py
+++ b/sycamore/reader.py
@@ -19,8 +19,11 @@ class DocSetReader:
         binary_format: str,
         parallelism: Optional[int] = None,
         filesystem: Optional[FileSystem] = None,
+        **resource_args
     ) -> DocSet:
-        scan = BinaryScan(paths, binary_format=binary_format, parallelism=parallelism, filesystem=filesystem)
+        scan = BinaryScan(
+            paths, binary_format=binary_format, parallelism=parallelism, filesystem=filesystem, **resource_args
+        )
         return DocSet(self._context, scan)
 
     def arrow(self, tables: Union[Table, bytes, list[Union[Table, bytes]]]) -> DocSet:

--- a/sycamore/tests/unit/execution/transforms/test_partition.py
+++ b/sycamore/tests/unit/execution/transforms/test_partition.py
@@ -20,18 +20,20 @@ class TestPartition:
     def test_partitioner(self):
         dict = {
             "type": "Title",
-            "coordinates": (
-                (116.519, 70.34515579999993),
-                (116.519, 100.63135580000005),
-                (481.02724959999995, 100.63135580000005),
-                (481.02724959999995, 70.34515579999993),
-            ),
-            "coordinate_system": "PixelSpace",
-            "layout_width": 595.276,
-            "layout_height": 841.89,
+            "coordinates": {
+                "points": (
+                    (116.519, 70.34515579999993),
+                    (116.519, 100.63135580000005),
+                    (481.02724959999995, 100.63135580000005),
+                    (481.02724959999995, 70.34515579999993),
+                ),
+                "coordinate_system": "PixelSpace",
+                "layout_width": 595.276,
+                "layout_height": 841.89,
+            },
             "element_id": "af2a328be129ce50f85b7946c35d1cf1",
             "metadata": {"filename": "Bert.pdf", "filetype": "application/pdf", "page_number": 1},
-            "text": "BERT: Pre-training of Deep Bidirectional Transformers " "for Language Understanding",
+            "text": "BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding",
         }
         element = Partitioner.to_element(dict)
         assert element.type == "Title"
@@ -40,15 +42,17 @@ class TestPartition:
             " Language Understanding"
         )
         assert element.properties == {
-            "coordinates": (
-                (116.519, 70.34515579999993),
-                (116.519, 100.63135580000005),
-                (481.02724959999995, 100.63135580000005),
-                (481.02724959999995, 70.34515579999993),
-            ),
-            "coordinate_system": "PixelSpace",
-            "layout_width": 595.276,
-            "layout_height": 841.89,
+            "coordinates": {
+                "points": (
+                    (116.519, 70.34515579999993),
+                    (116.519, 100.63135580000005),
+                    (481.02724959999995, 100.63135580000005),
+                    (481.02724959999995, 70.34515579999993),
+                ),
+                "coordinate_system": "PixelSpace",
+                "layout_width": 595.276,
+                "layout_height": 841.89,
+            },
             "element_id": "af2a328be129ce50f85b7946c35d1cf1",
             "filename": "Bert.pdf",
             "filetype": "application/pdf",

--- a/sycamore/writer.py
+++ b/sycamore/writer.py
@@ -5,15 +5,16 @@ from sycamore.execution import Node
 
 
 class DocSetWriter:
-    def __init__(self, context: Context, plan: Node, **resource_args):
+    def __init__(self, context: Context, plan: Node):
         self.context = context
         self.plan = plan
-        self.resource_args = resource_args
 
-    def opensearch(self, *, os_client_args: dict, index_name: str, index_settings: Optional[dict] = None) -> None:
+    def opensearch(
+        self, *, os_client_args: dict, index_name: str, index_settings: Optional[dict] = None, **resource_args
+    ) -> None:
         from sycamore.execution.writes import OpenSearchWriter
 
         os = OpenSearchWriter(
-            self.plan, index_name, os_client_args=os_client_args, index_settings=index_settings, **self.resource_args
+            self.plan, index_name, os_client_args=os_client_args, index_settings=index_settings, **resource_args
         )
         os.execute()


### PR DESCRIPTION
1. Add a Limit Operator for Test
2. Add resource args for operators
3. Enforce Unstructured.io coordinates layout height and width to be float to avoid different data types for same column
4. Move docset writer resource args to opensearch writer
5. Remove duplicate num_gpus setup in embedding