### PR TITLE
Transform to denormalize specified properties from parents to children

### DIFF
--- a/examples/simple_ingest.py
+++ b/examples/simple_ingest.py
@@ -25,6 +25,7 @@ ds = (
     ctx.read.binary(paths, binary_format="pdf")
     .partition(partitioner=UnstructuredPdfPartitioner())
     .extract_entity(entity_extractor=OpenAIEntityExtractor("title", llm=davinci_llm, prompt_template=title_template))
+    .spread_properties(["path", "title"])
     .explode()
     .embed(embedder=SentenceTransformerEmbedder(model_name="all-MiniLM-L6-v2", batch_size=100))
 )

--- a/sycamore/docset.py
+++ b/sycamore/docset.py
@@ -182,6 +182,23 @@ class DocSet:
         plan = Partition(self.plan, partitioner=partitioner, table_extractor=table_extractor, **kwargs)
         return DocSet(self.context, plan)
 
+    def spread_properties(self, props: list[str], **resource_args) -> "DocSet":
+        """
+        Copies listed properties from parent document to child elements.
+
+        Example:
+            .. code-block:: python
+
+               pdf_docset = context.read.binary(paths, binary_format="pdf")
+                    .partition(partitioner=UnstructuredPdfPartitioner())
+                    .spread_properties(["title"])
+                    .explode()
+        """
+        from sycamore.transforms import SpreadProperties
+
+        plan = SpreadProperties(self.plan, props, **resource_args)
+        return DocSet(self.context, plan)
+
     def explode(self, **resource_args) -> "DocSet":
         """
         Applies the Explode transform on the Docset.

--- a/sycamore/tests/unit/transforms/test_partition.py
+++ b/sycamore/tests/unit/transforms/test_partition.py
@@ -62,8 +62,6 @@ class TestPartition:
     def test_pdf_partitioner(self, partitioner, read_local_binary, partition_count):
         document = partitioner.partition(read_local_binary)
         assert len(document.elements) == partition_count
-        for elem in document.elements:
-            assert len(elem.properties["path"]) > 0
 
     @pytest.mark.parametrize(
         "partitioner, read_local_binary, expected_partition_count",

--- a/sycamore/tests/unit/transforms/test_spread_properties.py
+++ b/sycamore/tests/unit/transforms/test_spread_properties.py
@@ -1,0 +1,37 @@
+from sycamore.data import Document
+from sycamore.transforms import SpreadProperties
+
+
+class TestSpreadProperties:
+    def test_spread_properties(self):
+        dict0 = {
+            "doc_id": "doc_id",
+            "type": "pdf",
+            "text_representation": "text",
+            "binary_representation": None,
+            "parent_id": None,
+            "properties": {"path": "/docs/foo.txt", "title": "bar"},
+            "elements": {
+                "array": [
+                    {
+                        "type": "UncategorizedText",
+                        "text_representation": "text1",
+                        "properties": {"filetype": "text/plain", "page_number": 1},
+                    },
+                    {
+                        "type": "UncategorizedText",
+                        "text_representation": "text2",
+                        "properties": {"filetype": "text/plain", "page_number": 2},
+                    },
+                ]
+            },
+        }
+        doc0 = Document(dict0)
+
+        sp = SpreadProperties(None, [])
+        spc = sp.SpreadPropertiesCallable(["path", "title"])
+        doc1 = spc.spreadProperties(doc0)
+        for elem in doc1.elements:
+            assert elem.properties["filetype"] == "text/plain"
+            assert elem.properties["path"] == "/docs/foo.txt"
+            assert elem.properties["title"] == "bar"

--- a/sycamore/tests/unit/transforms/test_spread_properties.py
+++ b/sycamore/tests/unit/transforms/test_spread_properties.py
@@ -1,33 +1,44 @@
+import ray.data
+
 from sycamore.data import Document
+from sycamore.plan_nodes import Node
 from sycamore.transforms import SpreadProperties
 
 
-class TestSpreadProperties:
-    def test_spread_properties(self):
-        dict0 = {
-            "doc_id": "doc_id",
-            "type": "pdf",
-            "text_representation": "text",
-            "binary_representation": None,
-            "parent_id": None,
-            "properties": {"path": "/docs/foo.txt", "title": "bar"},
-            "elements": {
-                "array": [
-                    {
-                        "type": "UncategorizedText",
-                        "text_representation": "text1",
-                        "properties": {"filetype": "text/plain", "page_number": 1},
-                    },
-                    {
-                        "type": "UncategorizedText",
-                        "text_representation": "text2",
-                        "properties": {"filetype": "text/plain", "page_number": 2},
-                    },
-                ]
-            },
-        }
-        doc0 = Document(dict0)
+class FakeNode(Node):
+    def __init__(self, doc: dict):
+        self.doc = doc
 
+    def execute(self) -> ray.data.Dataset:
+        return ray.data.from_items([self.doc])
+
+
+class TestSpreadProperties:
+    dict0 = {
+        "doc_id": "doc_id",
+        "type": "pdf",
+        "text_representation": "text",
+        "binary_representation": None,
+        "parent_id": None,
+        "properties": {"path": "/docs/foo.txt", "title": "bar"},
+        "elements": {
+            "array": [
+                {
+                    "type": "UncategorizedText",
+                    "text_representation": "text1",
+                    "properties": {"filetype": "text/plain", "page_number": 1},
+                },
+                {
+                    "type": "UncategorizedText",
+                    "text_representation": "text2",
+                    "properties": {"filetype": "text/plain", "page_number": 2},
+                },
+            ]
+        },
+    }
+
+    def test_spread_properties(self):
+        doc0 = Document(self.dict0)
         sp = SpreadProperties(None, [])
         spc = sp.SpreadPropertiesCallable(["path", "title"])
         doc1 = spc.spreadProperties(doc0)
@@ -35,3 +46,14 @@ class TestSpreadProperties:
             assert elem.properties["filetype"] == "text/plain"
             assert elem.properties["path"] == "/docs/foo.txt"
             assert elem.properties["title"] == "bar"
+
+    def test_via_execute(self):
+        plan = FakeNode(self.dict0)
+        sp = SpreadProperties(plan, ["path", "title"])
+        ds = sp.execute()
+        for row in ds.iter_rows():
+            doc = Document(row)
+            for elem in doc.elements:
+                assert elem.properties["filetype"] == "text/plain"
+                assert elem.properties["path"] == "/docs/foo.txt"
+                assert elem.properties["title"] == "bar"

--- a/sycamore/transforms/__init__.py
+++ b/sycamore/transforms/__init__.py
@@ -5,6 +5,7 @@ from sycamore.transforms.explode import Explode
 from sycamore.transforms.map import Map, FlatMap, MapBatch
 from sycamore.transforms.partition import Partition, Partitioner
 from sycamore.transforms.extract_table import TableExtractor
+from sycamore.transforms.spread_properties import SpreadProperties
 from sycamore.transforms.summarize import Summarize
 
 __all__ = [
@@ -20,6 +21,7 @@ __all__ = [
     "ExtractEntity",
     "EntityExtractor",
     "TableExtractor",
+    "SpreadProperties",
     "Summarize",
     "Filter",
 ]

--- a/sycamore/transforms/partition.py
+++ b/sycamore/transforms/partition.py
@@ -140,22 +140,8 @@ class UnstructuredPdfPartitioner(Partitioner):
         )
 
         # Here we convert unstructured.io elements into our elements and
-        # append them as child elements to the document.  We copy the
-        # document path from parent to children, so we can access it
-        # efficiently at retrieval time.
-        inherit_properties = ["path"]
-        inherit_dict = {}
-        for inherit_property in inherit_properties:
-            inherit_val = document.properties.get(inherit_property)
-            if inherit_val is not None:
-                inherit_dict[inherit_property] = inherit_val
-
-        new_elements = []
-        for element in elements:
-            new_element = self.to_element(element.to_dict())
-            new_element.properties.update(inherit_dict)
-            new_elements.append(new_element)
-        document.elements = new_elements
+        # set them as the child elements of the document.
+        document.elements = [self.to_element(ee.to_dict()) for ee in elements]
         del elements
 
         document = reorder_elements(document, _elements_reorder_comparator)

--- a/sycamore/transforms/spread_properties.py
+++ b/sycamore/transforms/spread_properties.py
@@ -1,0 +1,48 @@
+from ray.data import Dataset
+
+from sycamore.data import Document
+from sycamore.plan_nodes import Node, Transform, SingleThreadUser, NonGPUUser
+from sycamore.transforms.map import generate_map_function
+
+
+class SpreadProperties(SingleThreadUser, NonGPUUser, Transform):
+    """
+    The SpreadProperties transform copies properties from each document to its
+    subordinate elements.
+
+    Args:
+        child: The source node or component that provides the hierarchical documents to be exploded.
+        resource_args: Additional resource-related arguments that can be passed to the explosion operation.
+
+    Example:
+        .. code-block:: python
+
+            source_node = ...  # Define a source node or component that provides hierarchical documents.
+            spread_transform = SpreadProperties(child=source_node, list=["title"])
+            spread_dataset = spread_transform.execute()
+    """
+
+    def __init__(self, child: Node, props: list[str], **resource_args):
+        super().__init__(child, **resource_args)
+        self._props = props
+
+    class SpreadPropertiesCallable:
+        def __init__(self, props: list[str]):
+            self._props = props
+
+        def spreadProperties(self, parent: Document) -> Document:
+            newProps = {}
+            for key in self._props:
+                val = parent.properties.get(key)
+                if val is not None:
+                    newProps[key] = val
+
+            # TODO: Have a way to let existing element properties win.
+            for element in parent.elements:
+                element.properties.update(newProps)
+            return parent
+
+    def execute(self) -> Dataset:
+        dataset = self.child().execute()
+        spreader = SpreadProperties.SpreadPropertiesCallable(self._props)
+        return dataset.map(generate_map_function(spreader.spreadProperties))


### PR DESCRIPTION
The new SpreadProperties transform copies properties from a Document to its Elements.  This denormalization can be useful to provide efficient access to the properties from the retrieved documents at search time.  The current use is for 'title' and 'path' in examples/simple_ingest.py.  Its use is optional.

This supersedes the previous code in the PDF partitioner that inherited the path from parents.  A unit test is included.