### PR TITLE
Add SerDe for Document

### DIFF
--- a/sycamore/data/__init__.py
+++ b/sycamore/data/__init__.py
@@ -1,3 +1,5 @@
-from sycamore.data.document import BoundingBox, Document, Element
+from sycamore.data.bbox import BoundingBox
+from sycamore.data.element import Element, TableElement
+from sycamore.data.document import Document
 
-__all__ = ["BoundingBox", "Document", "Element"]
+__all__ = ["BoundingBox", "Document", "Element", "TableElement"]

--- a/sycamore/data/bbox.py
+++ b/sycamore/data/bbox.py
@@ -1,0 +1,31 @@
+from abc import ABC
+from typing import Tuple
+
+
+class BoundingBox(ABC):
+    """
+    Defines a bounding box by top left and bottom right coordinates, coordinates units are ratio over the whole
+     document width or height.
+        (x1, y1) ------
+        |             |
+        |             |
+        -------(x2, y2)
+    """
+
+    def __init__(self, x1: float, y1: float, x2: float, y2: float):
+        self.x1 = x1
+        self.y1 = y1
+        self.x2 = x2
+        self.y2 = y2
+
+    @property
+    def height(self) -> float:
+        return self.y2 - self.y1
+
+    @property
+    def width(self) -> float:
+        return self.x2 - self.x1
+
+    @property
+    def coordinates(self) -> Tuple[float, float, float, float]:
+        return self.x1, self.y1, self.x2, self.y2

--- a/sycamore/data/document.py
+++ b/sycamore/data/document.py
@@ -1,133 +1,7 @@
-from abc import ABC
 from collections import UserDict
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
 
-
-class BoundingBox(ABC):
-    """
-    Defines a bounding box by top left and bottom right coordinates, coordinates units are ratio over the whole
-     document width or height.
-        (x1, y1) ------
-        |             |
-        |             |
-        -------(x2, y2)
-    """
-
-    def __init__(self, x1: float, y1: float, x2: float, y2: float):
-        self.x1 = x1
-        self.y1 = y1
-        self.x2 = x2
-        self.y2 = y2
-
-    @property
-    def height(self) -> float:
-        return self.y2 - self.y1
-
-    @property
-    def width(self) -> float:
-        return self.x2 - self.x1
-
-    @property
-    def coordinates(self) -> Tuple[float, float, float, float]:
-        return self.x1, self.y1, self.x2, self.y2
-
-
-class Element(UserDict):
-    """
-    It is often useful to process different parts of a document separately. For example, you might want to process
-    tables differently than text paragraphs, and typically small chunks of text are embedded separately for vector
-    search. In Sycamore, these chunks are called elements. Like documents, elements contain a text or binary
-    representations and collection of properties that can be set by the user or by built-in transforms.
-    """
-
-    def __init__(self, element=None, /, **kwargs):
-        super().__init__(element, **kwargs)
-        default = {
-            "type": None,
-            "text_representation": None,
-            "binary_representation": None,
-            "bbox": None,
-            "properties": {},
-        }
-
-        for k, v in default.items():
-            if k not in self.data:
-                self.data[k] = v
-
-    @property
-    def type(self) -> Optional[str]:
-        return self.data["type"]
-
-    @type.setter
-    def type(self, value: str) -> None:
-        self.data["type"] = value
-
-    @property
-    def text_representation(self) -> Optional[str]:
-        return self.data["text_representation"]
-
-    @text_representation.setter
-    def text_representation(self, value: str) -> None:
-        self.data["text_representation"] = value
-
-    @property
-    def binary_representation(self) -> Optional[bytes]:
-        return self.data["binary_representation"]
-
-    @binary_representation.setter
-    def binary_representation(self, value: str) -> None:
-        self.data["binary_representation"] = value
-
-    @property
-    def bbox(self) -> Optional[BoundingBox]:
-        return None if self.data.get("bbox") is None else BoundingBox(*self.data["bbox"])
-
-    @bbox.setter
-    def bbox(self, bbox: BoundingBox) -> None:
-        self.data["bbox"] = bbox.coordinates
-
-    @property
-    def properties(self) -> dict[str, Any]:
-        return self.data["properties"]
-
-    @properties.deleter
-    def properties(self) -> None:
-        self.data["properties"] = {}
-
-    def to_dict(self) -> dict[str, Any]:
-        return self.data
-
-
-class TableElement(Element):
-    def __init__(
-        self,
-        element=None,
-        title: Optional[str] = None,
-        columns: Optional[list[str]] = None,
-        rows: Optional[list[Any]] = None,
-        **kwargs,
-    ):
-        super().__init__(element, **kwargs)
-        self.data["type"] = "table"
-        self.data["properties"]["title"] = title
-        self.data["properties"]["columns"] = columns
-        self.data["properties"]["rows"] = rows
-
-    @property
-    def rows(self) -> Optional[list[Any]]:
-        return self.data["properties"]["rows"]
-
-    @rows.setter
-    def rows(self, rows: Optional[list[Any]] = None) -> None:
-        self.data["properties"]["rows"] = rows
-
-    @property
-    def columns(self) -> Optional[list[str]]:
-        return self.data["properties"]["columns"]
-
-    @columns.setter
-    def columns(self, columns: Optional[list[str]] = None) -> None:
-        self.data["properties"]["columns"] = columns
+from sycamore.data import BoundingBox, Element
 
 
 class Document(UserDict):
@@ -137,27 +11,16 @@ class Document(UserDict):
     """
 
     def __init__(self, document=None, /, **kwargs):
-        super().__init__(document, **kwargs)
-        default = {
-            "doc_id": None,
-            "type": None,
-            "text_representation": None,
-            "binary_representation": None,
-            "elements": {"array": []},
-            "embedding": None,
-            "parent_id": None,
-            "bbox": None,
-            "properties": {},
-        }
+        if isinstance(document, bytes):
+            from pickle import loads
 
-        for k, v in default.items():
-            if k not in self.data:
-                self.data[k] = v
+            document = loads(document)
+        super().__init__(document, **kwargs)
 
     @property
     def doc_id(self) -> Optional[str]:
         """A unique identifier for the document. Defaults to a uuid."""
-        return self.data["doc_id"]
+        return self.data.get("doc_id")
 
     @doc_id.setter
     def doc_id(self, value: str) -> None:
@@ -165,7 +28,7 @@ class Document(UserDict):
 
     @property
     def type(self) -> Optional[str]:
-        return self.data["type"]
+        return self.data.get("type")
 
     @type.setter
     def type(self, value: str) -> None:
@@ -173,7 +36,7 @@ class Document(UserDict):
 
     @property
     def text_representation(self) -> Optional[str]:
-        return self.data["text_representation"]
+        return self.data.get("text_representation")
 
     @text_representation.setter
     def text_representation(self, value: str) -> None:
@@ -183,7 +46,7 @@ class Document(UserDict):
     def binary_representation(self) -> Optional[bytes]:
         """The raw content of the document in stored in the appropriate format.For example, the
         content of a PDF document will be stored as the binary_representation."""
-        return self.data["binary_representation"]
+        return self.data.get("binary_representation")
 
     @binary_representation.setter
     def binary_representation(self, value: bytes) -> None:
@@ -197,19 +60,19 @@ class Document(UserDict):
     def elements(self) -> list[Element]:
         """A list of elements belonging to this document. A document does not necessarily always have
         elements, for instance, before a document is chunked."""
-        return [Element(element) for element in self.data["elements"]["array"]]
+        return [Element(element) for element in self.data.get("elements", [])]
 
     @elements.setter
     def elements(self, elements: list[Element]):
-        self.data["elements"] = {"array": [element.to_dict() for element in elements]}
+        self.data["elements"] = [element.data for element in elements]
 
     @elements.deleter
     def elements(self) -> None:
-        self.data["elements"] = {"array": []}
+        self.data["elements"] = []
 
     @property
-    def embedding(self) -> list[list[float]]:
-        return self.data["embedding"]
+    def embedding(self) -> Optional[list[list[float]]]:
+        return self.data.get("embedding")
 
     @embedding.setter
     def embedding(self, embedding: list[list[float]]) -> None:
@@ -221,7 +84,7 @@ class Document(UserDict):
         example, the explode transform promotes elements to be top-level documents, and these documents retain a
         pointer to the document from which they were created using the parent_id field. For those documents which
         have no parent, parent_id is None."""
-        return self.data["parent_id"]
+        return self.data.get("parent_id")
 
     @parent_id.setter
     def parent_id(self, value: str) -> None:
@@ -239,11 +102,30 @@ class Document(UserDict):
     def properties(self) -> dict[str, Any]:
         """A collection of system or customer defined properties, for instance, a PDF document might have
         title and author properties."""
-        return self.data["properties"]
+        return self.data.get("properties", {})
+
+    @properties.setter
+    def properties(self, properties: dict[str, Any]):
+        self.data["properties"] = properties
 
     @properties.deleter
     def properties(self) -> None:
         self.data["properties"] = {}
 
-    def to_dict(self) -> dict[str, Any]:
-        return self.data
+    def serialize(self) -> bytes:
+        from pickle import dumps
+
+        return dumps(self.data)
+
+    @staticmethod
+    def deserialize(raw: bytes) -> "Document":
+        from pickle import loads
+
+        return Document(loads(raw))
+
+    @staticmethod
+    def from_row(row: dict[str, bytes]) -> "Document":
+        return Document(row["doc"])
+
+    def to_row(self) -> dict[str, bytes]:
+        return {"doc": self.serialize()}

--- a/sycamore/data/element.py
+++ b/sycamore/data/element.py
@@ -1,0 +1,93 @@
+from collections import UserDict
+from typing import Any, Optional
+
+from sycamore.data import BoundingBox
+
+
+class Element(UserDict):
+    """
+    It is often useful to process different parts of a document separately. For example, you might want to process
+    tables differently than text paragraphs, and typically small chunks of text are embedded separately for vector
+    search. In Sycamore, these chunks are called elements. Like documents, elements contain a text or binary
+    representations and collection of properties that can be set by the user or by built-in transforms.
+    """
+
+    def __init__(self, element=None, /, **kwargs):
+        super().__init__(element, **kwargs)
+
+    @property
+    def type(self) -> Optional[str]:
+        return self.data.get("type")
+
+    @type.setter
+    def type(self, value: str) -> None:
+        self.data["type"] = value
+
+    @property
+    def text_representation(self) -> Optional[str]:
+        return self.data.get("text_representation")
+
+    @text_representation.setter
+    def text_representation(self, value: str) -> None:
+        self.data["text_representation"] = value
+
+    @property
+    def binary_representation(self) -> Optional[bytes]:
+        return self.data.get("binary_representation")
+
+    @binary_representation.setter
+    def binary_representation(self, value: str) -> None:
+        self.data["binary_representation"] = value
+
+    @property
+    def bbox(self) -> Optional[BoundingBox]:
+        return None if self.data.get("bbox") is None else BoundingBox(*self.data["bbox"])
+
+    @bbox.setter
+    def bbox(self, bbox: BoundingBox) -> None:
+        self.data["bbox"] = bbox.coordinates
+
+    @property
+    def properties(self) -> dict[str, Any]:
+        return self.data.get("properties", {})
+
+    @properties.setter
+    def properties(self, properties: dict[str, Any]):
+        self.data["properties"] = properties
+
+    @properties.deleter
+    def properties(self) -> None:
+        self.data["properties"] = {}
+
+
+class TableElement(Element):
+    def __init__(
+        self,
+        element=None,
+        title: Optional[str] = None,
+        columns: Optional[list[str]] = None,
+        rows: Optional[list[Any]] = None,
+        **kwargs,
+    ):
+        super().__init__(element, **kwargs)
+        self.data["type"] = "table"
+        self.data["properties"] = {}
+        self.data["properties"]["title"] = title
+        self.data["properties"]["columns"] = columns
+        self.data["properties"]["rows"] = rows
+
+    @property
+    def rows(self) -> Optional[list[Any]]:
+        return self.data["properties"]["rows"]
+
+    @rows.setter
+    def rows(self, rows: Optional[list[Any]] = None) -> None:
+        self.data["properties"]["rows"] = rows
+
+    @property
+    def columns(self) -> Optional[list[str]]:
+        return self.data["properties"]["columns"]
+
+    @columns.setter
+    def columns(self, columns: Optional[list[str]] = None) -> None:
+        self.data["properties"]["columns"] = columns

--- a/sycamore/docset.py
+++ b/sycamore/docset.py
@@ -71,11 +71,11 @@ class DocSet:
 
         execution = Execution(self.context, self.plan)
         dataset = execution.execute(self.plan)
-        documents = [Document(row) for row in dataset.take(limit)]
+        documents = [Document.from_row(row) for row in dataset.take(limit)]
         for document in documents:
             if not show_elements:
                 num_elems = len(document.elements)
-                document.data["elements"]["array"] = f"<{num_elems} elements>"
+                document.data["elements"] = f"<{num_elems} elements>"
             else:
                 if document.elements is not None and 0 <= num_elements < len(document.elements):
                     document.elements = document.elements[:num_elements]
@@ -142,7 +142,7 @@ class DocSet:
 
         execution = Execution(self.context, self.plan)
         dataset = execution.execute(self.plan)
-        return [Document(row) for row in dataset.take(limit)]
+        return [Document.from_row(row) for row in dataset.take(limit)]
 
     def limit(self, limit: int = 20) -> "DocSet":
         """

--- a/sycamore/functions/document.py
+++ b/sycamore/functions/document.py
@@ -48,9 +48,11 @@ def split_and_convert_to_image(doc: Document) -> list[Document]:
     sorted_elements_by_page = sorted(elements_by_page.items(), key=lambda x: x[0])
     new_docs = []
     for image, (page, elements) in zip(images, sorted_elements_by_page):
-        new_doc = Document(binary_representation=image.tobytes(), elements={"array": elements})
-        new_doc.properties.update(doc.properties)
-        new_doc.properties.update({"size": list(image.size), "mode": image.mode, "page_number": page})
+        new_doc = Document(binary_representation=image.tobytes(), elements=elements)
+        properties = {}
+        properties.update(doc.properties)
+        properties.update({"size": list(image.size), "mode": image.mode, "page_number": page})
+        new_doc.properties = properties
         new_docs.append(new_doc)
     return new_docs
 

--- a/sycamore/scans/file_scan.py
+++ b/sycamore/scans/file_scan.py
@@ -76,23 +76,29 @@ class BinaryScan(FileScan):
         self._filesystem = filesystem
         self._metadata_provider = metadata_provider
 
-    def _to_document(self, dict: dict[str, Any]) -> dict[str, Any]:
+    def _is_s3_scheme(self):
+        if isinstance(self._paths, str):
+            return self._paths.startswith("s3:")
+        else:
+            return all(path.startswith("s3:") for path in self._paths)
+
+    def _to_document(self, dict: dict[str, Any]) -> dict[str, bytes]:
         document = Document()
         import uuid
 
         document.doc_id = str(uuid.uuid1())
         document.type = self._binary_format
         document.binary_representation = dict["bytes"]
-        document.properties.update({"path": dict["path"]})
-        if self._metadata_provider:
-            document.properties.update(self._metadata_provider.get_metadata(dict["path"]))
-        return document.data
 
-    def _is_s3_scheme(self):
-        if isinstance(self._paths, str):
-            return self._paths.startswith("s3:")
-        else:
-            return all(path.startswith("s3:") for path in self._paths)
+        properties = document.properties
+        if self._is_s3_scheme():
+            dict["path"] = "s3://" + dict["path"]
+        properties.update({"path": dict["path"]})
+        if self._metadata_provider:
+            properties.update(self._metadata_provider.get_metadata(dict["path"]))
+        document.properties = properties
+
+        return {"doc": document.serialize()}
 
     def execute(self) -> "Dataset":
         partition_filter = FileExtensionFilter(self.format())
@@ -104,13 +110,6 @@ class BinaryScan(FileScan):
             partition_filter=partition_filter,
             ray_remote_args=self.resource_args,
         )
-
-        def prepend_scheme(file):
-            file["path"] = "s3://" + file["path"]
-            return file
-
-        if self._is_s3_scheme():
-            files = files.map(prepend_scheme, **self.resource_args)
 
         return files.map(self._to_document, **self.resource_args)
 

--- a/sycamore/scans/materialized_scan.py
+++ b/sycamore/scans/materialized_scan.py
@@ -24,7 +24,7 @@ class ArrowScan(MaterializedScan):
         self._tables = tables
 
     def execute(self) -> Dataset:
-        return from_arrow(tables=self._tables).map(lambda dict: Document(dict))
+        return from_arrow(tables=self._tables).map(lambda dict: {"doc": Document(dict).serialize()})
 
     def format(self):
         return "arrow"
@@ -33,10 +33,10 @@ class ArrowScan(MaterializedScan):
 class DocScan(MaterializedScan):
     def __init__(self, docs: list[Document], **resource_args):
         super().__init__(**resource_args)
-        self._dicts = docs
+        self._docs = docs
 
     def execute(self) -> Dataset:
-        return from_items(items=self._dicts)
+        return from_items(items=[{"doc": doc.serialize()} for doc in self._docs])
 
     def format(self):
         return "document"
@@ -48,7 +48,7 @@ class PandasScan(MaterializedScan):
         self._dfs = dfs
 
     def execute(self) -> Dataset:
-        return from_pandas(dfs=self._dfs).map(lambda dict: Document(dict))
+        return from_pandas(dfs=self._dfs).map(lambda dict: {"doc": Document(dict).serialize()})
 
     def format(self):
         return "pandas"

--- a/sycamore/tests/conftest.py
+++ b/sycamore/tests/conftest.py
@@ -11,5 +11,7 @@ def read_local_binary(request) -> Document:
     input_stream = local.open_input_stream(path)
     document = Document()
     document.binary_representation = input_stream.readall()
-    document.properties["path"] = path
+    properties = document.properties
+    properties["path"] = path
+    document.properties = properties
     return document

--- a/sycamore/tests/unit/data/test_document.py
+++ b/sycamore/tests/unit/data/test_document.py
@@ -13,17 +13,21 @@ class TestElement:
         element.type = "table"
         element.text_representation = "text"
         element.bbox = BoundingBox(1, 2, 3, 4)
-        element.properties.update({"property1": 1})
+        properties = element.properties
+        properties.update({"property1": 1})
+        element.properties = properties
         assert element.type == "table"
         assert element.text_representation == "text"
         assert element.properties == {"property1": 1}
 
-        element.properties.update({"property2": 2})
+        properties = element.properties
+        properties.update({"property2": 2})
+        element.properties = properties
         assert element.properties == {"property1": 1, "property2": 2}
 
         del element.properties
         assert element.properties == {}
-        assert element.to_dict()["bbox"] == (1, 2, 3, 4)
+        assert element.data["bbox"] == (1, 2, 3, 4)
 
 
 class TestDocument:
@@ -46,18 +50,20 @@ class TestDocument:
         document.elements = [element1]
         document.embedding = [[1.0, 2.0], [2.0, 3.0]]
         document.bbox = BoundingBox(1, 2, 3, 4)
-        document.properties.update({"property1": 1})
+        document.properties = {"property1": 1}
         assert document.doc_id == "doc_id"
         assert document.type == "table"
         assert document.text_representation == "text"
-        assert document.elements == [element1.to_dict()]
+        assert document.elements == [element1.data]
         assert document.embedding == [[1.0, 2.0], [2.0, 3.0]]
         assert document.properties == {"property1": 1}
 
         element2 = Element({"type": "image", "text": "text"})
         document.elements = [element1, element2]
-        assert document.elements == [element1.to_dict(), element2.to_dict()]
-        document.properties.update({"property2": 2})
+        assert document.elements == [element1.data, element2.data]
+        properties = document.properties
+        properties.update({"property2": 2})
+        document.properties = properties
         assert document.properties == {"property1": 1, "property2": 2}
 
         del document.elements
@@ -65,4 +71,26 @@ class TestDocument:
         assert document.elements == []
         assert document.properties == {}
 
-        assert document.to_dict()["bbox"] == (1, 2, 3, 4)
+        assert document.data["bbox"] == (1, 2, 3, 4)
+
+    def test_serde(self):
+        dict = {
+            "doc_id": "doc_id",
+            "type": "pdf",
+            "text_representation": "text_representation",
+            "bbox": (1, 2.3, 3.4, 4.5),
+            "elements": [
+                {
+                    "type": "table",
+                    "bbox": (1, 2, 3, 4.0),
+                },
+                {
+                    "type": "figure",
+                    "bbox": (1, 2, 3, 4.0),
+                },
+            ],
+            "properties": {"int": 0, "float": 3.14, "list": [1, 2, 3, 4], "tuple": (1, "tuple")},
+        }
+        document = Document(dict)
+        serde = Document(document.serialize())
+        assert serde.data == dict

--- a/sycamore/tests/unit/scans/test_binary_scan.py
+++ b/sycamore/tests/unit/scans/test_binary_scan.py
@@ -1,6 +1,7 @@
 import json
 import tempfile
 
+from sycamore.data import Document
 from sycamore.scans.file_scan import JsonManifestMetadataProvider
 from sycamore.scans import BinaryScan
 from sycamore.tests.config import TEST_DIR
@@ -11,17 +12,7 @@ class TestBinaryScan:
         paths = str(TEST_DIR / "resources/data/pdfs/")
         scan = BinaryScan(paths, binary_format="pdf")
         ds = scan.execute()
-        assert ds.schema().names == [
-            "doc_id",
-            "type",
-            "text_representation",
-            "binary_representation",
-            "elements",
-            "embedding",
-            "parent_id",
-            "bbox",
-            "properties",
-        ]
+        assert ds.schema().names == ["doc"]
 
     def test_json_manifest(self):
         base_path = str(TEST_DIR / "resources/data/htmls/")
@@ -43,8 +34,8 @@ class TestBinaryScan:
                 base_path, binary_format="html", metadata_provider=JsonManifestMetadataProvider(manifest_path)
             )
             ds = scan.execute()
-            doc = ds.take(1)[0]
-            assert doc["properties"]["remote_url"] == remote_url
-            assert doc["properties"]["indexed_at"] == indexed_at
+            doc = Document.from_row(ds.take(1)[0])
+            assert doc.properties["remote_url"] == remote_url
+            assert doc.properties["indexed_at"] == indexed_at
         finally:
             tmp_manifest.close()

--- a/sycamore/tests/unit/scans/test_materialized_scan.py
+++ b/sycamore/tests/unit/scans/test_materialized_scan.py
@@ -15,14 +15,4 @@ class TestMaterializedScan:
     )
     def test_materialized_scan(self, scanner):
         ds = scanner.execute()
-        assert ds.schema().names == [
-            "doc_id",
-            "type",
-            "text_representation",
-            "binary_representation",
-            "elements",
-            "embedding",
-            "parent_id",
-            "bbox",
-            "properties",
-        ]
+        assert ds.schema().names == ["doc"]

--- a/sycamore/tests/unit/test_writer.py
+++ b/sycamore/tests/unit/test_writer.py
@@ -22,7 +22,7 @@ def generate_docs(num: int, type: str = "test", text=True, binary=False, num_ele
             {
                 "doc_id": f"doc_{i}",
                 "type": "test",
-                "elements": {"array": []},
+                "elements": [],
                 "properties": {"filename": f"doc_{i}.dat"},
             }
         )

--- a/sycamore/tests/unit/transforms/test_embed.py
+++ b/sycamore/tests/unit/transforms/test_embed.py
@@ -67,12 +67,11 @@ class TestEmbedding:
             node,
             embedder=SentenceTransformerEmbedder(model_name="sentence-transformers/all-MiniLM-L6-v2", batch_size=100),
         )
-        input_dataset = ray.data.from_items(
-            [
-                {"doc_id": 1, "text_representation": "Members of a strike at Yale University.", "embedding": None},
-                {"doc_id": 2, "text_representation": "A woman is speaking at a podium outdoors.", "embedding": None},
-            ]
-        )
+        dicts = [
+            {"doc_id": 1, "text_representation": "Members of a strike at Yale University.", "embedding": None},
+            {"doc_id": 2, "text_representation": "A woman is speaking at a podium outdoors.", "embedding": None},
+        ]
+        input_dataset = ray.data.from_items([{"doc": Document(dict).serialize()} for dict in dicts])
         execute = mocker.patch.object(node, "execute")
         execute.return_value = input_dataset
         input_dataset.show()

--- a/sycamore/tests/unit/transforms/test_explode.py
+++ b/sycamore/tests/unit/transforms/test_explode.py
@@ -6,15 +6,15 @@ from sycamore.transforms import Explode
 
 
 class TestExplode:
-    doc = {
-        "doc_id": "doc_id",
-        "type": "pdf",
-        "content": {"binary": None, "text": "text"},
-        "parent_id": None,
-        "properties": {"path": "s3://path"},
-        "embedding": {"binary": None, "text": None},
-        "elements": {
-            "array": [
+    doc = Document(
+        {
+            "doc_id": "doc_id",
+            "type": "pdf",
+            "content": {"binary": None, "text": "text"},
+            "parent_id": None,
+            "properties": {"path": "s3://path"},
+            "embedding": {"binary": None, "text": None},
+            "elements": [
                 {
                     "type": "title",
                     "content": {"binary": None, "text": "text1"},
@@ -25,19 +25,19 @@ class TestExplode:
                     "content": {"binary": None, "text": "text2"},
                     "properties": {"page_name": "name", "coordinates": [(1, 2)], "coordinate_system": "pixel"},
                 },
-            ]
-        },
-    }
+            ],
+        }
+    )
 
     def test_explode_callable(self):
         exploder = Explode.ExplodeCallable()
-        docs = exploder.explode(Document(self.doc))
+        docs = exploder.explode(self.doc)
         assert len(docs) == 3
 
     def test_explode(self, mocker):
         node = mocker.Mock(spec=Node)
         explode = Explode(node)
-        input_dataset = ray.data.from_items([self.doc])
+        input_dataset = ray.data.from_items([{"doc": self.doc.serialize()}])
         execute = mocker.patch.object(node, "execute")
         execute.return_value = input_dataset
         input_dataset.show()

--- a/sycamore/tests/unit/transforms/test_mapping.py
+++ b/sycamore/tests/unit/transforms/test_mapping.py
@@ -7,7 +7,7 @@ from ray.data import ActorPoolStrategy
 from sycamore.data import Document
 from sycamore.plan_nodes import Node
 from sycamore.transforms import Map, FlatMap, MapBatch, Filter
-from sycamore.transforms.map import generate_map_batch_class_from_callable
+from sycamore.utils import generate_map_batch_class_from_callable
 
 
 def map_func(doc: Document) -> Document:
@@ -39,16 +39,15 @@ class TestMapping:
     def test_map_function(self, mocker, function):
         node = mocker.Mock(spec=Node)
         mapping = Map(node, f=function)
-        input_dataset = ray.data.from_items(
-            [
-                {"index": 1, "doc": "Members of a strike at Yale University."},
-                {"index": 2, "doc": "A woman is speaking at a podium outdoors."},
-            ]
-        )
+        dicts = [
+            {"index": 1, "doc": "Members of a strike at Yale University."},
+            {"index": 2, "doc": "A woman is speaking at a podium outdoors."},
+        ]
+        input_dataset = ray.data.from_items([{"doc": Document(dict).serialize()} for dict in dicts])
         execute = mocker.patch.object(node, "execute")
         execute.return_value = input_dataset
         output_dataset = mapping.execute()
-        dicts = output_dataset.take()
+        dicts = [Document.from_row(doc).data for doc in output_dataset.take()]
         assert dicts[0]["index"] == 2 and dicts[1]["index"] == 3
 
     class FlatMapClass:
@@ -59,12 +58,11 @@ class TestMapping:
     def test_flat_map(self, mocker, function):
         node = mocker.Mock(spec=Node)
         mapping = FlatMap(node, f=function)
-        input_dataset = ray.data.from_items(
-            [
-                {"index": 1, "doc": "Members of a strike at Yale University."},
-                {"index": 2, "doc": "A woman is speaking at a podium outdoors."},
-            ]
-        )
+        dicts = [
+            {"index": 1, "doc": "Members of a strike at Yale University."},
+            {"index": 2, "doc": "A woman is speaking at a podium outdoors."},
+        ]
+        input_dataset = ray.data.from_items([{"doc": Document(dict).serialize()} for dict in dicts])
         execute = mocker.patch.object(node, "execute")
         execute.return_value = input_dataset
         output_dataset = mapping.execute()
@@ -81,16 +79,15 @@ class TestMapping:
     def test_map_batch(self, mocker, function):
         node = mocker.Mock(spec=Node)
         mapping = MapBatch(node, f=function)
-        input_dataset = ray.data.from_items(
-            [
-                {"index": 1, "doc": "Members of a strike at Yale University."},
-                {"index": 2, "doc": "A woman is speaking at a podium outdoors."},
-            ]
-        )
+        dicts = [
+            {"index": 1, "doc": "Members of a strike at Yale University."},
+            {"index": 2, "doc": "A woman is speaking at a podium outdoors."},
+        ]
+        input_dataset = ray.data.from_items([{"doc": Document(dict).serialize()} for dict in dicts])
         execute = mocker.patch.object(node, "execute")
         execute.return_value = input_dataset
         output_dataset = mapping.execute()
-        dicts = output_dataset.take()
+        dicts = [Document.from_row(doc).data for doc in output_dataset.take()]
         assert dicts[0]["index"] == 2 and dicts[1]["index"] == 3
 
     def test_generate_map_batch_class_from_callable(self):
@@ -101,29 +98,53 @@ class TestMapping:
                 return docs
 
         ray_callable = generate_map_batch_class_from_callable(BatchClass())
-        input_dataset = ray.data.from_items(
-            [
-                {"index": 1, "doc": "Members of a strike at Yale University."},
-                {"index": 2, "doc": "A woman is speaking at a podium outdoors."},
-            ]
-        )
-        output = input_dataset.map_batches(ray_callable, compute=ActorPoolStrategy())
-        dicts = output.take()
+        dicts = [
+            {"index": 1, "doc": "Members of a strike at Yale University."},
+            {"index": 2, "doc": "A woman is speaking at a podium outdoors."},
+        ]
+        input_dataset = ray.data.from_items([{"doc": Document(dict).serialize()} for dict in dicts])
+        output_dataset = input_dataset.map_batches(ray_callable, compute=ActorPoolStrategy())
+        dicts = [Document.from_row(doc).data for doc in output_dataset.take()]
         assert dicts[0]["index"] == 2 and dicts[1]["index"] == 3
 
     def test_generate_map_batch_filter_function(self, mocker):
         node = mocker.Mock(spec=Node)
         filtered = Filter(node, f=filter_func)
-        input_dataset = ray.data.from_items(
-            [
-                {"index": 1, "doc": "Members of a strike at Yale University.", "properties": {"page_number": 1}},
-                {"index": 2, "doc": "A woman is speaking at a podium outdoors.", "properties": {"page_number": 2}},
-            ]
-        )
+        dicts = [
+            {"index": 1, "doc": "Members of a strike at Yale University.", "properties": {"page_number": 1}},
+            {"index": 2, "doc": "A woman is speaking at a podium outdoors.", "properties": {"page_number": 2}},
+        ]
+        input_dataset = ray.data.from_items([{"doc": Document(dict).serialize()} for dict in dicts])
         execute = mocker.patch.object(node, "execute")
         execute.return_value = input_dataset
         output = filtered.execute()
 
-        dicts = output.take()
+        dicts = [Document.from_row(doc).data for doc in output.take()]
         assert len(dicts) == 1
         assert dicts[0]["properties"]["page_number"] == 1
+
+    def test_flat_map_conflict(self, mocker):
+        def func(doc: Document) -> List[Document]:
+            if doc.doc_id == 1:
+                return [
+                    Document({"doc_id": 11, "parent_id": 1, "properties": {"author": "author"}}),
+                    Document({"doc_id": 12, "properties": {"title": "title"}}),
+                ]
+            else:
+                return [
+                    Document({"doc_id": 21, "binary_representation": bytes("abc", "utf-8")}),
+                    Document({"doc_id": 22, "text_representation": "abc"}),
+                ]
+
+        node = mocker.Mock(spec=Node)
+        mapping = FlatMap(node, f=func)
+        dicts = [
+            {"doc_id": 1, "doc": "Members of a strike at Yale University."},
+            {"doc_id": 2, "doc": "A woman is speaking at a podium outdoors."},
+        ]
+        input_dataset = ray.data.from_items([{"doc": Document(dict).serialize()} for dict in dicts])
+        execute = mocker.patch.object(node, "execute")
+        execute.return_value = input_dataset
+        output_dataset = mapping.execute()
+        batch = output_dataset.take_batch()
+        assert len(batch["doc"]) == 4

--- a/sycamore/tests/unit/transforms/test_merge_elements.py
+++ b/sycamore/tests/unit/transforms/test_merge_elements.py
@@ -15,15 +15,15 @@ class FakeNode(Node):
 
 
 class TestMergeElements:
-    dict0 = {
-        "doc_id": "doc_id",
-        "type": "pdf",
-        "text_representation": "text",
-        "binary_representation": None,
-        "parent_id": None,
-        "properties": {"path": "/docs/foo.txt", "title": "bar"},
-        "elements": {
-            "array": [
+    doc = Document(
+        {
+            "doc_id": "doc_id",
+            "type": "pdf",
+            "text_representation": "text",
+            "binary_representation": None,
+            "parent_id": None,
+            "properties": {"path": "/docs/foo.txt", "title": "bar"},
+            "elements": [
                 {
                     "type": "UncategorizedText",
                     "text_representation": "text1",
@@ -75,15 +75,14 @@ class TestMergeElements:
                     "properties": {"doc_title": "title"},
                 },
                 {},
-            ]
-        },
-    }
+            ],
+        }
+    )
 
     def test_merge_elements(self):
-        doc = Document(self.dict0)
         tokenizer = HuggingFaceTokenizer("sentence-transformers/all-MiniLM-L6-v2")
         merger = GreedyTextElementMerger(tokenizer, 120)
-        new_doc = merger.merge_elements(doc)
+        new_doc = merger.merge_elements(self.doc)
         assert len(new_doc.elements) == 4
 
         e = new_doc.elements[0]
@@ -106,9 +105,13 @@ class TestMergeElements:
         assert e.binary_representation == b"title1"
         assert e.properties == {"doc_title": "title"}
 
-    def test_merge_elements_via_execute(self):
-        plan = FakeNode(self.dict0)
+    def test_merge_elements_via_execute(self, mocker):
+        node = mocker.Mock(spec=Node)
+        input_dataset = ray.data.from_items([{"doc": self.doc.serialize()}])
+        execute = mocker.patch.object(node, "execute")
+        execute.return_value = input_dataset
         tokenizer = HuggingFaceTokenizer("sentence-transformers/all-MiniLM-L6-v2")
         merger = GreedyTextElementMerger(tokenizer, 120)
-        merge = Merge(plan, merger)
-        merge.execute()
+        merge = Merge(node, merger)
+        output_dataset = merge.execute()
+        output_dataset.show()

--- a/sycamore/tests/unit/transforms/test_summarize.py
+++ b/sycamore/tests/unit/transforms/test_summarize.py
@@ -2,7 +2,6 @@ import random
 import string
 
 from sycamore.data import Document, Element
-from sycamore.functions import filter_elements
 from sycamore.llms import LLM
 from sycamore.transforms.summarize import LLMElementTextSummarizer
 
@@ -18,7 +17,7 @@ class TestSummarize:
         text_summarizer = LLMElementTextSummarizer(llm, filter_elements_on_length)
         doc = text_summarizer.summarize(doc)
 
-        assert doc["elements"]["array"][0]["properties"] == {}
+        assert doc.elements[0].properties == {}
 
     def test_summarize_text_calls_llm(self, mocker):
         llm = mocker.Mock(spec=LLM)
@@ -34,16 +33,9 @@ class TestSummarize:
         text_summarizer = LLMElementTextSummarizer(llm, filter_elements_on_length)
         doc = text_summarizer.summarize(doc)
 
-        assert doc["elements"]["array"][0]["properties"] == {}
-        assert doc["elements"]["array"][1]["properties"] == {"summary": "summary"}
+        assert doc.elements[0].properties == {}
+        assert doc.elements[1].properties == {"summary": "summary"}
 
 
-def filter_elements_on_length(
-    document: Document,
-    minimum_length: int = 10,
-) -> list[Element]:
-    def filter_func(element: Element):
-        if element.text_representation is not None:
-            return len(element.text_representation) > minimum_length
-
-    return filter_elements(document, filter_func)
+def filter_elements_on_length(element: Element) -> bool:
+    return False if element.text_representation is None else len(element.text_representation) > 10

--- a/sycamore/transforms/basics.py
+++ b/sycamore/transforms/basics.py
@@ -6,7 +6,7 @@ from sycamore.plan_nodes import Node, NonGPUUser, NonCPUUser, Transform
 
 from sycamore.data import Document
 from sycamore.plan_nodes import UnaryNode
-from sycamore.transforms.map import generate_map_batch_filter_function
+from sycamore.utils import generate_map_batch_filter_function
 
 
 class Limit(NonCPUUser, NonGPUUser, Transform):

--- a/sycamore/transforms/embed.py
+++ b/sycamore/transforms/embed.py
@@ -8,7 +8,7 @@ from sentence_transformers import SentenceTransformer
 
 from sycamore.data import Document
 from sycamore.plan_nodes import Node, Transform
-from sycamore.transforms.map import generate_map_batch_function, generate_map_batch_class_from_callable
+from sycamore.utils import generate_map_batch_function, generate_map_batch_class_from_callable
 
 
 class Embedder(ABC):

--- a/sycamore/transforms/explode.py
+++ b/sycamore/transforms/explode.py
@@ -34,7 +34,7 @@ class Explode(SingleThreadUser, NonGPUUser, Transform):
             import uuid
 
             for element in parent.elements:
-                cur = Document(element.to_dict())
+                cur = Document(element.data)
                 cur.doc_id = str(uuid.uuid1())
                 cur.parent_id = parent.doc_id
                 documents.append(cur)

--- a/sycamore/transforms/extract_entity.py
+++ b/sycamore/transforms/extract_entity.py
@@ -18,7 +18,7 @@ from sycamore.llms.prompts import (
 def element_list_formatter(elements: list[Element]) -> str:
     query = ""
     for i in range(len(elements)):
-        query += f"ELEMENT {i + 1}: {elements[i]['text_representation']}\n"
+        query += f"ELEMENT {i + 1}: {elements[i].text_representation}\n"
     return query
 
 
@@ -82,7 +82,9 @@ class OpenAIEntityExtractor(EntityExtractor):
         else:
             entities = self._handle_zero_shot_prompting(document)
 
-        document.properties.update({f"{self._entity_name}": entities["answer"]})
+        properties = document.properties
+        properties.update({f"{self._entity_name}": entities["answer"]})
+        document.properties = properties
 
         return document
 

--- a/sycamore/transforms/extract_table.py
+++ b/sycamore/transforms/extract_table.py
@@ -53,9 +53,11 @@ class TextractTableExtractor(TableExtractor):
         for table in result.tables:
             element = Element()
             element.type = "Table"
-            element.properties["boxes"] = []
-            element.properties["id"] = table.id
-            element.properties["page"] = table.page
+            properties = element.properties
+            properties["boxes"] = []
+            properties["id"] = table.id
+            properties["page"] = table.page
+            element.properties = properties
 
             if table.title:
                 element.text_representation = table.title.text + "\n"

--- a/sycamore/transforms/map.py
+++ b/sycamore/transforms/map.py
@@ -1,11 +1,18 @@
-from collections import defaultdict
-from typing import Any, Callable, Iterable, Optional, Type
+from typing import Any, Callable, Iterable, Optional
 
-import numpy as np
 from ray.data import ActorPoolStrategy, Dataset
 
 from sycamore.data import Document
 from sycamore.plan_nodes import Node, UnaryNode
+
+from sycamore.utils import (
+    generate_map_function,
+    generate_map_class,
+    generate_flat_map_function,
+    generate_flat_map_class,
+    generate_map_batch_function,
+    generate_map_batch_class,
+)
 
 
 def rename(new_function_name: str):
@@ -14,153 +21,6 @@ def rename(new_function_name: str):
         return f
 
     return decorator
-
-
-def generate_map_function(f: Callable[[Document], Document]) -> Callable[[dict[str, Any]], dict[str, Any]]:
-    @rename(f.__name__)
-    def ray_callable(input_dict: dict[str, Any]) -> dict[str, Any]:
-        document = f(Document(input_dict))
-        return document.data
-
-    return ray_callable
-
-
-def generate_map_class(c: Type[Callable[[Document], Document]]) -> Callable[[dict[str, Any]], dict[str, Any]]:
-    def ray_init(self):
-        self.base = c()
-
-    def ray_callable(self, input_dict: dict[str, Any]) -> dict[str, Any]:
-        document = self.base(Document(input_dict))
-        return document.data
-
-    new_class = type("CustomRay" + c.__name__, (), {"__init__": ray_init, "__call__": ray_callable})
-    return new_class
-
-
-def generate_flat_map_function(
-    f: Callable[[Document], list[Document]]
-) -> Callable[[dict[str, Any]], list[dict[str, Any]]]:
-    @rename(f.__name__)
-    def ray_callable(input_dict: dict[str, Any]) -> list[dict[str, Any]]:
-        documents = f(Document(input_dict))
-        return [document.data for document in documents]
-
-    return ray_callable
-
-
-def generate_flat_map_class(
-    c: Type[Callable[[Document], list[Document]]]
-) -> Callable[[dict[str, Any]], list[dict[str, Any]]]:
-    def ray_init(self):
-        self.base = c()
-
-    def ray_callable(self, input_dict: dict[str, Any]) -> list[dict[str, Any]]:
-        documents = self.base(Document(input_dict))
-        return [document.data for document in documents]
-
-    new_class = type("CustomRay" + c.__name__, (), {"__init__": ray_init, "__call__": ray_callable})
-    return new_class
-
-
-def generate_map_batch_function(
-    f: Callable[[list[Document]], list[Document]]
-) -> Callable[[dict[str, np.ndarray]], dict[str, list]]:
-    @rename(f.__name__)
-    def ray_callable(doc_batch: dict[str, np.ndarray]) -> dict[str, list]:
-        input_docs = _get_documents_from_columnar_format(doc_batch)
-        output_docs = f(input_docs)
-
-        return _get_columnar_format_from_documents(output_docs)
-
-    return ray_callable
-
-
-def generate_map_batch_filter_function(
-    f: Callable[[Document], bool]
-) -> Callable[[dict[str, np.ndarray]], dict[str, list]]:
-    @rename(f.__name__)
-    def ray_callable(doc_batch: dict[str, np.ndarray]) -> dict[str, list]:
-        input_docs = _get_documents_from_columnar_format(doc_batch)
-        output_docs = list(filter(f, input_docs))
-
-        return _get_columnar_format_from_documents(output_docs)
-
-    return ray_callable
-
-
-def _get_documents_from_columnar_format(doc_batch: dict[str, np.ndarray]) -> list[Document]:
-    input_docs = []
-    cols = doc_batch.keys()
-    rows = doc_batch.values()
-
-    for row in zip(*rows):
-        document = {}
-        for i, col in enumerate(cols):
-            document[col] = row[i]
-        input_docs.append(Document(document))
-
-    return input_docs
-
-
-def _get_columnar_format_from_documents(doc_batch: list[Document]) -> dict[str, list]:
-    output = defaultdict(list)
-
-    for doc in doc_batch:
-        for key, value in doc.data.items():
-            output[key].append(value)
-
-    return output
-
-
-def generate_map_batch_class(
-    c: Type[Callable[[list[Document]], list[Document]]],
-    f_args: Optional[Iterable[Any]] = None,
-    f_kwargs: Optional[dict[str, Any]] = None,
-    f_constructor_args: Optional[Iterable[Any]] = None,
-    f_constructor_kwargs: Optional[dict[str, Any]] = None,
-) -> Callable[[list[dict[str, Any]]], list[dict[str, Any]]]:
-    if f_constructor_args is None:
-        f_constructor_args = tuple()
-    if f_constructor_kwargs is None:
-        f_constructor_kwargs = {}
-    if f_args is None:
-        f_args = tuple()
-    if f_kwargs is None:
-        f_kwargs = {}
-
-    def ray_init(self):
-        self.base = c(*f_constructor_args, **f_constructor_kwargs)
-
-    def ray_callable(self, doc_batch: dict[str, np.ndarray]) -> dict[str, list]:
-        input_docs = _get_documents_from_columnar_format(doc_batch)
-        output_docs = self.base(input_docs, *f_args, **f_kwargs)
-
-        return _get_columnar_format_from_documents(output_docs)
-
-    new_class = type("CustomRay" + c.__name__, (), {"__init__": ray_init, "__call__": ray_callable})
-    return new_class
-
-
-def generate_map_batch_class_from_callable(
-    f: Callable[[list[Document]], list[Document]],
-) -> Callable[[list[dict[str, Any]]], list[dict[str, Any]]]:
-    def ray_callable(self, doc_batch: dict[str, np.ndarray]) -> dict[str, list]:
-        input_docs = _get_documents_from_columnar_format(doc_batch)
-        output_docs = f(input_docs)
-
-        return _get_columnar_format_from_documents(output_docs)
-
-    new_class = type("CustomRay", (), {"__call__": ray_callable})
-    return new_class
-
-
-def generate_map_class_from_callable(f: Callable[[Document], Document]) -> Callable[[dict[str, Any]], dict[str, Any]]:
-    def ray_callable(self, input_dict: dict[str, Any]) -> dict[str, Any]:
-        document = f(Document(input_dict))
-        return document.data
-
-    new_class = type(f.__name__, (), {"__call__": ray_callable})
-    return new_class
 
 
 class Map(UnaryNode):

--- a/sycamore/transforms/merge_elements.py
+++ b/sycamore/transforms/merge_elements.py
@@ -4,7 +4,7 @@ from ray.data import Dataset, ActorPoolStrategy
 
 from sycamore.data import Document, Element, BoundingBox
 from sycamore.plan_nodes import NonCPUUser, NonGPUUser, Transform, Node
-from sycamore.transforms.map import generate_map_class_from_callable
+from sycamore.utils import generate_map_class_from_callable
 from sycamore.functions.tokenizer import Tokenizer
 
 
@@ -117,11 +117,13 @@ class GreedyTextElementMerger(ElementMerger):
                 max(elt1.bbox.y2, elt2.bbox.y2),
             )
         # Merge properties by taking the union of the keys
+        properties = new_elt.properties
         for k, v in elt1.properties.items():
-            new_elt.properties[k] = v
+            properties[k] = v
         for k, v in elt2.properties.items():
-            if new_elt.properties.get(k) is None:
-                new_elt.properties[k] = v
+            if properties.get(k) is None:
+                properties[k] = v
+        new_elt.properties = properties
 
         return new_elt
 

--- a/sycamore/utils/__init__.py
+++ b/sycamore/utils/__init__.py
@@ -1,0 +1,23 @@
+from sycamore.utils.generate_ray_func import (
+    generate_map_function,
+    generate_map_class,
+    generate_map_class_from_callable,
+    generate_flat_map_function,
+    generate_flat_map_class,
+    generate_map_batch_function,
+    generate_map_batch_filter_function,
+    generate_map_batch_class,
+    generate_map_batch_class_from_callable,
+)
+
+__all__ = [
+    "generate_map_function",
+    "generate_map_class",
+    "generate_map_class_from_callable",
+    "generate_flat_map_function",
+    "generate_flat_map_class",
+    "generate_map_batch_function",
+    "generate_map_batch_filter_function",
+    "generate_map_batch_class",
+    "generate_map_batch_class_from_callable",
+]

--- a/sycamore/utils/generate_ray_func.py
+++ b/sycamore/utils/generate_ray_func.py
@@ -1,0 +1,132 @@
+from typing import Any, Callable, Iterable, Optional, Type
+
+import numpy as np
+
+from sycamore.data import Document
+
+
+def _get_documents_from_columnar_format(doc_batch: dict[str, np.ndarray]) -> list[Document]:
+    return [Document(ser_doc) for ser_doc in doc_batch["doc"]]
+
+
+def _get_columnar_format_from_documents(doc_batch: list[Document]) -> dict[str, list]:
+    return {"doc": [doc.serialize() for doc in doc_batch]}
+
+
+def generate_map_function(f: Callable[[Document], Document]) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    def ray_callable(input_dict: dict[str, Any]) -> dict[str, Any]:
+        document = f(Document.from_row(input_dict))
+        return document.to_row()
+
+    return ray_callable
+
+
+def generate_map_class(c: Type[Callable[[Document], Document]]) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    def ray_init(self):
+        self.base = c()
+
+    def ray_callable(self, input_dict: dict[str, Any]) -> dict[str, Any]:
+        document = self.base(Document.from_row(input_dict))
+        return document.to_row()
+
+    new_class = type("CustomRay" + c.__name__, (), {"__init__": ray_init, "__call__": ray_callable})
+    return new_class
+
+
+def generate_map_class_from_callable(f: Callable[[Document], Document]) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    def ray_callable(self, input_dict: dict[str, Any]) -> dict[str, Any]:
+        document = f(Document.from_row(input_dict))
+        return document.to_row()
+
+    new_class = type(f.__name__, (), {"__call__": ray_callable})
+    return new_class
+
+
+def generate_flat_map_function(
+    f: Callable[[Document], list[Document]]
+) -> Callable[[dict[str, Any]], list[dict[str, Any]]]:
+    def ray_callable(input_dict: dict[str, Any]) -> list[dict[str, Any]]:
+        documents = f(Document.from_row(input_dict))
+        return [{"doc": document.serialize()} for document in documents]
+
+    return ray_callable
+
+
+def generate_flat_map_class(
+    c: Type[Callable[[Document], list[Document]]]
+) -> Callable[[dict[str, Any]], list[dict[str, Any]]]:
+    def ray_init(self):
+        self.base = c()
+
+    def ray_callable(self, input_dict: dict[str, Any]) -> list[dict[str, Any]]:
+        documents = self.base(Document.from_row(input_dict))
+        return [document.to_row() for document in documents]
+
+    new_class = type("CustomRay" + c.__name__, (), {"__init__": ray_init, "__call__": ray_callable})
+    return new_class
+
+
+def generate_map_batch_function(
+    f: Callable[[list[Document]], list[Document]]
+) -> Callable[[dict[str, np.ndarray]], dict[str, list]]:
+    def ray_callable(doc_batch: dict[str, np.ndarray]) -> dict[str, list]:
+        input_docs = _get_documents_from_columnar_format(doc_batch)
+        output_docs = f(input_docs)
+
+        return _get_columnar_format_from_documents(output_docs)
+
+    return ray_callable
+
+
+def generate_map_batch_filter_function(
+    f: Callable[[Document], bool]
+) -> Callable[[dict[str, np.ndarray]], dict[str, list]]:
+    def ray_callable(doc_batch: dict[str, np.ndarray]) -> dict[str, list]:
+        input_docs = _get_documents_from_columnar_format(doc_batch)
+        output_docs = list(filter(f, input_docs))
+
+        return _get_columnar_format_from_documents(output_docs)
+
+    return ray_callable
+
+
+def generate_map_batch_class(
+    c: Type[Callable[[list[Document]], list[Document]]],
+    f_args: Optional[Iterable[Any]] = None,
+    f_kwargs: Optional[dict[str, Any]] = None,
+    f_constructor_args: Optional[Iterable[Any]] = None,
+    f_constructor_kwargs: Optional[dict[str, Any]] = None,
+) -> Callable[[list[dict[str, Any]]], list[dict[str, Any]]]:
+    if f_constructor_args is None:
+        f_constructor_args = tuple()
+    if f_constructor_kwargs is None:
+        f_constructor_kwargs = {}
+    if f_args is None:
+        f_args = tuple()
+    if f_kwargs is None:
+        f_kwargs = {}
+
+    def ray_init(self):
+        self.base = c(*f_constructor_args, **f_constructor_kwargs)
+
+    def ray_callable(self, doc_batch: dict[str, np.ndarray]) -> dict[str, list]:
+        input_docs = _get_documents_from_columnar_format(doc_batch)
+        output_docs = self.base(input_docs, *f_args, **f_kwargs)
+
+        return _get_columnar_format_from_documents(output_docs)
+
+    new_class = type("CustomRay" + c.__name__, (), {"__init__": ray_init, "__call__": ray_callable})
+    return new_class
+
+
+def generate_map_batch_class_from_callable(
+    f: Callable[[list[Document]], list[Document]],
+) -> Callable[[list[dict[str, Any]]], list[dict[str, Any]]]:
+    def ray_callable(self, doc_batch: dict[str, np.ndarray]) -> dict[str, list]:
+        input_docs = _get_documents_from_columnar_format(doc_batch)
+        output_docs = f(input_docs)
+
+        return _get_columnar_format_from_documents(output_docs)
+
+    new_class = type("CustomRay", (), {"__call__": ray_callable})
+    return new_class

--- a/sycamore/writers/file_writer.py
+++ b/sycamore/writers/file_writer.py
@@ -191,7 +191,7 @@ class _WritableFilePerRowDataSource(FileBasedDatasource):
             fs = _unwrap_s3_serialization_workaround(filesystem)
 
             for row in block.iter_rows(public_row_format=True):
-                doc = Document(row)
+                doc = Document.from_row(row)
                 filename = filename_fn(doc)
 
                 write_path = os.path.join(path, filename)

--- a/sycamore/writers/opensearch.py
+++ b/sycamore/writers/opensearch.py
@@ -8,6 +8,8 @@ from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data.block import Block, BlockAccessor
 from ray.data.datasource import WriteResult
 from ray.data._internal.execution.interfaces import TaskContext
+
+from sycamore.data import Document
 from sycamore.plan_nodes import Node, Write
 
 log = logging.getLogger(__name__)
@@ -65,7 +67,7 @@ class OSDataSource(Datasource):
             "doc_id": None,
             "type": None,
             "text_representation": None,
-            "elements": {"array": []},
+            "elements": [],
             "embedding": None,
             "parent_id": None,
             "properties": {},
@@ -78,7 +80,7 @@ class OSDataSource(Datasource):
                 result[k] = v
         return result
 
-    # The type: ignore is required for the ctx paramter, which is not part of the Datasource
+    # The type: ignore is required for the ctx parameter, which is not part of the Datasource
     # API spec, but is passed at runtime by Ray. This can be removed once this commit is
     # included in Ray's release:
     #
@@ -108,7 +110,7 @@ class OSDataSource(Datasource):
 
         def create_actions():
             for i, row in enumerate(block):
-                doc = OSDataSource.extract_os_document(row)
+                doc = OSDataSource.extract_os_document(Document.from_row(row).data)
                 action = {"_index": index_name, "_id": doc["doc_id"], "_source": doc}
                 yield action
 


### PR DESCRIPTION
We serialize document into {"doc": bytes} when it's fed into ray dataset transformations due to ray dataset's rigid requirement for schema compatibiity across rows and batch.

This bring in overhead from perspective of performance, we might consider to merge certain compatible transformations to reduce the number of times of serde, or even get rid of ray dataset.

Fixes #85 Another 'Unable to merge' problem