### PR TITLE
Merging/breaking elements based on heuristics including bbox

### DIFF
--- a/examples/s3_ingest.py
+++ b/examples/s3_ingest.py
@@ -8,7 +8,6 @@ sys.path.append("../sycamore")
 import sycamore
 from sycamore.functions.tokenizer import HuggingFaceTokenizer
 from sycamore.llms import OpenAIModels, OpenAI
-from sycamore.reader import DocSetReader
 from sycamore.scans.file_scan import JsonManifestMetadataProvider
 from sycamore.transforms import COALESCE_WHITESPACE
 from sycamore.transforms.merge_elements import MarkedMerger
@@ -43,7 +42,7 @@ ds = (
     .extract_entity(entity_extractor=OpenAIEntityExtractor("title", llm=davinci_llm, prompt_template=title_template))
     .mark_bbox_preset(tokenizer=tokenizer)
     .merge(merger=MarkedMerger())
-    .spread_properties(["title", "path"])
+    .spread_properties(["path", "title"])
     .explode()
     .embed(embedder=SentenceTransformerEmbedder(model_name="thenlper/gte-small", batch_size=100))
 )

--- a/examples/s3_ingest.py
+++ b/examples/s3_ingest.py
@@ -9,7 +9,7 @@ import sycamore
 from sycamore.functions.tokenizer import HuggingFaceTokenizer
 from sycamore.llms import OpenAIModels, OpenAI
 from sycamore.transforms import COALESCE_WHITESPACE
-from sycamore.transforms.merge_elements import GreedyTextElementMerger
+from sycamore.transforms.merge_elements import GreedyTextElementMerger, MarkedMerger
 from sycamore.transforms.partition import UnstructuredPdfPartitioner
 from sycamore.transforms.extract_entity import OpenAIEntityExtractor
 from sycamore.transforms.embed import SentenceTransformerEmbedder
@@ -41,7 +41,8 @@ ds = (
     .partition(partitioner=UnstructuredPdfPartitioner())
     .regex_replace(COALESCE_WHITESPACE)
     .extract_entity(entity_extractor=OpenAIEntityExtractor("title", llm=davinci_llm, prompt_template=title_template))
-    .merge(merger=GreedyTextElementMerger(tokenizer=tokenizer, max_tokens=512))
+    .mark_bbox_preset(tokenizer=tokenizer)
+    .merge(merger=MarkedMerger())
     .spread_properties(["path", "title"])
     .explode()
     .embed(embedder=SentenceTransformerEmbedder(model_name="thenlper/gte-small", batch_size=100))

--- a/examples/simple_ingest.py
+++ b/examples/simple_ingest.py
@@ -37,7 +37,7 @@ ds = (
     .embed(embedder=SentenceTransformerEmbedder(model_name="thenlper/gte-small", batch_size=100))
 )
 
-# ds.show(limit=1000, truncate_length=500)
+ds.show(limit=1000, truncate_length=500)
 ds.write.opensearch(
     os_client_args=osrch_args,
     index_name=index,

--- a/examples/simple_ingest.py
+++ b/examples/simple_ingest.py
@@ -7,7 +7,7 @@ import sycamore
 from sycamore.functions.tokenizer import HuggingFaceTokenizer
 from sycamore.llms import OpenAIModels, OpenAI
 from sycamore.transforms import COALESCE_WHITESPACE
-from sycamore.transforms.merge_elements import GreedyTextElementMerger, MarkedMerger
+from sycamore.transforms.merge_elements import MarkedMerger
 from sycamore.transforms.partition import UnstructuredPdfPartitioner
 from sycamore.transforms.extract_entity import OpenAIEntityExtractor
 from sycamore.transforms.embed import SentenceTransformerEmbedder

--- a/examples/simple_ingest.py
+++ b/examples/simple_ingest.py
@@ -7,6 +7,7 @@ import sycamore
 from sycamore.functions.tokenizer import HuggingFaceTokenizer
 from sycamore.llms import OpenAIModels, OpenAI
 from sycamore.transforms import COALESCE_WHITESPACE
+from sycamore.transforms.bbox_merge import BboxMerger
 from sycamore.transforms.merge_elements import GreedyTextElementMerger
 from sycamore.transforms.partition import UnstructuredPdfPartitioner
 from sycamore.transforms.extract_entity import OpenAIEntityExtractor
@@ -30,7 +31,7 @@ ds = (
     .partition(partitioner=UnstructuredPdfPartitioner())
     .regex_replace(COALESCE_WHITESPACE)
     .extract_entity(entity_extractor=OpenAIEntityExtractor("title", llm=davinci_llm, prompt_template=title_template))
-    .merge(merger=GreedyTextElementMerger(tokenizer=tokenizer, max_tokens=512))
+    .merge(merger=BboxMerger(tokenizer=tokenizer))
     .spread_properties(["path", "title"])
     .explode()
     .embed(embedder=SentenceTransformerEmbedder(model_name="thenlper/gte-small", batch_size=100))

--- a/examples/simple_ingest.py
+++ b/examples/simple_ingest.py
@@ -7,8 +7,7 @@ import sycamore
 from sycamore.functions.tokenizer import HuggingFaceTokenizer
 from sycamore.llms import OpenAIModels, OpenAI
 from sycamore.transforms import COALESCE_WHITESPACE
-from sycamore.transforms.bbox_merge import BboxMerger
-from sycamore.transforms.merge_elements import GreedyTextElementMerger
+from sycamore.transforms.merge_elements import GreedyTextElementMerger, MarkedMerger
 from sycamore.transforms.partition import UnstructuredPdfPartitioner
 from sycamore.transforms.extract_entity import OpenAIEntityExtractor
 from sycamore.transforms.embed import SentenceTransformerEmbedder
@@ -31,7 +30,8 @@ ds = (
     .partition(partitioner=UnstructuredPdfPartitioner())
     .regex_replace(COALESCE_WHITESPACE)
     .extract_entity(entity_extractor=OpenAIEntityExtractor("title", llm=davinci_llm, prompt_template=title_template))
-    .merge(merger=BboxMerger(tokenizer=tokenizer))
+    .mark_bbox_preset(tokenizer=tokenizer)
+    .merge(merger=MarkedMerger())
     .spread_properties(["path", "title"])
     .explode()
     .embed(embedder=SentenceTransformerEmbedder(model_name="thenlper/gte-small", batch_size=100))

--- a/examples/simple_ingest.py
+++ b/examples/simple_ingest.py
@@ -37,7 +37,7 @@ ds = (
     .embed(embedder=SentenceTransformerEmbedder(model_name="thenlper/gte-small", batch_size=100))
 )
 
-ds.show(limit=1000, truncate_length=500)
+# ds.show(limit=1000, truncate_length=500)
 ds.write.opensearch(
     os_client_args=osrch_args,
     index_name=index,

--- a/sycamore/docset.py
+++ b/sycamore/docset.py
@@ -308,64 +308,6 @@ class DocSet:
         summaries = Summarize(self.plan, summarizer=summarizer, **kwargs)
         return DocSet(self.context, summaries)
 
-    def sort_top_to_bottom(self, **kwargs) -> "DocSet":
-        """
-        Uses page_number and bbox to reorder elements top to bottom.
-        """
-        from sycamore.transforms import SortByPageBbox
-
-        plan = SortByPageBbox(self.plan, **kwargs)
-        return DocSet(self.context, plan)
-
-    def mark_drop_tiny(self, minimum: int = 2, **kwargs) -> "DocSet":
-        """
-        Marks for removal elements with text_representation shorter than
-        a specified minimum length.
-        """
-        from sycamore.transforms import MarkDropTiny
-
-        plan = MarkDropTiny(self.plan, minimum, **kwargs)
-        return DocSet(self.context, plan)
-
-    def mark_drop_header_footer(self, top: float = 0.05, bottom: float | None = None, **kwargs) -> "DocSet":
-        """
-        Marks for removal elements very close to the top or bottom of pages.
-        Requires bbox.
-        """
-        from sycamore.transforms import MarkDropHeaderFooter
-
-        plan = MarkDropHeaderFooter(self.plan, top, bottom, **kwargs)
-        return DocSet(self.context, plan)
-
-    def mark_break_page(self, **kwargs) -> "DocSet":
-        """
-        Marks element breaks before start of each new page.
-        """
-        from sycamore.transforms import MarkBreakPage
-
-        plan = MarkBreakPage(self.plan, **kwargs)
-        return DocSet(self.context, plan)
-
-    def mark_break_column(self, **kwargs) -> "DocSet":
-        """
-        Marks element breaks at transitions from columnar to full-width
-        layout.  Requires bbox.
-        """
-        from sycamore.transforms import MarkBreakByColumn
-
-        plan = MarkBreakByColumn(self.plan, **kwargs)
-        return DocSet(self.context, plan)
-
-    def mark_break_tokens(self, tokenizer: Tokenizer, limit: int = 512, **kwargs) -> "DocSet":
-        """
-        Marks element breaks in order to keep each element from exceeding
-        the token limit specified.
-        """
-        from sycamore.transforms import MarkBreakByTokens
-
-        plan = MarkBreakByTokens(self.plan, tokenizer, limit, **kwargs)
-        return DocSet(self.context, plan)
-
     def mark_bbox_preset(self, tokenizer: Tokenizer, **kwargs) -> "DocSet":
         """
         Convenience composition of:
@@ -385,13 +327,14 @@ class DocSet:
             MarkBreakByColumn,
             MarkBreakByTokens,
         )
-        plan = SortByPageBbox(self.plan, **kwargs)
-        plan = MarkDropTiny(plan, 2, **kwargs)
-        plan = MarkDropHeaderFooter(plan, 0.05, 0.05, **kwargs)
-        plan = MarkBreakPage(plan, **kwargs)
-        plan = MarkBreakByColumn(plan, **kwargs)
-        plan = MarkBreakByTokens(plan, tokenizer, 512, **kwargs)
-        return DocSet(self.context, plan)
+
+        plan0 = SortByPageBbox(self.plan, **kwargs)
+        plan1 = MarkDropTiny(plan0, 2, **kwargs)
+        plan2 = MarkDropHeaderFooter(plan1, 0.05, 0.05, **kwargs)
+        plan3 = MarkBreakPage(plan2, **kwargs)
+        plan4 = MarkBreakByColumn(plan3, **kwargs)
+        plan5 = MarkBreakByTokens(plan4, tokenizer, 512, **kwargs)
+        return DocSet(self.context, plan5)
 
     def merge(self, merger: ElementMerger, **kwargs) -> "DocSet":
         """

--- a/sycamore/docset.py
+++ b/sycamore/docset.py
@@ -327,7 +327,7 @@ class DocSet:
         plan = MarkDropTiny(self.plan, minimum, **kwargs)
         return DocSet(self.context, plan)
 
-    def mark_drop_header_footer(self, top: float = 0.05, bottom: float = None, **kwargs) -> "DocSet":
+    def mark_drop_header_footer(self, top: float = 0.05, bottom: float | None = None, **kwargs) -> "DocSet":
         """
         Marks for removal elements very close to the top or bottom of pages.
         Requires bbox.
@@ -369,22 +369,29 @@ class DocSet:
     def mark_bbox_preset(self, tokenizer: Tokenizer, **kwargs) -> "DocSet":
         """
         Convenience composition of:
-          sort_top_to_bottom()
-          mark_drop_tiny(2)
-          mark_drop_header_footer(0.05)
-          mark_break_page()
-          mark_break_column()
-          mark_break_tokens(tokenizer, 512)
+            SortByPageBbox
+            MarkDropTiny minimum=2
+            MarkDropHeaderFooter top=0.05 bottom=0.05
+            MarkBreakPage
+            MarkBreakByColumn
+            MarkBreakByTokens limit=512
         Meant to work in concert with MarkedMerger.
         """
-        return (
-            self.sort_top_to_bottom(**kwargs)
-            .mark_drop_tiny(2, **kwargs)
-            .mark_drop_header_footer(0.05, 0.05, **kwargs)
-            .mark_break_page(**kwargs)
-            .mark_break_column(**kwargs)
-            .mark_break_tokens(tokenizer, 512, **kwargs)
+        from sycamore.transforms import (
+            SortByPageBbox,
+            MarkDropTiny,
+            MarkDropHeaderFooter,
+            MarkBreakPage,
+            MarkBreakByColumn,
+            MarkBreakByTokens,
         )
+        plan = SortByPageBbox(self.plan, **kwargs)
+        plan = MarkDropTiny(plan, 2, **kwargs)
+        plan = MarkDropHeaderFooter(plan, 0.05, 0.05, **kwargs)
+        plan = MarkBreakPage(plan, **kwargs)
+        plan = MarkBreakByColumn(plan, **kwargs)
+        plan = MarkBreakByTokens(plan, tokenizer, 512, **kwargs)
+        return DocSet(self.context, plan)
 
     def merge(self, merger: ElementMerger, **kwargs) -> "DocSet":
         """

--- a/sycamore/tests/unit/transforms/test_bbox_merge.py
+++ b/sycamore/tests/unit/transforms/test_bbox_merge.py
@@ -1,0 +1,87 @@
+import ray.data
+
+from sycamore.data import Document
+from sycamore.transforms.bbox_merge import BboxMerger
+from sycamore.transforms.merge_elements import Merge
+from sycamore.functions.tokenizer import HuggingFaceTokenizer
+from sycamore.plan_nodes import Node
+
+
+def spew(n: int, pfx: str = "") -> str:
+    words = ("lorem", "ipsum", "dolor", "sit")
+    rv = pfx
+    for i in range(n):
+        if rv:
+            rv += " "
+        rv += words[i % len(words)]
+    return rv
+
+
+def mkText(text: str, page: int, left: float, top: float, right: float, bot: float) -> dict:
+    return {
+        "type": "UncategorizedText",
+        "text_representation": text,
+        "properties": {"page_number": page, "title": "foo title"},
+        "bbox": [left, top, right, bot],
+    }
+
+
+class FakeNode(Node):
+    def __init__(self, doc: dict):
+        self.doc = doc
+
+    def execute(self) -> ray.data.Dataset:
+        return ray.data.from_items([self.doc])
+
+
+class TestBboxMerge:
+    doc = Document(
+        {
+            "doc_id": "doc_id",
+            "type": "pdf",
+            "text_representation": "foobar",
+            "binary_representation": None,
+            "parent_id": None,
+            "properties": {"path": "/docs/foo.txt", "title": "bar"},
+            "elements": [
+                mkText("previous page", 1, 0.1, 0.8, 0.3, 0.9),
+                mkText("top of page", 2, 0.1, 0.1, 0.3, 0.15),
+                mkText(spew(20, "column begin"), 2, 0.1, 0.2, 0.4, 0.25),
+                mkText(spew(20), 2, 0.6, 0.2, 0.9, 0.25),
+                mkText(spew(20), 2, 0.1, 0.3, 0.4, 0.35),
+                mkText(spew(20), 2, 0.6, 0.3, 0.9, 0.35),
+                mkText(spew(20, "column end"), 2, 0.1, 0.4, 0.4, 0.45),
+                mkText(spew(100, "wide text"), 2, 0.1, 0.5, 0.9, 0.55),
+                mkText("0", 2, 0.5, 0.5, 0.55, 0.55),
+                mkText(spew(600), 2, 0.1, 0.6, 0.9, 0.7),
+                mkText("footer", 2, 0.4, 0.96, 0.6, 0.99),
+                mkText("next page", 3, 0.1, 0.1, 0.3, 0.15),
+            ],
+        }
+    )
+    tokenizer = HuggingFaceTokenizer("sentence-transformers/all-MiniLM-L6-v2")
+
+    def testMergeElements(self):
+        merger = BboxMerger(self.tokenizer, 512)
+        mdoc = merger.merge_elements(self.doc)
+        merged = mdoc.elements
+        assert len(merged) == 5
+
+        assert merged[0].text_representation.startswith("previous page")
+        assert merged[1].text_representation.startswith("top of page")
+        assert merged[2].text_representation.startswith("wide text")
+        assert merged[4].text_representation.startswith("next page")
+
+        for elem in merged:
+            assert "0" not in elem.text_representation
+            assert "footer" not in elem.text_representation
+
+    def testViaExecute(self, mocker):
+        node = mocker.Mock(spec=Node)
+        input = ray.data.from_items([{"doc": self.doc.serialize()}])
+        execMock = mocker.patch.object(node, "execute")
+        execMock.return_value = input
+        merger = BboxMerger(self.tokenizer, 512)
+        merge = Merge(node, merger)
+        output = merge.execute()
+        output.show()

--- a/sycamore/transforms/__init__.py
+++ b/sycamore/transforms/__init__.py
@@ -8,6 +8,16 @@ from sycamore.transforms.extract_table import TableExtractor
 from sycamore.transforms.regex_replace import COALESCE_WHITESPACE, RegexReplace
 from sycamore.transforms.spread_properties import SpreadProperties
 from sycamore.transforms.summarize import Summarize
+from sycamore.transforms.bbox_merge import (
+    SortByPageBbox,
+    MarkDropHeaderFooter,
+    MarkBreakByColumn,
+)
+from sycamore.transforms.mark_misc import (
+    MarkDropTiny,
+    MarkBreakPage,
+    MarkBreakByTokens,
+)
 from sycamore.transforms.merge_elements import Merge
 from sycamore.transforms.random_sample import RandomSample
 
@@ -28,6 +38,12 @@ __all__ = [
     "SpreadProperties",
     "RegexReplace",
     "Summarize",
+    "SortByPageBbox",
+    "MarkBreakByColumn",
+    "MarkBreakPage",
+    "MarkBreakByTokens",
+    "MarkDropTiny",
+    "MarkDropHeaderFooter",
     "Filter",
     "Merge",
     "RandomSample",

--- a/sycamore/transforms/bbox_merge.py
+++ b/sycamore/transforms/bbox_merge.py
@@ -1,0 +1,265 @@
+from typing import Any, Dict
+from sycamore.data import Document, Element
+from sycamore.functions.tokenizer import Tokenizer
+from sycamore.transforms.merge_elements import ElementMerger
+
+# TODO:
+# - overlap?
+# - 3 columns, N columns
+
+
+def validBbox(bbox):
+    for idx in range(4):
+        val = bbox[idx]
+        if (val < 0.0) or (val > 1.0):
+            return False
+    return True
+
+
+def getBboxTop(elem: Element):
+    return elem.data["bbox"][1]
+
+
+def getBboxLeft(elem: Element):
+    return elem.data["bbox"][0]
+
+
+def getBboxLeftTop(elem: Element):
+    bb = elem.data["bbox"]
+    return (bb[0], bb[1])
+
+
+def getPageTopLeft(elem: Element):
+    bb = elem.data["bbox"]
+    return (elem.properties["page_number"], bb[1], bb[0])
+
+
+def getRow(elem: Element, elements: list[Element]) -> list[Element]:
+    page = elem.properties["page_number"]
+    bbox = elem.data["bbox"]
+    left = bbox[0]
+    top = bbox[1]
+    right = bbox[2]
+    bottom = bbox[3]
+
+    # !!! assuming elements are sorted by y-values
+    n = len(elements)
+    beg = 0
+    end = n
+    idx = 0
+    while beg < end:
+        mid = beg + ((end - beg) // 2)
+        melem = elements[mid]
+        mpage = melem.properties["page_number"]
+        if mpage < page:
+            beg = mid + 1
+            idx = mid
+        elif mpage > page:
+            end = mid
+        else:
+            mbb = melem.data["bbox"]
+            mtop = mbb[1]
+            if mtop < top:
+                beg = mid + 1
+                idx = mid
+            elif mtop > top:
+                end = mid
+            else:
+                break
+
+    rv = [elem]
+    for idx in range(idx, n):
+        ee = elements[idx]
+        bb = ee.data["bbox"]
+        if bb[1] > bottom:
+            break
+        if bb[3] < top:
+            continue
+        if (bb[0] > right) or (bb[2] < left):
+            rv.append(ee)
+
+    rv.sort(key=getBboxLeftTop)
+    return rv
+
+
+def partOfTwoCol(elem: Element, xmin, xmax) -> bool:
+    cc = elem.data.get("_colCnt")
+    if (cc is None) or (cc != 2):
+        return False
+    bb = elem.data.get("bbox")
+    if bb is None:
+        return False
+    left = bb[0]
+    width = bb[2] - left
+    pageWidth = xmax - xmin
+    halfWidth = pageWidth / 2
+    if width > halfWidth:
+        return False
+    frac = (left - xmin) / pageWidth
+    return (frac <= 0.1) or ((frac >= 0.45) and (frac <= 0.6))
+
+
+class BboxMerger(ElementMerger):
+    def __init__(self, tokenizer: Tokenizer, maxToks: int = 512):
+        self.tokenizer = tokenizer
+        self.maxToks = maxToks
+
+    def should_merge(self, element1: Element, element2: Element) -> bool:
+        return False
+
+    def merge(self, element1: Element, element2: Element) -> Element:
+        return element1
+
+    def preprocess_element(self, elem: Element) -> Element:
+        if elem.text_representation:
+            n = len(self.tokenizer.tokenize(elem.text_representation))
+        else:
+            n = 0
+        elem.data["_tokCnt"] = n
+        return elem
+
+    def postprocess_element(self, elem: Element) -> Element:
+        del elem.data["token_count"]
+        return elem
+
+    def merge_elements(self, document: Document) -> Document:
+        if len(document.elements) < 2:
+            return document
+        elements = document.elements
+
+        # FIXME: make separate transforms to mark/remove these
+        for elem in elements:
+            tr = elem.text_representation or ""
+            if len(tr) <= 1:  # specks of lint
+                elem.data["_drop"] = True
+        for elem in elements:
+            bbox = elem.data["bbox"]  # must be defined for this merger
+            if (bbox[1] > 0.95) or (bbox[3] < 0.05):  # headers and footers
+                elem.data["_drop"] = True
+
+        for elem in elements:
+            self.preprocess_element(elem)
+
+        # measure width in-use
+        xmin = 1.0  # FIXME are these global?
+        xmax = 0.0
+        for elem in elements:
+            bbox = elem.data["bbox"]  # make sure it's defined
+            if validBbox(bbox):  # avoid bug
+                xmin = min(xmin, bbox[0])
+                xmax = max(xmax, bbox[2])
+        fullWidth = (xmax - xmin) * 0.8  # fudge
+
+        # sort entire document top-to-bottom
+        elements.sort(key=getPageTopLeft)
+
+        # mark break at page breaks
+        lastPage = elements[0].properties["page_number"]
+        for elem in elements:
+            page = elem.properties["page_number"]
+            if page != lastPage:
+                elem.data["_break"] = True
+                lastPage = page
+
+        # tag elements by column
+        for elem in elements:
+            if elem.data.get("_colIdx") is None:
+                row = getRow(elem, elements)
+                if len(row) == 1:
+                    bbox = elem.data["bbox"]
+                    width = bbox[2] - bbox[0]
+                    if width > fullWidth:
+                        cnt = 0  # signal full-width
+                    else:
+                        cnt = 1
+                    elem.data["_colIdx"] = 0
+                    elem.data["_colCnt"] = cnt
+                else:
+                    idx = -1
+                    last = 0.0
+                    for ee in row:
+                        bbox = ee.data["bbox"]
+                        if bbox[0] >= last:  # may be stacked vertically
+                            idx += 1
+                        last = bbox[2]
+                        if ee.data.get("_colIdx") is None:
+                            ee.data["_colIdx"] = idx
+                    for ee in row:
+                        if ee.data.get("_colCnt") is None:
+                            ee.data["_colCnt"] = idx + 1
+
+        # re-sort ranges of two-column text
+        last = 0
+        ranges = []
+        for idx, elem in enumerate(elements):
+            if not partOfTwoCol(elem, xmin, xmax):
+                if (idx - last) > 4:
+                    ranges.append((last + 1, idx))
+                last = idx
+        for xx, yy in ranges:
+            elements[xx:yy] = sorted(elements[xx:yy], key=getBboxLeftTop)
+
+        # mark breaks due to column transitions
+        lastCols = 0
+        for elem in elements:
+            ecols = elem.data["_colCnt"]
+            if ecols != lastCols:
+                if ecols == 0:
+                    elem.data["_break"] = True
+                lastCols = ecols
+
+        # mark breaks to keep within token limit
+        # FIXME: do this in a balanced way
+        toks = 0
+        for elem in elements:
+            etoks = elem.data["_tokCnt"]
+            if elem.data.get("_break") or ((toks + etoks) > self.maxToks):
+                elem.data["_break"] = True
+                toks = 0
+            toks += etoks
+
+        # merge elements, honoring marked breaks and drops
+        merged = []
+        bin = b""
+        text = ""
+        props: Dict[str, Any] = {}
+        bbox = None
+
+        for elem in elements:
+            if elem.data.get("_drop"):
+                continue
+            if elem.data.get("_break"):
+                ee = Element()
+                ee.binary_representation = bin
+                ee.text_representation = text
+                ee.properties = props
+                ee.data["bbox"] = bbox
+                merged.append(ee)
+                bin = b""
+                text = ""
+                props = {}
+                bbox = None
+            if elem.binary_representation:
+                bin += elem.binary_representation + b"\n"
+            if elem.text_representation:
+                text += elem.text_representation + "\n"
+            for k, v in elem.properties.items():
+                if k not in props:  # FIXME: order may matter here
+                    props[k] = v
+            ebb = elem.data.get("bbox")
+            if ebb is not None:
+                if bbox is None:
+                    bbox = ebb
+                else:
+                    bbox = (min(bbox[0], ebb[0]), min(bbox[1], ebb[1]), max(bbox[2], ebb[2]), max(bbox[3], ebb[3]))
+
+        if text:
+            ee = Element()
+            ee.binary_representation = bin
+            ee.text_representation = text
+            ee.properties = props
+            ee.data["bbox"] = bbox
+            merged.append(ee)
+
+        document.elements = merged
+        return document

--- a/sycamore/transforms/bbox_merge.py
+++ b/sycamore/transforms/bbox_merge.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from ray.data import Dataset
 
 from sycamore.data import Document, Element
@@ -152,7 +154,7 @@ class MarkDropHeaderFooter(SingleThreadUser, NonGPUUser, Transform):
             dataset = marker.execute()
     """
 
-    def __init__(self, child: Node, top: float = 0.05, bottom: float | None = None, **resource_args):
+    def __init__(self, child: Node, top: float = 0.05, bottom: Optional[float] = None, **resource_args):
         super().__init__(child, **resource_args)
         if bottom is None:
             bottom = top

--- a/sycamore/transforms/bbox_merge.py
+++ b/sycamore/transforms/bbox_merge.py
@@ -1,11 +1,8 @@
-from typing import Any, Dict
-from sycamore.data import Document, Element
-from sycamore.functions.tokenizer import Tokenizer
-from sycamore.transforms.merge_elements import ElementMerger
+from ray.data import Dataset
 
-# TODO:
-# - overlap?
-# - 3 columns, N columns
+from sycamore.data import Document, Element
+from sycamore.plan_nodes import Node, Transform, SingleThreadUser, NonGPUUser
+from sycamore.transforms.map import generate_map_function
 
 
 def validBbox(bbox):
@@ -16,31 +13,33 @@ def validBbox(bbox):
     return True
 
 
-def getBboxTop(elem: Element):
-    return elem.data["bbox"][1]
-
-
-def getBboxLeft(elem: Element):
-    return elem.data["bbox"][0]
-
-
 def getBboxLeftTop(elem: Element):
-    bb = elem.data["bbox"]
-    return (bb[0], bb[1])
+    bbox = elem.data.get("bbox")
+    if bbox is None:
+        return (0.0, 0.0)
+    else:
+        return (bbox[0], bbox[1])
 
 
 def getPageTopLeft(elem: Element):
-    bb = elem.data["bbox"]
-    return (elem.properties["page_number"], bb[1], bb[0])
+    bbox = elem.data.get("bbox")
+    if bbox is None:
+        return (elem.properties["page_number"], 0.0, 0.0)
+    else:
+        return (elem.properties["page_number"], bbox[1], bbox[0])
 
 
 def getRow(elem: Element, elements: list[Element]) -> list[Element]:
-    page = elem.properties["page_number"]
-    bbox = elem.data["bbox"]
+    rv = [elem]
+
+    bbox = elem.data.get("bbox")
+    if bbox is None:
+        return rv
     left = bbox[0]
     top = bbox[1]
     right = bbox[2]
     bottom = bbox[3]
+    page = elem.properties["page_number"]
 
     # !!! assuming elements are sorted by y-values
     n = len(elements)
@@ -67,7 +66,6 @@ def getRow(elem: Element, elements: list[Element]) -> list[Element]:
             else:
                 break
 
-    rv = [elem]
     for idx in range(idx, n):
         ee = elements[idx]
         bb = ee.data["bbox"]
@@ -99,167 +97,184 @@ def partOfTwoCol(elem: Element, xmin, xmax) -> bool:
     return (frac <= 0.1) or ((frac >= 0.45) and (frac <= 0.6))
 
 
-class BboxMerger(ElementMerger):
-    def __init__(self, tokenizer: Tokenizer, maxToks: int = 512):
-        self.tokenizer = tokenizer
-        self.maxToks = maxToks
+###############################################################################
 
-    def should_merge(self, element1: Element, element2: Element) -> bool:
-        return False
 
-    def merge(self, element1: Element, element2: Element) -> Element:
-        return element1
+class SortByPageBbox(SingleThreadUser, NonGPUUser, Transform):
+    """
+    SortByPageBbox is a transform to add reorder the Elements
+    in 'natural order', top to bottom using page_number and bbox.
 
-    def preprocess_element(self, elem: Element) -> Element:
-        if elem.text_representation:
-            n = len(self.tokenizer.tokenize(elem.text_representation))
-        else:
-            n = 0
-        elem.data["_tokCnt"] = n
-        return elem
+    Args:
+        child: The source Node or component that provides the Elements
 
-    def postprocess_element(self, elem: Element) -> Element:
-        del elem.data["token_count"]
-        return elem
+    Example:
+        .. code-block:: python
+            source_node = ...
+            sorter = SortByPageBbox(child=source_node)
+            dataset = sorter.execute()
+    """
 
-    def merge_elements(self, document: Document) -> Document:
-        if len(document.elements) < 2:
-            return document
-        elements = document.elements
+    def __init__(self, child: Node, **resource_args):
+        super().__init__(child, **resource_args)
 
-        # FIXME: make separate transforms to mark/remove these
-        for elem in elements:
-            tr = elem.text_representation or ""
-            if len(tr) <= 1:  # specks of lint
-                elem.data["_drop"] = True
-        for elem in elements:
-            bbox = elem.data["bbox"]  # must be defined for this merger
-            if (bbox[1] > 0.95) or (bbox[3] < 0.05):  # headers and footers
-                elem.data["_drop"] = True
+    class Callable:
+        def run(self, parent: Document) -> Document:
+            elementsCopy = parent.elements
+            elementsCopy.sort(key=getPageTopLeft)
+            parent.elements = elementsCopy
+            return parent
 
-        for elem in elements:
-            self.preprocess_element(elem)
+    def execute(self) -> Dataset:
+        dataset = self.child().execute()
+        sorter = SortByPageBbox.Callable()
+        return dataset.map(generate_map_function(sorter.run))
 
-        # measure width in-use
-        xmin = 1.0  # FIXME are these global?
-        xmax = 0.0
-        for elem in elements:
-            bbox = elem.data["bbox"]  # make sure it's defined
-            if validBbox(bbox):  # avoid bug
-                xmin = min(xmin, bbox[0])
-                xmax = max(xmax, bbox[2])
-        fullWidth = (xmax - xmin) * 0.8  # fudge
 
-        # sort entire document top-to-bottom
-        elements.sort(key=getPageTopLeft)
+###############################################################################
 
-        # mark break at page breaks
-        lastPage = elements[0].properties["page_number"]
-        for elem in elements:
-            page = elem.properties["page_number"]
-            if page != lastPage:
-                elem.data["_break"] = True
-                lastPage = page
 
-        # tag elements by column
-        for elem in elements:
-            if elem.data.get("_colIdx") is None:
-                row = getRow(elem, elements)
-                if len(row) == 1:
-                    bbox = elem.data["bbox"]
-                    width = bbox[2] - bbox[0]
-                    if width > fullWidth:
-                        cnt = 0  # signal full-width
+class MarkDropHeaderFooter(SingleThreadUser, NonGPUUser, Transform):
+    """
+    MarkDropHeaderFooter is a transform to add the '_drop' data attribute to
+    each Element at the top or bottom X fraction of the page.  Requires
+    the 'bbox' attribute.
+
+    Args:
+        child: The source Node or component that provides the Elements
+        top: The fraction of the page to exclude from the top (def 0.05)
+        bottom: The fraction of the page to exclude from the bottom (0.05)
+
+    Example:
+        .. code-block:: python
+            source_node = ...
+            marker = MarkDropHeaderFooter(child=source_node, top=0.05)
+            dataset = marker.execute()
+    """
+
+    def __init__(self, child: Node, top: float = 0.05, bottom: float = None, **resource_args):
+        super().__init__(child, **resource_args)
+        if bottom is None:
+            bottom = top
+        self.top = top
+        self.bottom = bottom
+
+    class Callable:
+        def __init__(self, top: float, bottom: float):
+            self.top = top
+            self.bottom = bottom
+
+        def run(self, parent: Document) -> Document:
+            lo = self.top
+            hi = 1.0 - self.bottom
+            elements = parent.elements  # makes a copy
+            for elem in elements:
+                bbox = elem.data.get("bbox")
+                if (bbox is not None) and ((bbox[1] > hi) or (bbox[3] < lo)):
+                    elem.data["_drop"] = True  # mark for removal
+            parent.elements = elements  # copy back
+            return parent
+
+    def execute(self) -> Dataset:
+        dataset = self.child().execute()
+        marker = MarkDropHeaderFooter.Callable(self.top, self.bottom)
+        return dataset.map(generate_map_function(marker.run))
+
+
+###############################################################################
+
+
+class MarkBreakByColumn(SingleThreadUser, NonGPUUser, Transform):
+    """
+    MarkBreakByColumn is a transform that marks '_break' where
+    two-column layout changes to full-width layout.  Ranges of two-
+    column Elements are also re-sorted left to right.  Elements must
+    already be sorted top-to-bottom.
+
+    Args:
+        child: The source Node or component that provides the Elements
+
+    Example:
+        .. code-block:: python
+            source_node = ...
+            marker = MarkBreakByColumn(child=source_node)
+            dataset = marker.execute()
+    """
+
+    def __init__(self, child: Node, **resource_args):
+        super().__init__(child, **resource_args)
+
+    class Callable:
+        def run(self, parent: Document) -> Document:
+            elements = parent.elements  # makes a copy
+
+            # measure width in-use
+            xmin = 1.0  # FIXME are these global?
+            xmax = 0.0
+            for elem in elements:
+                bbox = elem.data.get("bbox")
+                if (bbox is not None) and validBbox(bbox):
+                    xmin = min(xmin, bbox[0])
+                    xmax = max(xmax, bbox[2])
+            if xmin < xmax:
+                fullWidth = (xmax - xmin) * 0.8  # fudge
+            else:
+                fullWidth = 0.8
+
+            # tag elements by column
+            for elem in elements:
+                if elem.data.get("_colIdx") is None:
+                    row = getRow(elem, elements)
+                    if len(row) == 1:
+                        bbox = elem.data.get("bbox")
+                        if bbox is None:
+                            width = 0.0
+                        else:
+                            width = bbox[2] - bbox[0]
+                        if width > fullWidth:
+                            cnt = 0  # signal full-width
+                        else:
+                            cnt = 1
+                        elem.data["_colIdx"] = 0
+                        elem.data["_colCnt"] = cnt
                     else:
-                        cnt = 1
-                    elem.data["_colIdx"] = 0
-                    elem.data["_colCnt"] = cnt
-                else:
-                    idx = -1
-                    last = 0.0
-                    for ee in row:
-                        bbox = ee.data["bbox"]
-                        if bbox[0] >= last:  # may be stacked vertically
-                            idx += 1
-                        last = bbox[2]
-                        if ee.data.get("_colIdx") is None:
-                            ee.data["_colIdx"] = idx
-                    for ee in row:
-                        if ee.data.get("_colCnt") is None:
-                            ee.data["_colCnt"] = idx + 1
+                        idx = -1
+                        last = 0.0
+                        for ee in row:
+                            bbox = ee.data["bbox"]
+                            if bbox[0] >= last:  # may be stacked vertically
+                                idx += 1
+                            last = bbox[2]
+                            if ee.data.get("_colIdx") is None:
+                                ee.data["_colIdx"] = idx
+                        for ee in row:
+                            if ee.data.get("_colCnt") is None:
+                                ee.data["_colCnt"] = idx + 1
 
-        # re-sort ranges of two-column text
-        last = 0
-        ranges = []
-        for idx, elem in enumerate(elements):
-            if not partOfTwoCol(elem, xmin, xmax):
-                if (idx - last) > 4:
-                    ranges.append((last + 1, idx))
-                last = idx
-        for xx, yy in ranges:
-            elements[xx:yy] = sorted(elements[xx:yy], key=getBboxLeftTop)
+            # re-sort ranges of two-column text
+            last = 0
+            ranges = []
+            for idx, elem in enumerate(elements):
+                if not partOfTwoCol(elem, xmin, xmax):
+                    if (idx - last) > 4:
+                        ranges.append((last + 1, idx))
+                    last = idx
+            for xx, yy in ranges:
+                elements[xx:yy] = sorted(elements[xx:yy], key=getBboxLeftTop)
 
-        # mark breaks due to column transitions
-        lastCols = 0
-        for elem in elements:
-            ecols = elem.data["_colCnt"]
-            if ecols != lastCols:
-                if ecols == 0:
-                    elem.data["_break"] = True
-                lastCols = ecols
+            # mark breaks due to column transitions
+            lastCols = 0
+            for elem in elements:
+                ecols = elem.data["_colCnt"]
+                if ecols != lastCols:
+                    if ecols == 0:
+                        elem.data["_break"] = True
+                    lastCols = ecols
 
-        # mark breaks to keep within token limit
-        # FIXME: do this in a balanced way
-        toks = 0
-        for elem in elements:
-            etoks = elem.data["_tokCnt"]
-            if elem.data.get("_break") or ((toks + etoks) > self.maxToks):
-                elem.data["_break"] = True
-                toks = 0
-            toks += etoks
+            parent.elements = elements  # must copy back in
+            return parent
 
-        # merge elements, honoring marked breaks and drops
-        merged = []
-        bin = b""
-        text = ""
-        props: Dict[str, Any] = {}
-        bbox = None
-
-        for elem in elements:
-            if elem.data.get("_drop"):
-                continue
-            if elem.data.get("_break"):
-                ee = Element()
-                ee.binary_representation = bin
-                ee.text_representation = text
-                ee.properties = props
-                ee.data["bbox"] = bbox
-                merged.append(ee)
-                bin = b""
-                text = ""
-                props = {}
-                bbox = None
-            if elem.binary_representation:
-                bin += elem.binary_representation + b"\n"
-            if elem.text_representation:
-                text += elem.text_representation + "\n"
-            for k, v in elem.properties.items():
-                if k not in props:  # FIXME: order may matter here
-                    props[k] = v
-            ebb = elem.data.get("bbox")
-            if ebb is not None:
-                if bbox is None:
-                    bbox = ebb
-                else:
-                    bbox = (min(bbox[0], ebb[0]), min(bbox[1], ebb[1]), max(bbox[2], ebb[2]), max(bbox[3], ebb[3]))
-
-        if text:
-            ee = Element()
-            ee.binary_representation = bin
-            ee.text_representation = text
-            ee.properties = props
-            ee.data["bbox"] = bbox
-            merged.append(ee)
-
-        document.elements = merged
-        return document
+    def execute(self) -> Dataset:
+        dataset = self.child().execute()
+        xform = MarkBreakByColumn.Callable()
+        return dataset.map(generate_map_function(xform.run))

--- a/sycamore/transforms/bbox_merge.py
+++ b/sycamore/transforms/bbox_merge.py
@@ -152,7 +152,7 @@ class MarkDropHeaderFooter(SingleThreadUser, NonGPUUser, Transform):
             dataset = marker.execute()
     """
 
-    def __init__(self, child: Node, top: float = 0.05, bottom: float = None, **resource_args):
+    def __init__(self, child: Node, top: float = 0.05, bottom: float | None = None, **resource_args):
         super().__init__(child, **resource_args)
         if bottom is None:
             bottom = top

--- a/sycamore/transforms/mark_misc.py
+++ b/sycamore/transforms/mark_misc.py
@@ -1,0 +1,142 @@
+from ray.data import Dataset
+
+from sycamore.data import Document
+from sycamore.functions.tokenizer import Tokenizer
+from sycamore.plan_nodes import Node, Transform, SingleThreadUser, NonGPUUser
+from sycamore.transforms.map import generate_map_function
+
+# TODO:
+# - make breaks balanced in size
+# - maybe move token counting elsewhere to avoid duplicate work
+
+
+class MarkDropTiny(SingleThreadUser, NonGPUUser, Transform):
+    """
+    MarkDropTiny is a transform to add the '_drop' data attribute to
+    each Element smaller than a certain size.
+
+    Args:
+        child: The source Node or component that provides the Elements
+        minimum: The smallest Element to keep (def 2)
+
+    Example:
+        .. code-block:: python
+            source_node = ...
+            marker = MarkDropTiny(child=source_node, minimum=2)
+            dataset = marker.execute()
+    """
+
+    def __init__(self, child: Node, minimum: int = 2, **resource_args):
+        super().__init__(child, **resource_args)
+        self.min = minimum
+
+    class Callable:
+        def __init__(self, minimum: int):
+            self.min = minimum
+
+        def run(self, parent: Document) -> Document:
+            elements = parent.elements  # makes a copy
+            for elem in elements:
+                tr = elem.text_representation or ""
+                if len(tr) < self.min:
+                    elem.data["_drop"] = True  # remove specks
+            parent.elements = elements  # copy back
+            return parent
+
+    def execute(self) -> Dataset:
+        dataset = self.child().execute()
+        marker = MarkDropTiny.Callable(self.min)
+        return dataset.map(generate_map_function(marker.run))
+
+
+###############################################################################
+
+
+class MarkBreakPage(SingleThreadUser, NonGPUUser, Transform):
+    """
+    MarkBreakPage is a transform to add the '_break' data attribute to
+    each Element when the 'page_number' property changes.
+
+    Args:
+        child: The source Node or component that provides the Elements
+
+    Example:
+        .. code-block:: python
+            source_node = ...
+            marker = MarkBreakPage(child=source_node)
+            dataset = marker.execute()
+    """
+
+    def __init__(self, child: Node, **resource_args):
+        super().__init__(child, **resource_args)
+
+    class Callable:
+        def run(self, parent: Document) -> Document:
+            if len(parent.elements) > 1:
+                elements = parent.elements  # makes a copy
+                last = elements[0].properties["page_number"]
+                for elem in elements:
+                    page = elem.properties["page_number"]
+                    if page != last:
+                        elem.data["_break"] = True  # mark for later
+                        last = page
+                parent.elements = elements  # copy back
+            return parent
+
+    def execute(self) -> Dataset:
+        dataset = self.child().execute()
+        marker = MarkBreakPage.Callable()
+        return dataset.map(generate_map_function(marker.run))
+
+
+###############################################################################
+
+
+class MarkBreakByTokens(SingleThreadUser, NonGPUUser, Transform):
+    """
+    MarkBreakByTokens is a transform to add the '_break' data attribute to
+    each Element when the number of tokens exceeds the limit.  This should
+    most likely be the last marking operation before final merge.
+
+    Args:
+        child: The source Node or component that provides the Elements
+        tokenizer: the tokenizer that will be used for embedding
+        limit: maximum permitted number of tokens
+
+    Example:
+        .. code-block:: python
+            source_node = ...
+            marker = MarkBreakByTokens(child=source_node, limit=512)
+            dataset = marker.execute()
+    """
+
+    def __init__(self, child: Node, tokenizer: Tokenizer, limit: int = 512, **resource_args):
+        super().__init__(child, **resource_args)
+        self.tokenizer = tokenizer
+        self.limit = limit
+
+    class Callable:
+        def __init__(self, tokenizer: Tokenizer, limit: int):
+            self.tokenizer = tokenizer
+            self.limit = limit
+
+        def run(self, parent: Document) -> Document:
+            toks = 0
+            elements = parent.elements  # makes a copy
+            for elem in elements:
+                if elem.text_representation:
+                    n = len(self.tokenizer.tokenize(elem.text_representation))
+                else:
+                    n = 0
+                elem.data["_tokCnt"] = n
+                if elem.data.get("_break") or ((toks + n) > self.limit):
+                    elem.data["_break"] = True
+                    toks = 0
+                toks += n
+            parent.elements = elements  # copy back
+            return parent
+
+    def execute(self) -> Dataset:
+        dataset = self.child().execute()
+        marker = MarkBreakByTokens.Callable(self.tokenizer, self.limit)
+        return dataset.map(generate_map_function(marker.run))


### PR DESCRIPTION
There are a few pieces of code that manipulate/mark elements:

- sort_top_to_bottom - reorder elements by page_number and bbox
- mark_drop_tiny - remove text shorter than a minimum size
- mark_drop_header_footer - remove text at extreme top or bottom
- mark_break_page - break before each new page
- mark_break_column - break at transitions from 2 columns to full-width (and re-sort)
- mark_break_tokens - break to keep element size within limit

- mark_bbox_preset - is a shorthand for a preconfigured set of the above

MarkedMerger does the merging according to the various marks on elements.

This is the same behavior that was tested and did well in the relevance benchmark.