### PR TITLE
Migrate from text-davinci-003 to gpt-3.5-turbo-instruct.

### DIFF
--- a/examples/html_ingest.py
+++ b/examples/html_ingest.py
@@ -21,7 +21,7 @@ if not paths:
 
 index = "demoindex0"
 
-davinci_llm = OpenAI(OpenAIModels.TEXT_DAVINCI.value)
+davinci_llm = OpenAI(OpenAIModels.GPT_3_5_TURBO_INSTRUCT.value)
 tokenizer = HuggingFaceTokenizer("thenlper/gte-small")
 
 ctx = sycamore.init()

--- a/examples/s3_ingest.py
+++ b/examples/s3_ingest.py
@@ -30,7 +30,7 @@ fsys = pyarrow.fs.S3FileSystem(
     session_token=cred.token,
 )
 
-davinci_llm = OpenAI(OpenAIModels.TEXT_DAVINCI.value)
+davinci_llm = OpenAI(OpenAIModels.GPT_3_5_TURBO_INSTRUCT.value)
 tokenizer = HuggingFaceTokenizer("thenlper/gte-small")
 
 ctx = sycamore.init()

--- a/examples/simple_ingest.py
+++ b/examples/simple_ingest.py
@@ -20,7 +20,7 @@ if not paths:
 
 index = "demoindex0"
 
-davinci_llm = OpenAI(OpenAIModels.TEXT_DAVINCI.value)
+davinci_llm = OpenAI(OpenAIModels.GPT_3_5_TURBO_INSTRUCT.value)
 tokenizer = HuggingFaceTokenizer("thenlper/gte-small")
 
 ctx = sycamore.init()

--- a/importer/docker_local_import.py
+++ b/importer/docker_local_import.py
@@ -271,7 +271,7 @@ def import_pdf(paths):
         print("WARNING: import_html called with empty paths")
         return
 
-    openai_llm = OpenAI(OpenAIModels.TEXT_DAVINCI.value)
+    openai_llm = OpenAI(OpenAIModels.GPT_3_5_TURBO_INSTRUCT.value)
     tokenizer = HuggingFaceTokenizer("sentence-transformers/all-MiniLM-L6-v2")
     merger = GreedyTextElementMerger(tokenizer, 256)
 

--- a/sycamore/llms/llms.py
+++ b/sycamore/llms/llms.py
@@ -9,8 +9,10 @@ from tenacity import retry, stop_after_attempt, wait_random, retry_if_exception_
 
 
 class OpenAIModels(Enum):
-    TEXT_DAVINCI = "text-davinci-003"
+    TEXT_DAVINCI = "text-davinci-003"  # Deprecated
     GPT_3_5_TURBO = "gpt-3.5-turbo-1106"
+    GPT_4_TURBO = "gpt-4-turbo"
+    GPT_3_5_TURBO_INSTRUCT = "gpt-3.5-turbo-instruct"
 
 
 class LLM(ABC):
@@ -50,6 +52,10 @@ class OpenAIClientParameters:
 
 class OpenAI(LLM):
     def __init__(self, model_name, api_key=None, params: OpenAIClientParameters = OpenAIClientParameters(), **kwargs):
+        if model_name == OpenAIModels.TEXT_DAVINCI.value:
+            print("text-davinci-003 is deprecated. Falling back to gpt-3.5-turbo-instruct")
+            model_name = OpenAIModels.GPT_3_5_TURBO_INSTRUCT
+
         super().__init__(model_name, **kwargs)
 
         self._params = params

--- a/sycamore/tests/integration/test_pdf_to_opensearch.py
+++ b/sycamore/tests/integration/test_pdf_to_opensearch.py
@@ -90,7 +90,7 @@ def test_pdf_to_opensearch():
 
     paths = str(TEST_DIR / "resources/data/pdfs/")
 
-    openai_llm = OpenAI(OpenAIModels.TEXT_DAVINCI.value)
+    openai_llm = OpenAI(OpenAIModels.GPT_3_5_TURBO_INSTRUCT.value)
 
     context = sycamore.init()
     ds = (


### PR DESCRIPTION
OpenAI deprecation is occuring on 1/4. To provide some level of compatibility we automatically switch the model with a warning if the caller passes in the deprecated model.