### PR TITLE
UnstructuredPdfPartitioner to inherit parent properties

### DIFF
--- a/sycamore/tests/conftest.py
+++ b/sycamore/tests/conftest.py
@@ -7,7 +7,9 @@ from sycamore.data.document import Document
 @pytest.fixture
 def read_local_binary(request) -> Document:
     local = LocalFileSystem()
-    input_stream = local.open_input_stream(str(request.param))
+    path = str(request.param)
+    input_stream = local.open_input_stream(path)
     document = Document()
     document.binary_representation = input_stream.readall()
+    document.properties["path"] = path
     return document

--- a/sycamore/tests/unit/transforms/test_partition.py
+++ b/sycamore/tests/unit/transforms/test_partition.py
@@ -68,7 +68,7 @@ class TestPartition:
         document = partitioner.partition(read_local_binary)
         assert len(document["elements"]["array"]) == partition_count
         for elem in document["elements"]["array"]:
-            assert(len(elem.properties["path"]) > 0)
+            assert len(elem.properties["path"]) > 0
 
     @pytest.mark.parametrize(
         "partitioner, read_local_binary, expected_partition_count",

--- a/sycamore/tests/unit/transforms/test_partition.py
+++ b/sycamore/tests/unit/transforms/test_partition.py
@@ -67,6 +67,8 @@ class TestPartition:
     def test_pdf_partitioner(self, partitioner, read_local_binary, partition_count):
         document = partitioner.partition(read_local_binary)
         assert len(document["elements"]["array"]) == partition_count
+        for elem in document["elements"]["array"]:
+            assert(len(elem.properties["path"]) > 0)
 
     @pytest.mark.parametrize(
         "partitioner, read_local_binary, expected_partition_count",


### PR DESCRIPTION
Modify UnstructuredPdfPartitioner to inherit parent document properties down to child elements.  For now, just "path", but extensible.  This allows properties to be directly available in search results without the complication and expense of retrieving the parent document.