### PR TITLE
Update docset.show to include some new parameters.

### DIFF
--- a/notebooks/sycamore_demo.ipynb
+++ b/notebooks/sycamore_demo.ipynb
@@ -153,7 +153,7 @@
     "context = sycamore.init()\n",
     "pdf_docset = context.read.binary(paths, binary_format=\"pdf\")\n",
     "\n",
-    "pdf_docset.show(show_binary = True)"
+    "pdf_docset.show(show_binary = False)"
    ]
   },
   {
@@ -188,7 +188,7 @@
     "              .extract_entity(entity_extractor=OpenAIEntityExtractor(\"title\", llm=openai_llm, prompt_template=title_context_template))\n",
     "              .extract_entity(entity_extractor=OpenAIEntityExtractor(\"authors\", llm=openai_llm, prompt_template=author_context_template)))\n",
     "\n",
-    "pdf_docset.show(show_binary = True,truncate_length=1)"
+    "pdf_docset.show(show_binary = False, show_elements=False)"
    ]
   },
   {
@@ -199,7 +199,7 @@
    "outputs": [],
    "source": [
     "pdf_docset = pdf_docset.explode()\n",
-    "pdf_docset.show(show_binary = True,truncate_length=1)"
+    "pdf_docset.show(show_binary = False)"
    ]
   },
   {
@@ -211,7 +211,7 @@
    "source": [
     "pdf_docset = (pdf_docset\n",
     "              .embed(embedder=SentenceTransformerEmbedder(batch_size=100, model_name=\"sentence-transformers/all-MiniLM-L6-v2\")))\n",
-    "pdf_docset.show(show_binary = True,truncate_length=1)"
+    "pdf_docset.show(show_binary = False)"
    ]
   }
  ],


### PR DESCRIPTION
No longer use the truncate_length for binary, text, and embeddings. Add some additional text to indicate what was truncated.