### PR TITLE
Add FileMetadataProvider

### DIFF
--- a/sycamore/reader.py
+++ b/sycamore/reader.py
@@ -15,13 +15,13 @@ class DocSetReader:
         self._context = context
 
     def binary(
-            self,
-            paths: Union[str, list[str]],
-            binary_format: str,
-            parallelism: Optional[int] = None,
-            filesystem: Optional[FileSystem] = None,
-            metadata_provider: Optional[FileMetadataProvider] = None,
-            **resource_args
+        self,
+        paths: Union[str, list[str]],
+        binary_format: str,
+        parallelism: Optional[int] = None,
+        filesystem: Optional[FileSystem] = None,
+        metadata_provider: Optional[FileMetadataProvider] = None,
+        **resource_args
     ) -> DocSet:
         scan = BinaryScan(
             paths,

--- a/sycamore/reader.py
+++ b/sycamore/reader.py
@@ -7,6 +7,7 @@ from pyarrow.filesystem import FileSystem
 from sycamore import Context, DocSet
 from sycamore.data import Document
 from sycamore.scans import ArrowScan, BinaryScan, DocScan, PandasScan
+from sycamore.scans.file_scan import FileMetadataProvider
 
 
 class DocSetReader:
@@ -14,15 +15,21 @@ class DocSetReader:
         self._context = context
 
     def binary(
-        self,
-        paths: Union[str, list[str]],
-        binary_format: str,
-        parallelism: Optional[int] = None,
-        filesystem: Optional[FileSystem] = None,
-        **resource_args
+            self,
+            paths: Union[str, list[str]],
+            binary_format: str,
+            parallelism: Optional[int] = None,
+            filesystem: Optional[FileSystem] = None,
+            metadata_provider: Optional[FileMetadataProvider] = None,
+            **resource_args
     ) -> DocSet:
         scan = BinaryScan(
-            paths, binary_format=binary_format, parallelism=parallelism, filesystem=filesystem, **resource_args
+            paths,
+            binary_format=binary_format,
+            parallelism=parallelism,
+            filesystem=filesystem,
+            metadata_provider=metadata_provider,
+            **resource_args
         )
         return DocSet(self._context, scan)
 

--- a/sycamore/scans/file_scan.py
+++ b/sycamore/scans/file_scan.py
@@ -31,10 +31,8 @@ class JsonManifestMetadataProvider(FileMetadataProvider):
         super().__init__()
         self._manifest_path = manifest_path
         self._path_to_metadata_map = self._load_json_manifest()
-        print("INITIALIZED MANIFEST", self._path_to_metadata_map)
 
     def get_metadata(self, file_path: str) -> dict[str, Any]:
-        print("Looking up ", file_path)
         return self._path_to_metadata_map.get(file_path, {})
 
     def _load_json_manifest(self) -> dict[str, Any]:

--- a/sycamore/scans/file_scan.py
+++ b/sycamore/scans/file_scan.py
@@ -88,7 +88,8 @@ class BinaryScan(FileScan):
         document.type = self._binary_format
         document.binary_representation = dict["bytes"]
         document.properties.update({"path": dict["path"]})
-        document.properties.update(self._metadata_provider.get_metadata(dict["path"]))
+        if self._metadata_provider:
+            document.properties.update(self._metadata_provider.get_metadata(dict["path"]))
         return document.data
 
     def _is_s3_scheme(self):

--- a/sycamore/scans/file_scan.py
+++ b/sycamore/scans/file_scan.py
@@ -17,16 +17,13 @@ def _set_id(doc: dict[str, Any]) -> dict[str, Any]:
     return doc
 
 
-
 class FileMetadataProvider(ABC):
-
     @abstractmethod
     def get_metadata(self, file_path: str) -> dict[str, Any]:
         pass
 
 
 class JsonManifestMetadataProvider(FileMetadataProvider):
-
     def __init__(self, manifest_path: str) -> None:
         super().__init__()
         self._manifest_path = manifest_path
@@ -37,12 +34,11 @@ class JsonManifestMetadataProvider(FileMetadataProvider):
 
     def _load_json_manifest(self) -> dict[str, Any]:
         try:
-            with open(self._manifest_path, 'r') as manifest_file:
+            with open(self._manifest_path, "r") as manifest_file:
                 metadata_map = json.load(manifest_file)
             return metadata_map
         except FileNotFoundError:
             raise FileNotFoundError(f"JSON manifest file not found at '{self._manifest_path}'")
-
 
 
 class FileScan(Scan):
@@ -64,14 +60,14 @@ class BinaryScan(FileScan):
     """
 
     def __init__(
-            self,
-            paths: Union[str, list[str]],
-            *,
-            binary_format: str,
-            parallelism: Optional[int] = None,
-            filesystem: Optional["FileSystem"] = None,
-            metadata_provider: Optional[FileMetadataProvider] = None,
-            **resource_args
+        self,
+        paths: Union[str, list[str]],
+        *,
+        binary_format: str,
+        parallelism: Optional[int] = None,
+        filesystem: Optional["FileSystem"] = None,
+        metadata_provider: Optional[FileMetadataProvider] = None,
+        **resource_args,
     ):
         super().__init__(paths, parallelism=parallelism, **resource_args)
         self._paths = paths

--- a/sycamore/scans/file_scan.py
+++ b/sycamore/scans/file_scan.py
@@ -1,3 +1,5 @@
+import json
+from abc import ABC, abstractmethod
 from typing import Any, Optional, Union
 
 from pyarrow.filesystem import FileSystem
@@ -13,6 +15,36 @@ def _set_id(doc: dict[str, Any]) -> dict[str, Any]:
 
     doc["doc_id"] = str(uuid.uuid1())
     return doc
+
+
+
+class FileMetadataProvider(ABC):
+
+    @abstractmethod
+    def get_metadata(self, file_path: str) -> dict[str, Any]:
+        pass
+
+
+class JsonManifestMetadataProvider(FileMetadataProvider):
+
+    def __init__(self, manifest_path: str) -> None:
+        super().__init__()
+        self._manifest_path = manifest_path
+        self._path_to_metadata_map = self._load_json_manifest()
+        print("INITIALIZED MANIFEST", self._path_to_metadata_map)
+
+    def get_metadata(self, file_path: str) -> dict[str, Any]:
+        print("Looking up ", file_path)
+        return self._path_to_metadata_map.get(file_path, {})
+
+    def _load_json_manifest(self) -> dict[str, Any]:
+        try:
+            with open(self._manifest_path, 'r') as manifest_file:
+                metadata_map = json.load(manifest_file)
+            return metadata_map
+        except FileNotFoundError:
+            raise FileNotFoundError(f"JSON manifest file not found at '{self._manifest_path}'")
+
 
 
 class FileScan(Scan):
@@ -34,19 +66,21 @@ class BinaryScan(FileScan):
     """
 
     def __init__(
-        self,
-        paths: Union[str, list[str]],
-        *,
-        binary_format: str,
-        parallelism: Optional[int] = None,
-        filesystem: Optional["FileSystem"] = None,
-        **resource_args
+            self,
+            paths: Union[str, list[str]],
+            *,
+            binary_format: str,
+            parallelism: Optional[int] = None,
+            filesystem: Optional["FileSystem"] = None,
+            metadata_provider: Optional[FileMetadataProvider] = None,
+            **resource_args
     ):
         super().__init__(paths, parallelism=parallelism, **resource_args)
         self._paths = paths
         self.parallelism = -1 if parallelism is None else parallelism
         self._binary_format = binary_format
         self._filesystem = filesystem
+        self._metadata_provider = metadata_provider
 
     def _to_document(self, dict: dict[str, Any]) -> dict[str, Any]:
         document = Document()
@@ -56,6 +90,7 @@ class BinaryScan(FileScan):
         document.type = self._binary_format
         document.binary_representation = dict["bytes"]
         document.properties.update({"path": dict["path"]})
+        document.properties.update(self._metadata_provider.get_metadata(dict["path"]))
         return document.data
 
     def _is_s3_scheme(self):

--- a/sycamore/tests/integration/test_html_to_opensearch.py
+++ b/sycamore/tests/integration/test_html_to_opensearch.py
@@ -13,7 +13,7 @@ def test_html_to_opensearch():
         "hosts": [{"host": "localhost", "port": 9200}],
         "http_compress": True,
         "http_auth": ("admin", "admin"),
-        "use_ssl": False,
+        "use_ssl": True,
         "verify_certs": False,
         "ssl_assert_hostname": False,
         "ssl_show_warn": False,
@@ -42,27 +42,12 @@ def test_html_to_opensearch():
     remote_url = "https://en.wikipedia.org/wiki/Binary_search_algorithm"
     indexed_at = "2023-10-04"
     manifest = {
-        base_path + "/wikipedia_binary_search.html": {
-            "remote_url": remote_url,
-            "indexed_at": indexed_at
-        },
-        "other file.html": {
-            "remote_url": "value",
-            "indexed_at": "date"
-        },
-        "non-dict element": {
-            "key1": "value1",
-            "key2": [
-                "listItem1",
-                "listItem2"
-            ]
-        },
-        "list property": [
-            "listItem1",
-            "listItem2"
-        ]
+        base_path + "/wikipedia_binary_search.html": {"remote_url": remote_url, "indexed_at": indexed_at},
+        "other file.html": {"remote_url": "value", "indexed_at": "date"},
+        "non-dict element": {"key1": "value1", "key2": ["listItem1", "listItem2"]},
+        "list property": ["listItem1", "listItem2"],
     }
-    tmp_manifest = tempfile.NamedTemporaryFile(mode='w+')
+    tmp_manifest = tempfile.NamedTemporaryFile(mode="w+")
     try:
         json.dump(manifest, tmp_manifest)
         tmp_manifest.flush()
@@ -70,10 +55,9 @@ def test_html_to_opensearch():
 
         context = sycamore.init()
         ds = (
-            context.read.binary(base_path,
-                                binary_format="html",
-                                metadata_provider=JsonManifestMetadataProvider(manifest_path)
-                                )
+            context.read.binary(
+                base_path, binary_format="html", metadata_provider=JsonManifestMetadataProvider(manifest_path)
+            )
             .partition(partitioner=HtmlPartitioner())
             .explode()
             .embed(SentenceTransformerEmbedder(batch_size=100, model_name="sentence-transformers/all-MiniLM-L6-v2"))

--- a/sycamore/tests/integration/test_html_to_opensearch.py
+++ b/sycamore/tests/integration/test_html_to_opensearch.py
@@ -78,9 +78,10 @@ def test_html_to_opensearch():
             .explode()
             .embed(SentenceTransformerEmbedder(batch_size=100, model_name="sentence-transformers/all-MiniLM-L6-v2"))
         )
-        doc = ds.take(1)[0]
-        assert doc.properties["remote_url"] == remote_url
-        assert doc.properties["indexed_at"] == indexed_at
+        # assert metadata properties are propagated to child elements
+        for doc in ds.take(5):
+            assert doc.properties["remote_url"] == remote_url
+            assert doc.properties["indexed_at"] == indexed_at
 
         ds.write.opensearch(os_client_args=os_client_args, index_name="toyindex", index_settings=index_settings)
     finally:

--- a/sycamore/tests/unit/scans/test_binary_scan.py
+++ b/sycamore/tests/unit/scans/test_binary_scan.py
@@ -27,36 +27,20 @@ class TestBinaryScan:
         remote_url = "https://en.wikipedia.org/wiki/Binary_search_algorithm"
         indexed_at = "2023-10-04"
         manifest = {
-            base_path + "/wikipedia_binary_search.html": {
-                "remote_url": remote_url,
-                "indexed_at": indexed_at
-            },
-            "other file.html": {
-                "remote_url": "value",
-                "indexed_at": "date"
-            },
-            "non-dict element": {
-                "key1": "value1",
-                "key2": [
-                    "listItem1",
-                    "listItem2"
-                ]
-            },
-            "list property": [
-                "listItem1",
-                "listItem2"
-            ]
+            base_path + "/wikipedia_binary_search.html": {"remote_url": remote_url, "indexed_at": indexed_at},
+            "other file.html": {"remote_url": "value", "indexed_at": "date"},
+            "non-dict element": {"key1": "value1", "key2": ["listItem1", "listItem2"]},
+            "list property": ["listItem1", "listItem2"],
         }
-        tmp_manifest = tempfile.NamedTemporaryFile(mode='w+')
+        tmp_manifest = tempfile.NamedTemporaryFile(mode="w+")
         try:
             json.dump(manifest, tmp_manifest)
             tmp_manifest.flush()
             manifest_path = tmp_manifest.name
 
-            scan = BinaryScan(base_path,
-                              binary_format="html",
-                              metadata_provider=JsonManifestMetadataProvider(manifest_path)
-                              )
+            scan = BinaryScan(
+                base_path, binary_format="html", metadata_provider=JsonManifestMetadataProvider(manifest_path)
+            )
             ds = scan.execute()
             doc = ds.take(1)[0]
             assert doc["properties"]["remote_url"] == remote_url

--- a/sycamore/tests/unit/scans/test_binary_scan.py
+++ b/sycamore/tests/unit/scans/test_binary_scan.py
@@ -1,7 +1,7 @@
 import json
 import tempfile
 
-from scans.file_scan import JsonManifestMetadataProvider
+from sycamore.scans.file_scan import JsonManifestMetadataProvider
 from sycamore.scans import BinaryScan
 from sycamore.tests.config import TEST_DIR
 

--- a/sycamore/tests/unit/scans/test_binary_scan.py
+++ b/sycamore/tests/unit/scans/test_binary_scan.py
@@ -1,3 +1,7 @@
+import json
+import tempfile
+
+from scans.file_scan import JsonManifestMetadataProvider
 from sycamore.scans import BinaryScan
 from sycamore.tests.config import TEST_DIR
 
@@ -17,3 +21,45 @@ class TestBinaryScan:
             "parent_id",
             "properties",
         ]
+
+    def test_json_manifest(self):
+        base_path = str(TEST_DIR / "resources/data/htmls/")
+        remote_url = "https://en.wikipedia.org/wiki/Binary_search_algorithm"
+        indexed_at = "2023-10-04"
+        manifest = {
+            base_path + "/wikipedia_binary_search.html": {
+                "remote_url": remote_url,
+                "indexed_at": indexed_at
+            },
+            "other file.html": {
+                "remote_url": "value",
+                "indexed_at": "date"
+            },
+            "non-dict element": {
+                "key1": "value1",
+                "key2": [
+                    "listItem1",
+                    "listItem2"
+                ]
+            },
+            "list property": [
+                "listItem1",
+                "listItem2"
+            ]
+        }
+        tmp_manifest = tempfile.NamedTemporaryFile(mode='w+')
+        try:
+            json.dump(manifest, tmp_manifest)
+            tmp_manifest.flush()
+            manifest_path = tmp_manifest.name
+
+            scan = BinaryScan(base_path,
+                              binary_format="html",
+                              metadata_provider=JsonManifestMetadataProvider(manifest_path)
+                              )
+            ds = scan.execute()
+            doc = ds.take(1)[0]
+            assert doc["properties"]["remote_url"] == remote_url
+            assert doc["properties"]["indexed_at"] == indexed_at
+        finally:
+            tmp_manifest.close()


### PR DESCRIPTION
This change adds a file-level metadata provider. The provider is invoked for each "document" read by BinaryScan and it's returned dictionary is merged with the element properties. The first metadata provider just reads from a JSON file where properties are keyed by the filePath. This allows us to build workflows against simple crawler results.

```
s3://mybucket/directory/
...TencentSort2016.pdf
...ExoshuffleCloudSort2022.pdf
...file3.pdf
...manifest.json
```

manifest.json would look like:
```json
{
  "s3://mybucket/directory/TencentSort2016.pdf": {
      "remote_url": "http://sortbenchmark.org/TencentSort2016.pdf",
      "indexed_at": "2023-10-04 and some time"
  },
  "s3://mybucket/directory/file2.pdf": {
      "remote_url": "http://sortbenchmark.org/ExoshuffleCloudSort2022.pdf",
      "indexed_at": "2023-10-04 and some time"
  }
}
```
and then in sycamore, the following would read in our files and associated metadata
```python
context.read.binary("s3://mybucket/directory/",
  binary_format="pdf",
  metadata_provider=JsonManifestMetadataProvider("s3://mybucket/directory/manifest.json")
)
```

This can also be used to inject document level IDs. We'll want to create a set of reserved system-level properties after this (e.g. prefixed with _, like '_remote_url", "_document_id", "_created_at")