### PR TITLE
Change the default merge size to 256.

### DIFF
--- a/importer/docker_local_import.py
+++ b/importer/docker_local_import.py
@@ -273,7 +273,7 @@ def import_pdf(paths):
 
     openai_llm = OpenAI(OpenAIModels.TEXT_DAVINCI.value)
     tokenizer = HuggingFaceTokenizer("sentence-transformers/all-MiniLM-L6-v2")
-    merger = GreedyTextElementMerger(tokenizer, 30)
+    merger = GreedyTextElementMerger(tokenizer, 256)
 
     ctx = sycamore_init()
     if enable_textract:


### PR DESCRIPTION
30 is too small to get good results.
512 crashes with a too large context window importing the sort benchmark.