### PR TITLE
Fix bug of SentenceTransformer exception for subscripting None

### DIFF
--- a/sycamore/transforms/embed.py
+++ b/sycamore/transforms/embed.py
@@ -82,7 +82,7 @@ class SentenceTransformerEmbedder(Embedder):
 
         assert self._transformer is not None
 
-        text_batch = [doc.text_representation for doc in doc_batch]
+        text_batch = ["" if doc.text_representation is None else doc.text_representation for doc in doc_batch]
         embeddings = self._transformer.encode(text_batch, batch_size=self.model_batch_size, device=self.device)
         for doc, embedding in zip(doc_batch, embeddings):
             doc.embedding = embedding


### PR DESCRIPTION
When SentenceTransformer embed a batch of sentences, and the first sentence happens to be None, an exception for subscripting None is thrown. We do an easy fix to convert None to empty string for now.

Closes #73