### PR TITLE
Simplify running the http crawler.

### DIFF
--- a/crawler/http/crawler/settings.py
+++ b/crawler/http/crawler/settings.py
@@ -16,6 +16,9 @@ NEWSPIDER_MODULE = "crawler.spiders"
 # Crawl responsibly by identifying yourself (and your website) on the user-agent
 USER_AGENT = "sycamore crawler (+https://github.com/aryn-ai/sycamore)"
 
+# Crawl at about 1 QPS
+DOWNLOAD_DELAY = 1
+
 # Obey robots.txt rules
 ROBOTSTXT_OBEY = True
 

--- a/crawler/http/run-crawler.sh
+++ b/crawler/http/run-crawler.sh
@@ -1,6 +1,24 @@
-#!/bin/sh
+#!/bin/bash
 echo "Version-Info, Sycamore Crawler HTTP Branch: ${GIT_BRANCH}"
 echo "Version-Info, Sycamore Crawler HTTP Commit: ${GIT_COMMIT}"
 echo "Version-Info, Sycamore Crawler HTTP Diff: ${GIT_DIFF}"
+
+case "$#-$1" in
+    1-http*)
+        poetry run scrapy crawl sycamore -a url="$1"
+        exit 0
+        ;;
+    1-help|1---help)
+        echo
+        echo "Usage:"
+        echo "# crawl starting at a url to the domain associated with that url (stripping www)"
+        echo "docker compose up sycamore_crawler_http <url>"
+        echo "# crawl starting at a url with a specified domain"
+        echo "or docker compose up sycamore_crawler_http -a url=<url> -a domain=<domain>"
+        echo "# crawl starting at a url ignoring links that don't match the prefix"
+        echo "or docker compose up sycamore_crawler_http -a url=<url> -a prefix=<string>"
+        exit 0
+        ;;
+esac
 
 poetry run scrapy crawl sycamore "$@"


### PR DESCRIPTION
You used to need to specify both a url and a domain, but we can infer the likely domain from the URL, so avoid needing to write it twice.

Also add support for a prefix check so people can download only a specific sub-tree.