### PR TITLE
Fix bug in dockerization from merge

### DIFF
--- a/docker_compose/compose.yaml
+++ b/docker_compose/compose.yaml
@@ -41,7 +41,6 @@ services:
       - crawl_data:/app/.scrapy
     environment:
       - OPENAI_API_KEY
-    shm_size: "4gb"
   sycamore_crawler_http:
     image: arynai/sycamore-crawler-http
     volumes:

--- a/importer/docker-poetry-packages.sh
+++ b/importer/docker-poetry-packages.sh
@@ -30,7 +30,7 @@ mkdir "${POETRY_CACHE_DIR}"
     fi
 )
 find "${POETRY_CACHE_DIR}" >/tmp/poetry.cache.before
-poetry install --only main,docker --no-root -v
+poetry install --only main,sycamore_library,docker --no-root -v
 find "${POETRY_CACHE_DIR}" >/tmp/poetry.cache.after
 
 diff -u /tmp/poetry.cache.before /tmp/poetry.cache.after >/tmp/poetry.cache.diff || true


### PR DESCRIPTION
compose.yaml: remove the shm setting -- testing indicates there's no useful default and it could
  cause problems on small memory machines

docker-poetry-packages.sh: install the sycamore packages since the script limits installation