### PR TITLE
Use classic shingles; simplified implementation; added debug; re-tuned

### DIFF
--- a/examples/simple_ingest.py
+++ b/examples/simple_ingest.py
@@ -6,7 +6,7 @@ sys.path.append("../sycamore")
 import sycamore
 from sycamore.functions.tokenizer import HuggingFaceTokenizer
 from sycamore.llms import OpenAIModels, OpenAI
-from sycamore.transforms import COALESCE_WHITESPACE, Sketcher, SketchUniquify
+from sycamore.transforms import COALESCE_WHITESPACE, Sketcher, SketchDebug, SketchUniquify
 from sycamore.transforms.merge_elements import MarkedMerger
 from sycamore.transforms.partition import UnstructuredPdfPartitioner
 from sycamore.transforms.extract_entity import OpenAIEntityExtractor
@@ -36,13 +36,14 @@ ds = (
     .split_elements(tokenizer=tokenizer, max_tokens=512)
     .explode()
     .embed(embedder=SentenceTransformerEmbedder(model_name="thenlper/gte-small", batch_size=100))
-    .transform(cls=Sketcher, window=32)
-    .transform(cls=SketchUniquify, threshold=14)
+    .transform(cls=Sketcher, window=17)
+    .transform(cls=SketchDebug, threshold=0.4)
 )
 
+ds.show()
 # ds.show(limit=1000, truncate_length=500)
-ds.write.opensearch(
-    os_client_args=osrch_args,
-    index_name=index,
-    index_settings=idx_settings,
-)
+#ds.write.opensearch(
+#    os_client_args=osrch_args,
+#    index_name=index,
+#    index_settings=idx_settings,
+#)

--- a/examples/simple_ingest.py
+++ b/examples/simple_ingest.py
@@ -6,7 +6,7 @@ sys.path.append("../sycamore")
 import sycamore
 from sycamore.functions.tokenizer import HuggingFaceTokenizer
 from sycamore.llms import OpenAIModels, OpenAI
-from sycamore.transforms import COALESCE_WHITESPACE, Sketcher, SketchDebug, SketchUniquify
+from sycamore.transforms import COALESCE_WHITESPACE, Sketcher, SketchDebug
 from sycamore.transforms.merge_elements import MarkedMerger
 from sycamore.transforms.partition import UnstructuredPdfPartitioner
 from sycamore.transforms.extract_entity import OpenAIEntityExtractor
@@ -40,10 +40,9 @@ ds = (
     .transform(cls=SketchDebug, threshold=0.4)
 )
 
-ds.show()
 # ds.show(limit=1000, truncate_length=500)
-#ds.write.opensearch(
-#    os_client_args=osrch_args,
-#    index_name=index,
-#    index_settings=idx_settings,
-#)
+ds.write.opensearch(
+    os_client_args=osrch_args,
+    index_name=index,
+    index_settings=idx_settings,
+)

--- a/sycamore/data/document.py
+++ b/sycamore/data/document.py
@@ -90,12 +90,12 @@ class Document(UserDict):
         self.data["embedding"] = embedding
 
     @property
-    def simHashes(self) -> Optional[list[int]]:
-        return self.data.get("simHashes")
+    def shingles(self) -> Optional[list[int]]:
+        return self.data.get("shingles")
 
-    @simHashes.setter
-    def simHashes(self, simHashes: list[int]) -> None:
-        self.data["simHashes"] = simHashes
+    @shingles.setter
+    def shingles(self, shingles: list[int]) -> None:
+        self.data["shingles"] = shingles
 
     @property
     def parent_id(self) -> Optional[str]:

--- a/sycamore/functions/rabin_karp.py
+++ b/sycamore/functions/rabin_karp.py
@@ -28,6 +28,11 @@ class RkHash:
     def hashOut(self, ch: int) -> None:
         self.val = (self.val + self.primeShift - (ch * self.inv)) % self.prime
 
+    def hashOutIn(self, chOut: int, chIn: int) -> None:
+        self.val = (
+            (((self.val + self.primeShift - (chOut * self.inv)) % self.prime) << self.shift) + chIn
+        ) % self.prime
+
     def get(self) -> int:
         return self.val
 
@@ -44,11 +49,10 @@ class RkWindow:
         if width < 1:
             raise ValueError
         hasher = RkHash(width)
-        seed = 149  # 8-bit prime with 4 bits set
         ary = []
         for ii in range(width):
-            hasher.hashIn(seed)
-            ary.append(seed)
+            hasher.hashIn(0)
+            ary.append(0)
         self.hasher = hasher
         self.ary = ary
         self.idx = 0
@@ -60,14 +64,14 @@ class RkWindow:
         a = ",".join(["[%d]" % ch if ii == idx else "%d" % ch for ii, ch in enumerate(self.ary)])
         return "(w%s%s)" % (h, a)
 
-    def hash(self, ch: int) -> None:
+    def hash(self, ch: int) -> Optional[int]:
         hasher = self.hasher
         ary = self.ary
         idx = self.idx % self.width
-        hasher.hashOut(ary[idx])
-        hasher.hashIn(ch)
+        hasher.hashOutIn(ary[idx], ch)
         ary[idx] = ch
         self.idx += 1
+        return hasher.val if self.idx >= self.width else None
 
     def get(self) -> Optional[int]:
-        return self.hasher.val if self.idx >= self.width else None
+        return self.hasher.val

--- a/sycamore/functions/simhash.py
+++ b/sycamore/functions/simhash.py
@@ -20,7 +20,7 @@ def scramble(val: int) -> int:
     9223372036854775783 = largest prime < 2^63
     """
 
-    return ((val * 6364136223846793005) + 9223372036854775783) & 0xFFFFFFFFFFFFFFFF
+    return ((val * 6364136223846793005) + 9223372036854775783) & 0x7FFFFFFFFFFFFFFF
 
 
 def sortedVectorCmp(aVec: list[int], bVec: list[int]) -> tuple[int, int]:

--- a/sycamore/functions/simhash.py
+++ b/sycamore/functions/simhash.py
@@ -1,4 +1,6 @@
 import sys
+import operator
+from functools import reduce
 from sycamore.functions.rabin_karp import RkWindow
 
 __all__ = ["shinglesCalc", "shinglesDist", "simHash", "simHashesDist", "simHashText"]
@@ -8,42 +10,6 @@ __all__ = ["shinglesCalc", "shinglesDist", "simHash", "simHashesDist", "simHashT
 # Helper Functions
 #
 ###############################################################################
-
-
-def downHeap(heap, idx):
-    """
-    downHeap() implements the down-heap operation on a binary max-heap
-    represented as a 1-based list.  If the list represents a valid heap
-    except that the element at `idx` may be too small, downHeap() will fix
-    the heap in log(N) time.
-    """
-
-    nn = len(heap) - 1
-    limit = nn // 2
-    val = heap[idx]
-
-    while idx <= limit:
-        kid = 2 * idx
-        if (kid < nn) and (heap[kid] < heap[kid + 1]):
-            kid += 1
-        kidVal = heap[kid]
-        if kidVal < val:
-            break
-        heap[idx] = kidVal
-        idx = kid
-    heap[idx] = val
-
-
-def heapUpdate(heap, item):
-    """
-    heapUpdate() does the equivalent of a pop() and push() if the new
-    item is less than the max value in the heap.  This is useful when
-    using a max-heap to keep track of the N lowest values.
-    """
-
-    if item < heap[1]:
-        heap[1] = item
-        downHeap(heap, 1)
 
 
 def scramble(val: int) -> int:
@@ -86,24 +52,18 @@ def sortedVectorCmp(aVec: list[int], bVec: list[int]) -> tuple[int, int]:
 #
 # Shingles Functions
 #
-# The terminology used below is based on basic roofing singles.  A
-# standard shingle has 3 "tabs" at the bottom.  These are what is visible
-# after the next higher shingle overlaps it.  Each horizonal row of
-# shingles is called a "course".
+# The analogy here is to shingles on a house.  They overlap each other.
+# Conceptually, a set of shingles looks like this:
 #
-#               +--------+
-# A standard    |        |
-# 3-tab shingle |  |  |  |
-#               +--+--+--+
-#
-#           |  |  |  |
-#           +--+--+--+
-# 4 courses  |  |  |  |
-# of 3-tab   +--+--+--+
-# shingles    |  |  |  |
-#             +--+--+--+
-#              |  |  |  |
-#              +--+--+--+
+# +--+
+# |  |
+# +--+
+#  |  |
+#  +--+   = shingles, with "number" = 4
+#   |  |
+#   +--+
+#    |  |
+#    +--+
 #
 # Each box above represents a single hash.  The hashes are made using a
 # sliding window.  For example, if the "window" is 5:
@@ -116,65 +76,50 @@ def sortedVectorCmp(aVec: list[int], bVec: list[int]) -> tuple[int, int]:
 # This code uses a hash function that is efficient for sliding windows
 # (Rabin-Karp).  The end result is a list of hashes, with length proportional
 # to the size of the input.  They are sorted and the first N constitute a
-# vertical shingle one-tab wide.  The next tab over is represents the same
-# process with a different permutation of the hash values.  Each tab shares
-# the same permutation.
+# set of shingles.
 #
 ###############################################################################
 
 
-def shinglesCalc(text: bytes, window: int = 32, courses: int = 29, tabs: int = 10) -> list[list[int]]:
+def shinglesCalc(text: bytes, window: int = 17, number: int = 16) -> list[int]:
     """
-    shinglesCalc() will process `text` and return a list of variants of
-    lists of hashes.  The inner list is often referred to as "shingles"
-    and consists for the lowest-value `courses` hashes.  Each top-level
-    list represents shingles scrambled `tabs` times.  Conceptually, when
-    looking at a section of roof, it's `courses` high and `tabs` wide.
-    `window` is the number of bytes in the sliding window that's hashed.
+    shinglesCalc() will process `text` and return a list of hashes.
+    This list is often referred to as "shingles" and consists of the
+    lowest-value `number` hashes.  Parameter `window` is the number of
+    bytes in the sliding window that's hashed.
+
+    text    - The text to process, in UTF-8 bytes
+    window  - Width in bytes of the sliding window used for shingles
+    number  - The number of least-value shingles to retain
     """
 
+    seen = set()
     ww = RkWindow(window)
-    heaps = [[0xFFFFFFFFFFFFFFFF for i in range(courses + 1)] for j in range(tabs)]
+
     for x in text:
-        ww.hash(x)
-        hh = ww.get()
+        hh = ww.hash(x)
         if hh is not None:
-            for heap in heaps:
-                hh = scramble(hh)
-                heapUpdate(heap, hh)
-    rv = []
-    for heap in heaps:
-        heap = list(filter(lambda x: x != 0xFFFFFFFFFFFFFFFF, heap))
-        nn = len(heap)
-        if nn == courses:
-            heap.sort()
-        elif nn == 0:
-            heap = [0] * courses
-        else:
-            copies = (courses + nn - 1) // nn
-            heap *= copies
-            heap.sort()
-            heap = heap[: courses + 1]
-        rv.append(heap)
-    return rv
+            seen.add(scramble(hh))
+
+    ary = sorted(seen)
+    nn = len(ary)
+    if nn == 0:
+        return [0] * number
+    elif nn < number:
+        copies = (number + nn - 1) // nn
+        ary *= copies
+        ary.sort()
+    return ary[:number]
 
 
-def shinglesDist(aa: list[list[int]], bb: list[list[int]]) -> float:
+def shinglesDist(aa: list[int], bb: list[int]) -> float:
     """
     shinglesDist() is a distance function for two sets of shingles.
     The outputs of shinglesCalc() can be used here.  The return value
     is a real number [0, 1.0] indicating dissimilarity.
     """
 
-    aLen = len(aa)
-    bLen = len(bb)
-    assert aLen == bLen
-    numer = 0
-    denom = 0
-    for ii in range(aLen):
-        n, d = sortedVectorCmp(aa[ii], bb[ii])
-        numer += n
-        denom += d
+    numer, denom = sortedVectorCmp(aa, bb)
     if denom == 0:
         return 1.0
     return (denom - numer) / denom
@@ -211,42 +156,42 @@ def simHash(tab: list[int]) -> int:
     return rv
 
 
-def simHashesDistFast(aa: list[int], bb: list[int]) -> int:
+def simHashesDistFast(aa: list[int], bb: list[int]) -> float:
     """
     simHashesDistFast() compares two lists of SimHashes and returns a
     distance metric.  Each list of SimHashes represents a document.
-    Corresponding elements in each list represent variants or "tabs" of
+    Corresponding elements in each list represent variants of
     shingles.  With a SimHash, the most bits in common means the most
-    similar.  This returns the average of the count of differing bits.
+    similar.  This returns the average of the count of differing bits / 64.
     This fast version for Python >=3.10 takes 50% less time than the slow.
     """
 
-    assert len(aa) == len(bb)
-    low = 64
+    nn = len(aa)
+    assert len(bb) == nn
+    tot = 0
     for a, b in zip(aa, bb):
         x = a ^ b
-        pop = x.bit_count()  # type: ignore[attr-defined]
-        low = min(low, pop)
-    return low
+        tot += x.bit_count()  # type: ignore[attr-defined]
+    return (tot / nn) / 64.0
 
 
-def simHashesDistSlow(aa: list[int], bb: list[int]) -> int:
+def simHashesDistSlow(aa: list[int], bb: list[int]) -> float:
     """
     simHashesDistSlow() compares two lists of SimHashes and returns a
     distance metric.  Each list of SimHashes represents a document.
-    Corresponding elements in each list represent variants or "tabs" of
+    Corresponding elements in each list represent variants of
     shingles.  With a SimHash, the most bits in common means the most
-    similar.  This returns the average of the count of differing bits.
+    similar.  This returns the average of the count of differing bits / 64.
     This slow version for Python <=3.9 takes 50% more time than the fast.
     """
 
-    assert len(aa) == len(bb)
-    low = 64
+    nn = len(aa)
+    assert len(bb) == nn
+    tot = 0
     for a, b in zip(aa, bb):
         x = a ^ b
-        pop = bin(x).count("1")  # slow way to count set bits
-        low = min(low, pop)
-    return low
+        tot += bin(x).count("1")  # slow way to count set bits
+    return (tot / nn) / 64.0
 
 
 # Python lacks int.bit_count() until version 3.10
@@ -256,15 +201,310 @@ else:
     simHashesDist = simHashesDistFast
 
 
-def simHashText(text: bytes, window: int = 32, courses: int = 29, tabs: int = 10) -> list[int]:
+def simHashText(text: bytes, window: int = 17, number: int = 16) -> list[int]:
     """
     Takes text and returns a list of SimHashes.  Arguments:
 
     text    - The text to process, in UTF-8 bytes
     window  - Width in bytes of the sliding window used for shingles
-    courses - The number of least-value shingles to retain
-    tabs    - The number of variants of each shingle to process
+    number  - The number of variant SimHashes to generate
     """
-    assert (courses & 1) == 1
-    shingles = shinglesCalc(text, window, courses, tabs)
-    return [simHash(hh) for hh in shingles]
+
+    ww = RkWindow(window)
+    countVecVec = [[0] * 64 for t in range(number)]
+
+    for x in text:
+        hh = ww.hash(x)
+        if hh is not None:
+            for countVec in countVecVec:
+                hh = scramble(hh)
+                # use lookup table, list appending, and element-wise addition
+                countVec[:] = map(
+                    operator.add,
+                    countVec,
+                    simTbl[hh & 0xFF]
+                    + simTbl[(hh >> 8) & 0xFF]
+                    + simTbl[(hh >> 16) & 0xFF]
+                    + simTbl[(hh >> 24) & 0xFF]
+                    + simTbl[(hh >> 32) & 0xFF]
+                    + simTbl[(hh >> 40) & 0xFF]
+                    + simTbl[(hh >> 48) & 0xFF]
+                    + simTbl[(hh >> 56) & 0xFF],
+                )
+
+    sims = []
+    if len(text) < window:
+        hh = ww.get()
+        for i in range(number):
+            hh = scramble(hh)  # type: ignore[arg-type]
+            sims.append(hh)
+        return sims
+
+    for countVec in countVecVec:
+        # convert array of 64 counts to binary string, to int, and append
+        sims.append(int(reduce(lambda s, x: ("1" if x >= 0 else "0") + s, countVec, ""), 2))
+    return sims
+
+
+# Lookup table to speed up SimHash calculation.  For each byte, for each bit,
+# value is 1 if bit is set, -1 if not set.  Bit 0 is least-significant.
+# fmt: off
+simTbl = [
+    [-1, -1, -1, -1, -1, -1, -1, -1],  # 00
+    [ 1, -1, -1, -1, -1, -1, -1, -1],  # 01
+    [-1,  1, -1, -1, -1, -1, -1, -1],  # 02
+    [ 1,  1, -1, -1, -1, -1, -1, -1],  # 03
+    [-1, -1,  1, -1, -1, -1, -1, -1],  # 04
+    [ 1, -1,  1, -1, -1, -1, -1, -1],  # 05
+    [-1,  1,  1, -1, -1, -1, -1, -1],  # 06
+    [ 1,  1,  1, -1, -1, -1, -1, -1],  # 07
+    [-1, -1, -1,  1, -1, -1, -1, -1],  # 08
+    [ 1, -1, -1,  1, -1, -1, -1, -1],  # 09
+    [-1,  1, -1,  1, -1, -1, -1, -1],  # 0a
+    [ 1,  1, -1,  1, -1, -1, -1, -1],  # 0b
+    [-1, -1,  1,  1, -1, -1, -1, -1],  # 0c
+    [ 1, -1,  1,  1, -1, -1, -1, -1],  # 0d
+    [-1,  1,  1,  1, -1, -1, -1, -1],  # 0e
+    [ 1,  1,  1,  1, -1, -1, -1, -1],  # 0f
+    [-1, -1, -1, -1,  1, -1, -1, -1],  # 10
+    [ 1, -1, -1, -1,  1, -1, -1, -1],  # 11
+    [-1,  1, -1, -1,  1, -1, -1, -1],  # 12
+    [ 1,  1, -1, -1,  1, -1, -1, -1],  # 13
+    [-1, -1,  1, -1,  1, -1, -1, -1],  # 14
+    [ 1, -1,  1, -1,  1, -1, -1, -1],  # 15
+    [-1,  1,  1, -1,  1, -1, -1, -1],  # 16
+    [ 1,  1,  1, -1,  1, -1, -1, -1],  # 17
+    [-1, -1, -1,  1,  1, -1, -1, -1],  # 18
+    [ 1, -1, -1,  1,  1, -1, -1, -1],  # 19
+    [-1,  1, -1,  1,  1, -1, -1, -1],  # 1a
+    [ 1,  1, -1,  1,  1, -1, -1, -1],  # 1b
+    [-1, -1,  1,  1,  1, -1, -1, -1],  # 1c
+    [ 1, -1,  1,  1,  1, -1, -1, -1],  # 1d
+    [-1,  1,  1,  1,  1, -1, -1, -1],  # 1e
+    [ 1,  1,  1,  1,  1, -1, -1, -1],  # 1f
+    [-1, -1, -1, -1, -1,  1, -1, -1],  # 20
+    [ 1, -1, -1, -1, -1,  1, -1, -1],  # 21
+    [-1,  1, -1, -1, -1,  1, -1, -1],  # 22
+    [ 1,  1, -1, -1, -1,  1, -1, -1],  # 23
+    [-1, -1,  1, -1, -1,  1, -1, -1],  # 24
+    [ 1, -1,  1, -1, -1,  1, -1, -1],  # 25
+    [-1,  1,  1, -1, -1,  1, -1, -1],  # 26
+    [ 1,  1,  1, -1, -1,  1, -1, -1],  # 27
+    [-1, -1, -1,  1, -1,  1, -1, -1],  # 28
+    [ 1, -1, -1,  1, -1,  1, -1, -1],  # 29
+    [-1,  1, -1,  1, -1,  1, -1, -1],  # 2a
+    [ 1,  1, -1,  1, -1,  1, -1, -1],  # 2b
+    [-1, -1,  1,  1, -1,  1, -1, -1],  # 2c
+    [ 1, -1,  1,  1, -1,  1, -1, -1],  # 2d
+    [-1,  1,  1,  1, -1,  1, -1, -1],  # 2e
+    [ 1,  1,  1,  1, -1,  1, -1, -1],  # 2f
+    [-1, -1, -1, -1,  1,  1, -1, -1],  # 30
+    [ 1, -1, -1, -1,  1,  1, -1, -1],  # 31
+    [-1,  1, -1, -1,  1,  1, -1, -1],  # 32
+    [ 1,  1, -1, -1,  1,  1, -1, -1],  # 33
+    [-1, -1,  1, -1,  1,  1, -1, -1],  # 34
+    [ 1, -1,  1, -1,  1,  1, -1, -1],  # 35
+    [-1,  1,  1, -1,  1,  1, -1, -1],  # 36
+    [ 1,  1,  1, -1,  1,  1, -1, -1],  # 37
+    [-1, -1, -1,  1,  1,  1, -1, -1],  # 38
+    [ 1, -1, -1,  1,  1,  1, -1, -1],  # 39
+    [-1,  1, -1,  1,  1,  1, -1, -1],  # 3a
+    [ 1,  1, -1,  1,  1,  1, -1, -1],  # 3b
+    [-1, -1,  1,  1,  1,  1, -1, -1],  # 3c
+    [ 1, -1,  1,  1,  1,  1, -1, -1],  # 3d
+    [-1,  1,  1,  1,  1,  1, -1, -1],  # 3e
+    [ 1,  1,  1,  1,  1,  1, -1, -1],  # 3f
+    [-1, -1, -1, -1, -1, -1,  1, -1],  # 40
+    [ 1, -1, -1, -1, -1, -1,  1, -1],  # 41
+    [-1,  1, -1, -1, -1, -1,  1, -1],  # 42
+    [ 1,  1, -1, -1, -1, -1,  1, -1],  # 43
+    [-1, -1,  1, -1, -1, -1,  1, -1],  # 44
+    [ 1, -1,  1, -1, -1, -1,  1, -1],  # 45
+    [-1,  1,  1, -1, -1, -1,  1, -1],  # 46
+    [ 1,  1,  1, -1, -1, -1,  1, -1],  # 47
+    [-1, -1, -1,  1, -1, -1,  1, -1],  # 48
+    [ 1, -1, -1,  1, -1, -1,  1, -1],  # 49
+    [-1,  1, -1,  1, -1, -1,  1, -1],  # 4a
+    [ 1,  1, -1,  1, -1, -1,  1, -1],  # 4b
+    [-1, -1,  1,  1, -1, -1,  1, -1],  # 4c
+    [ 1, -1,  1,  1, -1, -1,  1, -1],  # 4d
+    [-1,  1,  1,  1, -1, -1,  1, -1],  # 4e
+    [ 1,  1,  1,  1, -1, -1,  1, -1],  # 4f
+    [-1, -1, -1, -1,  1, -1,  1, -1],  # 50
+    [ 1, -1, -1, -1,  1, -1,  1, -1],  # 51
+    [-1,  1, -1, -1,  1, -1,  1, -1],  # 52
+    [ 1,  1, -1, -1,  1, -1,  1, -1],  # 53
+    [-1, -1,  1, -1,  1, -1,  1, -1],  # 54
+    [ 1, -1,  1, -1,  1, -1,  1, -1],  # 55
+    [-1,  1,  1, -1,  1, -1,  1, -1],  # 56
+    [ 1,  1,  1, -1,  1, -1,  1, -1],  # 57
+    [-1, -1, -1,  1,  1, -1,  1, -1],  # 58
+    [ 1, -1, -1,  1,  1, -1,  1, -1],  # 59
+    [-1,  1, -1,  1,  1, -1,  1, -1],  # 5a
+    [ 1,  1, -1,  1,  1, -1,  1, -1],  # 5b
+    [-1, -1,  1,  1,  1, -1,  1, -1],  # 5c
+    [ 1, -1,  1,  1,  1, -1,  1, -1],  # 5d
+    [-1,  1,  1,  1,  1, -1,  1, -1],  # 5e
+    [ 1,  1,  1,  1,  1, -1,  1, -1],  # 5f
+    [-1, -1, -1, -1, -1,  1,  1, -1],  # 60
+    [ 1, -1, -1, -1, -1,  1,  1, -1],  # 61
+    [-1,  1, -1, -1, -1,  1,  1, -1],  # 62
+    [ 1,  1, -1, -1, -1,  1,  1, -1],  # 63
+    [-1, -1,  1, -1, -1,  1,  1, -1],  # 64
+    [ 1, -1,  1, -1, -1,  1,  1, -1],  # 65
+    [-1,  1,  1, -1, -1,  1,  1, -1],  # 66
+    [ 1,  1,  1, -1, -1,  1,  1, -1],  # 67
+    [-1, -1, -1,  1, -1,  1,  1, -1],  # 68
+    [ 1, -1, -1,  1, -1,  1,  1, -1],  # 69
+    [-1,  1, -1,  1, -1,  1,  1, -1],  # 6a
+    [ 1,  1, -1,  1, -1,  1,  1, -1],  # 6b
+    [-1, -1,  1,  1, -1,  1,  1, -1],  # 6c
+    [ 1, -1,  1,  1, -1,  1,  1, -1],  # 6d
+    [-1,  1,  1,  1, -1,  1,  1, -1],  # 6e
+    [ 1,  1,  1,  1, -1,  1,  1, -1],  # 6f
+    [-1, -1, -1, -1,  1,  1,  1, -1],  # 70
+    [ 1, -1, -1, -1,  1,  1,  1, -1],  # 71
+    [-1,  1, -1, -1,  1,  1,  1, -1],  # 72
+    [ 1,  1, -1, -1,  1,  1,  1, -1],  # 73
+    [-1, -1,  1, -1,  1,  1,  1, -1],  # 74
+    [ 1, -1,  1, -1,  1,  1,  1, -1],  # 75
+    [-1,  1,  1, -1,  1,  1,  1, -1],  # 76
+    [ 1,  1,  1, -1,  1,  1,  1, -1],  # 77
+    [-1, -1, -1,  1,  1,  1,  1, -1],  # 78
+    [ 1, -1, -1,  1,  1,  1,  1, -1],  # 79
+    [-1,  1, -1,  1,  1,  1,  1, -1],  # 7a
+    [ 1,  1, -1,  1,  1,  1,  1, -1],  # 7b
+    [-1, -1,  1,  1,  1,  1,  1, -1],  # 7c
+    [ 1, -1,  1,  1,  1,  1,  1, -1],  # 7d
+    [-1,  1,  1,  1,  1,  1,  1, -1],  # 7e
+    [ 1,  1,  1,  1,  1,  1,  1, -1],  # 7f
+    [-1, -1, -1, -1, -1, -1, -1,  1],  # 80
+    [ 1, -1, -1, -1, -1, -1, -1,  1],  # 81
+    [-1,  1, -1, -1, -1, -1, -1,  1],  # 82
+    [ 1,  1, -1, -1, -1, -1, -1,  1],  # 83
+    [-1, -1,  1, -1, -1, -1, -1,  1],  # 84
+    [ 1, -1,  1, -1, -1, -1, -1,  1],  # 85
+    [-1,  1,  1, -1, -1, -1, -1,  1],  # 86
+    [ 1,  1,  1, -1, -1, -1, -1,  1],  # 87
+    [-1, -1, -1,  1, -1, -1, -1,  1],  # 88
+    [ 1, -1, -1,  1, -1, -1, -1,  1],  # 89
+    [-1,  1, -1,  1, -1, -1, -1,  1],  # 8a
+    [ 1,  1, -1,  1, -1, -1, -1,  1],  # 8b
+    [-1, -1,  1,  1, -1, -1, -1,  1],  # 8c
+    [ 1, -1,  1,  1, -1, -1, -1,  1],  # 8d
+    [-1,  1,  1,  1, -1, -1, -1,  1],  # 8e
+    [ 1,  1,  1,  1, -1, -1, -1,  1],  # 8f
+    [-1, -1, -1, -1,  1, -1, -1,  1],  # 90
+    [ 1, -1, -1, -1,  1, -1, -1,  1],  # 91
+    [-1,  1, -1, -1,  1, -1, -1,  1],  # 92
+    [ 1,  1, -1, -1,  1, -1, -1,  1],  # 93
+    [-1, -1,  1, -1,  1, -1, -1,  1],  # 94
+    [ 1, -1,  1, -1,  1, -1, -1,  1],  # 95
+    [-1,  1,  1, -1,  1, -1, -1,  1],  # 96
+    [ 1,  1,  1, -1,  1, -1, -1,  1],  # 97
+    [-1, -1, -1,  1,  1, -1, -1,  1],  # 98
+    [ 1, -1, -1,  1,  1, -1, -1,  1],  # 99
+    [-1,  1, -1,  1,  1, -1, -1,  1],  # 9a
+    [ 1,  1, -1,  1,  1, -1, -1,  1],  # 9b
+    [-1, -1,  1,  1,  1, -1, -1,  1],  # 9c
+    [ 1, -1,  1,  1,  1, -1, -1,  1],  # 9d
+    [-1,  1,  1,  1,  1, -1, -1,  1],  # 9e
+    [ 1,  1,  1,  1,  1, -1, -1,  1],  # 9f
+    [-1, -1, -1, -1, -1,  1, -1,  1],  # a0
+    [ 1, -1, -1, -1, -1,  1, -1,  1],  # a1
+    [-1,  1, -1, -1, -1,  1, -1,  1],  # a2
+    [ 1,  1, -1, -1, -1,  1, -1,  1],  # a3
+    [-1, -1,  1, -1, -1,  1, -1,  1],  # a4
+    [ 1, -1,  1, -1, -1,  1, -1,  1],  # a5
+    [-1,  1,  1, -1, -1,  1, -1,  1],  # a6
+    [ 1,  1,  1, -1, -1,  1, -1,  1],  # a7
+    [-1, -1, -1,  1, -1,  1, -1,  1],  # a8
+    [ 1, -1, -1,  1, -1,  1, -1,  1],  # a9
+    [-1,  1, -1,  1, -1,  1, -1,  1],  # aa
+    [ 1,  1, -1,  1, -1,  1, -1,  1],  # ab
+    [-1, -1,  1,  1, -1,  1, -1,  1],  # ac
+    [ 1, -1,  1,  1, -1,  1, -1,  1],  # ad
+    [-1,  1,  1,  1, -1,  1, -1,  1],  # ae
+    [ 1,  1,  1,  1, -1,  1, -1,  1],  # af
+    [-1, -1, -1, -1,  1,  1, -1,  1],  # b0
+    [ 1, -1, -1, -1,  1,  1, -1,  1],  # b1
+    [-1,  1, -1, -1,  1,  1, -1,  1],  # b2
+    [ 1,  1, -1, -1,  1,  1, -1,  1],  # b3
+    [-1, -1,  1, -1,  1,  1, -1,  1],  # b4
+    [ 1, -1,  1, -1,  1,  1, -1,  1],  # b5
+    [-1,  1,  1, -1,  1,  1, -1,  1],  # b6
+    [ 1,  1,  1, -1,  1,  1, -1,  1],  # b7
+    [-1, -1, -1,  1,  1,  1, -1,  1],  # b8
+    [ 1, -1, -1,  1,  1,  1, -1,  1],  # b9
+    [-1,  1, -1,  1,  1,  1, -1,  1],  # ba
+    [ 1,  1, -1,  1,  1,  1, -1,  1],  # bb
+    [-1, -1,  1,  1,  1,  1, -1,  1],  # bc
+    [ 1, -1,  1,  1,  1,  1, -1,  1],  # bd
+    [-1,  1,  1,  1,  1,  1, -1,  1],  # be
+    [ 1,  1,  1,  1,  1,  1, -1,  1],  # bf
+    [-1, -1, -1, -1, -1, -1,  1,  1],  # c0
+    [ 1, -1, -1, -1, -1, -1,  1,  1],  # c1
+    [-1,  1, -1, -1, -1, -1,  1,  1],  # c2
+    [ 1,  1, -1, -1, -1, -1,  1,  1],  # c3
+    [-1, -1,  1, -1, -1, -1,  1,  1],  # c4
+    [ 1, -1,  1, -1, -1, -1,  1,  1],  # c5
+    [-1,  1,  1, -1, -1, -1,  1,  1],  # c6
+    [ 1,  1,  1, -1, -1, -1,  1,  1],  # c7
+    [-1, -1, -1,  1, -1, -1,  1,  1],  # c8
+    [ 1, -1, -1,  1, -1, -1,  1,  1],  # c9
+    [-1,  1, -1,  1, -1, -1,  1,  1],  # ca
+    [ 1,  1, -1,  1, -1, -1,  1,  1],  # cb
+    [-1, -1,  1,  1, -1, -1,  1,  1],  # cc
+    [ 1, -1,  1,  1, -1, -1,  1,  1],  # cd
+    [-1,  1,  1,  1, -1, -1,  1,  1],  # ce
+    [ 1,  1,  1,  1, -1, -1,  1,  1],  # cf
+    [-1, -1, -1, -1,  1, -1,  1,  1],  # d0
+    [ 1, -1, -1, -1,  1, -1,  1,  1],  # d1
+    [-1,  1, -1, -1,  1, -1,  1,  1],  # d2
+    [ 1,  1, -1, -1,  1, -1,  1,  1],  # d3
+    [-1, -1,  1, -1,  1, -1,  1,  1],  # d4
+    [ 1, -1,  1, -1,  1, -1,  1,  1],  # d5
+    [-1,  1,  1, -1,  1, -1,  1,  1],  # d6
+    [ 1,  1,  1, -1,  1, -1,  1,  1],  # d7
+    [-1, -1, -1,  1,  1, -1,  1,  1],  # d8
+    [ 1, -1, -1,  1,  1, -1,  1,  1],  # d9
+    [-1,  1, -1,  1,  1, -1,  1,  1],  # da
+    [ 1,  1, -1,  1,  1, -1,  1,  1],  # db
+    [-1, -1,  1,  1,  1, -1,  1,  1],  # dc
+    [ 1, -1,  1,  1,  1, -1,  1,  1],  # dd
+    [-1,  1,  1,  1,  1, -1,  1,  1],  # de
+    [ 1,  1,  1,  1,  1, -1,  1,  1],  # df
+    [-1, -1, -1, -1, -1,  1,  1,  1],  # e0
+    [ 1, -1, -1, -1, -1,  1,  1,  1],  # e1
+    [-1,  1, -1, -1, -1,  1,  1,  1],  # e2
+    [ 1,  1, -1, -1, -1,  1,  1,  1],  # e3
+    [-1, -1,  1, -1, -1,  1,  1,  1],  # e4
+    [ 1, -1,  1, -1, -1,  1,  1,  1],  # e5
+    [-1,  1,  1, -1, -1,  1,  1,  1],  # e6
+    [ 1,  1,  1, -1, -1,  1,  1,  1],  # e7
+    [-1, -1, -1,  1, -1,  1,  1,  1],  # e8
+    [ 1, -1, -1,  1, -1,  1,  1,  1],  # e9
+    [-1,  1, -1,  1, -1,  1,  1,  1],  # ea
+    [ 1,  1, -1,  1, -1,  1,  1,  1],  # eb
+    [-1, -1,  1,  1, -1,  1,  1,  1],  # ec
+    [ 1, -1,  1,  1, -1,  1,  1,  1],  # ed
+    [-1,  1,  1,  1, -1,  1,  1,  1],  # ee
+    [ 1,  1,  1,  1, -1,  1,  1,  1],  # ef
+    [-1, -1, -1, -1,  1,  1,  1,  1],  # f0
+    [ 1, -1, -1, -1,  1,  1,  1,  1],  # f1
+    [-1,  1, -1, -1,  1,  1,  1,  1],  # f2
+    [ 1,  1, -1, -1,  1,  1,  1,  1],  # f3
+    [-1, -1,  1, -1,  1,  1,  1,  1],  # f4
+    [ 1, -1,  1, -1,  1,  1,  1,  1],  # f5
+    [-1,  1,  1, -1,  1,  1,  1,  1],  # f6
+    [ 1,  1,  1, -1,  1,  1,  1,  1],  # f7
+    [-1, -1, -1,  1,  1,  1,  1,  1],  # f8
+    [ 1, -1, -1,  1,  1,  1,  1,  1],  # f9
+    [-1,  1, -1,  1,  1,  1,  1,  1],  # fa
+    [ 1,  1, -1,  1,  1,  1,  1,  1],  # fb
+    [-1, -1,  1,  1,  1,  1,  1,  1],  # fc
+    [ 1, -1,  1,  1,  1,  1,  1,  1],  # fd
+    [-1,  1,  1,  1,  1,  1,  1,  1],  # fe
+    [ 1,  1,  1,  1,  1,  1,  1,  1],  # ff
+]
+# fmt: on

--- a/sycamore/tests/unit/functions/test_rabin_karp.py
+++ b/sycamore/tests/unit/functions/test_rabin_karp.py
@@ -25,8 +25,7 @@ class TestRabinKarp:
         bb = RkHash(32)
         for ch in range(100, 132):
             bb.hashIn(ch)
-        bb.hashOut(100)
-        bb.hashIn(132)
+        bb.hashOutIn(100, 132)
 
         assert aa.get() == bb.get()
 

--- a/sycamore/tests/unit/functions/test_simhash.py
+++ b/sycamore/tests/unit/functions/test_simhash.py
@@ -12,20 +12,18 @@ class TestShingles:
     def test_order(self):
         s = "The quick brown fox jumps over the lazy dog"
         shingles = sh.shinglesCalc(s.encode("utf-8"))
-        for tab in shingles:
-            for ii in range(1, len(tab)):
-                assert tab[ii - 1] <= tab[ii]
+        for ii in range(1, len(shingles)):
+            assert shingles[ii - 1] <= shingles[ii]
 
     def test_nonzero(self):
         s = "The quick brown fox jumps over the lazy dog"
         shingles = sh.shinglesCalc(s.encode("utf-8"))
-        for tab in shingles:
-            assert min(tab) > 0  # zeros are almost always a bug
+        assert min(shingles) > 0  # zeros are almost always a bug
 
     def test_shingle_dist(self):
-        aa = [[1, 2, 3, 4]]
-        bb = [[1, 2, 4, 5]]
-        cc = [[5, 6, 7, 8]]
+        aa = [1, 2, 3, 4]
+        bb = [1, 2, 4, 5]
+        cc = [5, 6, 7, 8]
         assert sh.shinglesDist(aa, aa) == 0.0
         assert sh.shinglesDist(aa, bb) == 0.25
         assert sh.shinglesDist(aa, cc) == 1.0
@@ -53,8 +51,8 @@ class TestShingles:
         assert sh.shinglesDist(shingles[2], shingles[3]) > 0.9
 
     def test_sim(self):
-        tab = list(range(0x07, 0x16))
-        sim = sh.simHash(tab)
+        shingle = list(range(0x07, 0x16))
+        sim = sh.simHash(shingle)
         assert sim == 0x09
 
     def test_sim_dist(self):
@@ -64,10 +62,10 @@ class TestShingles:
         dd = [0x1000, 0x0002, 0x0040, 0x0000]
         ee = [0x0000, 0x0000, 0x0000, 0x0000]
         assert sh.simHashesDist(aa, aa) == 0
-        assert sh.simHashesDist(aa, bb) == 1
-        assert sh.simHashesDist(aa, cc) == 2
-        assert sh.simHashesDist(aa, dd) == 3
-        assert sh.simHashesDist(aa, ee) == 4
+        assert sh.simHashesDist(aa, bb) == 19 / 256
+        assert sh.simHashesDist(aa, cc) == 22 / 256
+        assert sh.simHashesDist(aa, dd) == 25 / 256
+        assert sh.simHashesDist(aa, ee) == 28 / 256
 
     def test_simhashes(self):
         simHashes = []
@@ -84,9 +82,9 @@ class TestShingles:
             assert sh.simHashesDist(simHashes[ii], simHashes[ii]) == 0.0
 
         # make sure examples measure as expected
-        assert sh.simHashesDist(simHashes[0], simHashes[1]) < 12
-        assert sh.simHashesDist(simHashes[0], simHashes[2]) < 12
-        assert sh.simHashesDist(simHashes[1], simHashes[2]) < 12
-        assert sh.simHashesDist(simHashes[0], simHashes[3]) > 18
-        assert sh.simHashesDist(simHashes[1], simHashes[3]) > 18
-        assert sh.simHashesDist(simHashes[2], simHashes[3]) > 18
+        assert sh.simHashesDist(simHashes[0], simHashes[1]) < 0.2
+        assert sh.simHashesDist(simHashes[0], simHashes[2]) < 0.2
+        assert sh.simHashesDist(simHashes[1], simHashes[2]) < 0.2
+        assert sh.simHashesDist(simHashes[0], simHashes[3]) > 0.5
+        assert sh.simHashesDist(simHashes[1], simHashes[3]) > 0.5
+        assert sh.simHashesDist(simHashes[2], simHashes[3]) > 0.5

--- a/sycamore/transforms/__init__.py
+++ b/sycamore/transforms/__init__.py
@@ -6,7 +6,7 @@ from sycamore.transforms.map import Map, FlatMap, MapBatch
 from sycamore.transforms.partition import Partition, Partitioner
 from sycamore.transforms.extract_table import TableExtractor
 from sycamore.transforms.regex_replace import COALESCE_WHITESPACE, RegexReplace
-from sycamore.transforms.sketcher import Sketcher, SketchUniquify
+from sycamore.transforms.sketcher import Sketcher, SketchUniquify, SketchDebug
 from sycamore.transforms.spread_properties import SpreadProperties
 from sycamore.transforms.summarize import Summarize
 from sycamore.transforms.bbox_merge import (
@@ -49,6 +49,7 @@ __all__ = [
     "RegexReplace",
     "Sketcher",
     "SketchUniquify",
+    "SketchDebug",
     "Summarize",
     "SortByPageBbox",
     "MarkBreakByColumn",

--- a/sycamore/transforms/sketcher.py
+++ b/sycamore/transforms/sketcher.py
@@ -1,11 +1,12 @@
 import sys
 import re
+import functools
 import unicodedata
 
 from ray.data import ActorPoolStrategy, Dataset
 
 from sycamore.data import Document
-from sycamore.functions.simhash import simHashText, simHashesDist
+from sycamore.functions.simhash import shinglesCalc, shinglesDist
 from sycamore.plan_nodes import Node, Transform, SingleThreadUser, NonGPUUser
 from sycamore.transforms.map import generate_map_function
 from sycamore.utils.generate_ray_func import generate_map_batch_filter_class_from_callable
@@ -28,19 +29,16 @@ def normalizeString(s: str) -> str:
 class Sketcher(SingleThreadUser, NonGPUUser, Transform):
     """
     For each Document, uses shingling to hash sliding windows of the
-    text_representation using various permutations.  Uses SimHash
-    to reduce each shingle to a similarity hash.  The set of SimHashes
-    is called the sketch.  Documents' sketches can be compared to
-    determine if they have near-duplicate content.  The SketchUniquify
-    transform can be used to de-duplicate small docsets in Sycamore.
-    De-duplicating at retrieval-time is more scalable and avoids some
-    relevance problems.
+    text_representation.  The set of shingles is called the sketch.
+    Documents' sketches can be compared to determine if they have
+    near-duplicate content.  The SketchUniquify transform can be used
+    to de-duplicate small docsets in Sycamore. De-duplicating at
+    retrieval-time is more scalable and avoids some relevance problems.
 
     Args:
         child: The source node or component that provides the documents
-        window: Number of bytes in the sliding window that is hashed (32)
-        courses: Number of hashes comprising a shingle (29, must be odd)
-        tabs: Number of permutation variants in each shingle (10)
+        window: Number of bytes in the sliding window that is hashed (17)
+        number: Count of hashes comprising a shingle (16)
 
     Example:
         .. code-block:: python
@@ -50,42 +48,40 @@ class Sketcher(SingleThreadUser, NonGPUUser, Transform):
             dataset = xform.execute()
     """
 
-    def __init__(self, child: Node, window: int = 32, courses: int = 29, tabs: int = 10, **kwargs):
+    def __init__(self, child: Node, window: int = 17, number: int = 16, **kwargs):
         super().__init__(child, **kwargs)
         self.window = window
-        self.courses = courses
-        self.tabs = tabs
+        self.number = number
 
     class Callable:
-        def __init__(self, window: int, courses: int, tabs: int):
+        def __init__(self, window: int, number: int):
             self.window = window
-            self.courses = courses
-            self.tabs = tabs
+            self.number = number
 
         def run(self, doc: Document) -> Document:
             txt = doc.text_representation
             if txt:
                 utf = normalizeString(txt).encode("utf-8")
-                doc.simHashes = simHashText(utf, self.window, self.courses, self.tabs)
+                doc.shingles = shinglesCalc(utf, self.window, self.number)
             return doc
 
     def execute(self) -> Dataset:
         dataset = self.child().execute()
-        xform = Sketcher.Callable(self.window, self.courses, self.tabs)
+        xform = Sketcher.Callable(self.window, self.number)
         return dataset.map(generate_map_function(xform.run))
 
 
 class SketchUniquify(SingleThreadUser, NonGPUUser, Transform):
     """
     Removes each Document which is a near-duplicate of a Document seen
-    before.  Uses the SimHash values calculated by the Sketcher transform.
+    before.  Uses the shingles calculated by the Sketcher transform.
     This approach requires full materialization of the entire docset on a
     single node.  It will store all sketches in memory.  It is not
     suitable for large docsets.
 
     Args:
         child: The source node or component that provides the documents
-        threshold: Largest distance to be considered a duplicate (14)
+        threshold: Largest distance to be considered a duplicate (0.4)
 
     Example:
         .. code-block:: python
@@ -95,7 +91,7 @@ class SketchUniquify(SingleThreadUser, NonGPUUser, Transform):
            dataset = xform.execute()
     """
 
-    def __init__(self, child: Node, threshold: int = 14, **kwargs) -> None:
+    def __init__(self, child: Node, threshold: float = 0.4, **kwargs) -> None:
         super().__init__(child, **kwargs)
         self.threshold = threshold
 
@@ -109,21 +105,100 @@ class SketchUniquify(SingleThreadUser, NonGPUUser, Transform):
 
         def good(self, doc: Document) -> bool:
             self.total += 1
-            docSims = doc.simHashes
-            if docSims:
-                for prevSims in self.seenSketches:
-                    dist = simHashesDist(docSims, prevSims)
+            docSketch = doc.shingles
+            if docSketch:
+                for prevSketch in self.seenSketches:
+                    dist = shinglesDist(docSketch, prevSketch)
                     if dist <= self.threshold:
                         self.drops += 1
                         print(f"SketchUniquify dropped {self.drops} of {self.total}", file=sys.stderr)
                         return False
-                self.seenSketches.append(docSims)
+                self.seenSketches.append(docSketch)
             return True
 
     def execute(self) -> Dataset:
         ds = self.child().execute()
         ds = ds.materialize()  # force previous to finish to free up memory
         pred = SketchUniquify.Predicate(self.threshold)
+
+        filter_class = generate_map_batch_filter_class_from_callable(pred.good)
+
+        # Size is 1 here to use a global view of previous sketches...
+        ds = ds.map_batches(filter_class, compute=ActorPoolStrategy(size=1))
+        ds = ds.materialize()  # force filter to finish before moving on
+        return ds
+
+
+class SketchDebug(SingleThreadUser, NonGPUUser, Transform):
+    """
+    Removes each Document which is a near-duplicate of a Document seen
+    before.  Prints out duplicate pairs and a histogram of distances.
+    Uses the shingles calculated by the Sketcher transform.
+    This approach requires full materialization of the entire docset on a
+    single node.  It will store all sketches in memory.  It is not
+    suitable for large docsets.
+
+    Args:
+        child: The source node or component that provides the documents
+        threshold: Largest distance to be considered a duplicate (0.4)
+
+    Example:
+        .. code-block:: python
+
+           node = ...  # source node
+           xform = SketchUniquify(child=node)
+           dataset = xform.execute()
+    """
+
+    def __init__(self, child: Node, threshold: float = 0.4, **kwargs) -> None:
+        super().__init__(child, **kwargs)
+        self.threshold = threshold
+
+    class Predicate:
+        def __init__(self, threshold: float) -> None:
+            self.threshold = threshold
+            self.total = 0
+            self.drops = 0
+            # This is a significant amount of memory...
+            self.seenSketches: list[list[int]] = []
+            self.seenText: list[str] = []
+            self.seenLoc: list[str] = []
+            self.hist: dict[int, int] = {}
+
+        def good(self, doc: Document) -> bool:
+            self.total += 1
+            docSketch = doc.shingles
+            docText = str(doc.text_representation)
+            docLoc = "%s:%s" % (doc.properties.get("path", "NoPath"), doc.properties.get("page_number", "NoPage"))
+            if docSketch:
+                for ii, prevSketch in enumerate(self.seenSketches):
+                    dist = shinglesDist(docSketch, prevSketch)
+                    dpct = int(dist * 100.0)
+                    self.hist[dpct] = 1 + self.hist.get(dpct, 0)
+                    if dist <= self.threshold:
+                        self.drops += 1
+                        print(f"SketchDebug dropped {self.drops} of {self.total}", file=sys.stderr)
+                        seenText = self.seenText[ii]
+                        seenLoc = self.seenLoc[ii]
+                        print("DIST", dist, file=sys.stderr)
+                        print("PREV", seenLoc, seenText, file=sys.stderr)
+                        print("CURR", docLoc, docText, file=sys.stderr)
+                        print(
+                            functools.reduce(
+                                lambda s, k: s + "%d=%d " % (k, self.hist[k]), sorted(self.hist.keys()), ""
+                            ),
+                            file=sys.stderr,
+                        )
+                        return False
+                self.seenSketches.append(docSketch)
+                self.seenText.append(docText)
+                self.seenLoc.append(docLoc)
+            return True
+
+    def execute(self) -> Dataset:
+        ds = self.child().execute()
+        ds = ds.materialize()  # force previous to finish to free up memory
+        pred = SketchDebug.Predicate(self.threshold)
 
         filter_class = generate_map_batch_filter_class_from_callable(pred.good)
 

--- a/sycamore/writers/opensearch.py
+++ b/sycamore/writers/opensearch.py
@@ -72,6 +72,7 @@ class OSDataSource(Datasource):
             "parent_id": None,
             "properties": {},
             "bbox": None,
+            "shingles": None,
         }
         for k, v in default.items():
             if k in data:


### PR DESCRIPTION
No longer using SimHash by default, but code is still available.  Shingles are now one-dimensional.  Speed is improved.  Accuracy is better, without bizarre false positives.  SketchDebug added to show actual de-duped pairs.  Parameter space is reduced from 4 to 3 dimensions and defaults are tuned for the current state of the algorithm.  Overall, this looks like a substantial improvement.