### PR TITLE
Update README.

### DIFF
--- a/docker_compose/README.md
+++ b/docker_compose/README.md
@@ -5,5 +5,6 @@ Runs the entire sycamore stack + aryn demo UI.
 See compose.yaml for details and extensions, but in short:
 
 1. cd path/to/sycamore/docker_compose
+1. Set OPENAI_API_KEY, e.g. export OPENAI_API_KEY=sk-...
 1. docker compose up
 1. visit http://localhost:3000/


### PR DESCRIPTION
Let's make it clear to set the OpenAI API key before running docker compose.