### PR TITLE
Fixup dockerization -- skip sycamore library & add build-stamps

### DIFF
--- a/crawler/http/Dockerfile
+++ b/crawler/http/Dockerfile
@@ -1,6 +1,5 @@
-# In the root directory:
-# docker build -t sycamore_crawler_http -f crawler/http/Dockerfile
-# docker run -it sycamore_crawler_http
+# Repo name: arynai/sycamore-crawler-http
+
 FROM python:3
 
 WORKDIR /app
@@ -12,11 +11,24 @@ ENV POETRY_NO_INTERACTION=1 \
     POETRY_CACHE_DIR=/tmp/poetry_cache
 
 COPY pyproject.toml poetry.lock crawler/README.md ./
-RUN poetry install --only main,crawler_http --no-root && rm -rf $POETRY_CACHE_DIR
+RUN poetry install --only crawler_http --no-root && rm -rf $POETRY_CACHE_DIR
 
 COPY crawler/http .
 # Hack beccause pyproject.toml expects a sycamore directory
 RUN mkdir sycamore && touch sycamore/__init__.py
 RUN poetry install --only-root && rm -rf $POETRY_CACHE_DIR
+
+ARG GIT_BRANCH="main"
+ARG GIT_COMMIT="unknown"
+ARG GIT_DIFF="unknown"
+
+ENV GIT_BRANCH=${GIT_BRANCH}
+ENV GIT_COMMIT=${GIT_COMMIT}
+ENV GIT_DIFF=${GIT_DIFF}
+
+LABEL org.opencontainers.image.authors="opensource@aryn.ai"
+LABEL git_branch=${GIT_BRANCH}
+LABEL git_commit=${GIT_COMMIT}
+LABEL git_diff=${GIT_DIFF}
 
 ENTRYPOINT [ "./run-crawler.sh" ]

--- a/crawler/http/run-crawler.sh
+++ b/crawler/http/run-crawler.sh
@@ -1,2 +1,6 @@
 #!/bin/sh
+echo "Version-Info, Sycamore Crawler HTTP Branch: ${GIT_BRANCH}"
+echo "Version-Info, Sycamore Crawler HTTP Commit: ${GIT_COMMIT}"
+echo "Version-Info, Sycamore Crawler HTTP Diff: ${GIT_DIFF}"
+
 poetry run scrapy crawl sycamore "$@"


### PR DESCRIPTION
Avoid installing the sycamore library because it is large (GB) and unneeded.

Add the build stamp environment variables and logging we're adding to the other containers.