### PR TITLE
Change simple_ingest and s3_ingest to use GTE-small embedding model.

### DIFF
--- a/examples/s3_ingest.py
+++ b/examples/s3_ingest.py
@@ -41,7 +41,7 @@ ds = (
     .merge(merger=GreedyTextElementMerger(tokenizer=tokenizer, max_tokens=512))
     .extract_entity(entity_extractor=OpenAIEntityExtractor("title", llm=davinci_llm, prompt_template=title_template))
     .explode()
-    .embed(embedder=SentenceTransformerEmbedder(model_name="all-MiniLM-L6-v2", batch_size=100))
+    .embed(embedder=SentenceTransformerEmbedder(model_name="thenlper/gte-small", batch_size=100))
 )
 
 ds.write.opensearch(

--- a/examples/simple_ingest.py
+++ b/examples/simple_ingest.py
@@ -31,7 +31,7 @@ ds = (
     .merge(merger=GreedyTextElementMerger(tokenizer=tokenizer, max_tokens=512))
     .spread_properties(["path", "title"])
     .explode()
-    .embed(embedder=SentenceTransformerEmbedder(model_name="all-MiniLM-L6-v2", batch_size=100))
+    .embed(embedder=SentenceTransformerEmbedder(model_name="thenlper/gte-small", batch_size=100))
 )
 
 # ds.show(limit=1000, truncate_length=500)


### PR DESCRIPTION
The GTE-small embedding model is superior to MiniLM, yielding better relevance in retrieval.