### PR TITLE
Set default gpu usage in Embedder

### DIFF
--- a/sycamore/execution/rules/optimize_resource_args.py
+++ b/sycamore/execution/rules/optimize_resource_args.py
@@ -6,7 +6,7 @@ class EnforceResourceUsage(Rule):
         if isinstance(plan, NonCPUUser):
             plan.resource_args["num_cpus"] = 0
 
-        if isinstance(plan, SingleThreadUser):
+        if isinstance(plan, SingleThreadUser) and "num_cpus" not in plan.resource_args:
             plan.resource_args["num_cpus"] = 1
 
         if isinstance(plan, NonGPUUser):

--- a/sycamore/execution/transforms/embedding.py
+++ b/sycamore/execution/transforms/embedding.py
@@ -73,7 +73,9 @@ class Embed(Transform):
         dataset = self.child().execute()
         if self._embedder.device == "cuda":
             available_gpus = ray.available_resources().get("GPU")
-            if "num_gpus" not in self.resource_args or self.resource_args["num_gpus"] <= 0:
+            if "num_gpus" not in self.resource_args:
+                self.resource_args["num_gpus"] = 1
+            if self.resource_args["num_gpus"] <= 0:
                 raise RuntimeError("Invalid GPU Nums!")
             gpu_per_task = self.resource_args["num_gpus"]
 


### PR DESCRIPTION
Sycamore raise exception when customer does not specify num_gpus and whether use gpu twhile there does exist GPU in the system, fix it by setting default num_gpus.