### PR TITLE
Add random_sample transformation.

### DIFF
--- a/docs/source/APIs/transforms/random_sample.rst
+++ b/docs/source/APIs/transforms/random_sample.rst
@@ -1,0 +1,5 @@
+Random Sample
+==============
+.. autoclass:: sycamore.transforms.random_sample.RandomSample
+   :members:
+   :show-inheritance:

--- a/docs/source/APIs/transforms/transforms.rst
+++ b/docs/source/APIs/transforms/transforms.rst
@@ -18,4 +18,5 @@ Transforms
    map.rst
    merge_elements.rst
    partition.rst
+   random_sample.rst
    summarize.rst

--- a/sycamore/docset.py
+++ b/sycamore/docset.py
@@ -398,6 +398,22 @@ class DocSet:
         )
         return DocSet(self.context, map_batch)
 
+    def random_sample(self, fraction: float, seed: Optional[int] = None) -> "DocSet":
+        """
+        Retain a random sample of documents from this DocSet.
+
+        The number of documents in the output will be approximately `fraction * self.count()`
+
+        Args:
+            fraction: The fraction of documents to retain.
+            seed: Optional seed to use for the RNG.
+
+        """
+        from sycamore.transforms import RandomSample
+
+        sampled = RandomSample(self.plan, fraction=fraction, seed=seed)
+        return DocSet(self.context, sampled)
+
     @property
     def write(self) -> DocSetWriter:
         return DocSetWriter(self.context, self.plan)

--- a/sycamore/tests/unit/transforms/test_random_sample.py
+++ b/sycamore/tests/unit/transforms/test_random_sample.py
@@ -1,0 +1,32 @@
+import math
+
+import pytest
+
+import sycamore
+from sycamore import DocSet
+from sycamore.data import Document
+
+
+class TestRandomSample:
+    @pytest.fixture()
+    def docs(self) -> list[Document]:
+        print("Generating docs")
+        return [
+            Document(text_representation=f"Document {i}", doc_id=i, properties={"document_number": i})
+            for i in range(100)
+        ]
+
+    @pytest.fixture()
+    def docset(self, docs: list[Document]) -> DocSet:
+        context = sycamore.init()
+        return context.read.document(docs)
+
+    def test_empty_sample(self, docset: DocSet):
+        assert docset.random_sample(0).count() == 0
+
+    def test_complete_sample(self, docset: DocSet):
+        assert docset.random_sample(1).count() == 100
+
+    def test_random_sample(self, docset: DocSet):
+        actual = docset.random_sample(0.5).count()
+        math.isclose(actual, 50, rel_tol=2, abs_tol=2)

--- a/sycamore/transforms/__init__.py
+++ b/sycamore/transforms/__init__.py
@@ -8,6 +8,7 @@ from sycamore.transforms.extract_table import TableExtractor
 from sycamore.transforms.spread_properties import SpreadProperties
 from sycamore.transforms.summarize import Summarize
 from sycamore.transforms.merge_elements import Merge
+from sycamore.transforms.random_sample import RandomSample
 
 __all__ = [
     "Explode",
@@ -26,4 +27,5 @@ __all__ = [
     "Summarize",
     "Filter",
     "Merge",
+    "RandomSample",
 ]

--- a/sycamore/transforms/random_sample.py
+++ b/sycamore/transforms/random_sample.py
@@ -1,0 +1,26 @@
+from typing import Optional
+
+from ray.data import Dataset
+
+from sycamore.plan_nodes import Node, Transform
+
+
+class RandomSample(Transform):
+    """
+    Generates a random sample of documents in a collection.
+
+    Args:
+        child: The plan node providing the dataset.
+        fraction: The fraction of documents to retain.
+        seed: The seed to use to initialize the RNG.
+        resource_args: Additional resource-related arguments to pass to the execution env.
+    """
+
+    def __init__(self, child: Node, fraction: float, seed: Optional[int] = None, **resource_args):
+        super().__init__(child, **resource_args)
+        self.fraction = fraction
+        self.seed = seed
+
+    def execute(self) -> Dataset:
+        dataset = self.child().execute()
+        return dataset.random_sample(self.fraction, seed=self.seed)


### PR DESCRIPTION
This utilizes the underlying dataset.random_sample to randomly sample from a DocSet. Useful for tests and experiments.

Still trying to figure out a potential issue with the the documentation generation, but the functionality is working for me. 