### PR TITLE
Quickstart: use SSL for all network communication: OpenSearch and Jupyter

### DIFF
--- a/crawler/http/Dockerfile
+++ b/crawler/http/Dockerfile
@@ -1,5 +1,6 @@
 # Repo name: arynai/sycamore-crawler-http
 
+# Match Python version UI uses.  PyTorch not compatible with 3.12 yet.
 FROM python:3.11
 
 WORKDIR /app

--- a/crawler/http/Dockerfile
+++ b/crawler/http/Dockerfile
@@ -1,6 +1,6 @@
 # Repo name: arynai/sycamore-crawler-http
 
-FROM python:3
+FROM python:3.11
 
 WORKDIR /app
 RUN pip install poetry

--- a/crawler/s3/Dockerfile
+++ b/crawler/s3/Dockerfile
@@ -3,6 +3,8 @@
 # In the root directory:
 # docker build -t sycamore_crawler_s3 -f crawler/s3/Dockerfile
 # docker run -it -v crawl_data:/app/.data/.s3 -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN sycamore_crawler_s3
+
+# Match Python version UI uses.  PyTorch not compatible with 3.12 yet.
 FROM python:3.11
 
 WORKDIR /app

--- a/crawler/s3/Dockerfile
+++ b/crawler/s3/Dockerfile
@@ -3,7 +3,7 @@
 # In the root directory:
 # docker build -t sycamore_crawler_s3 -f crawler/s3/Dockerfile
 # docker run -it -v crawl_data:/app/.data/.s3 -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN sycamore_crawler_s3
-FROM python:3
+FROM python:3.11
 
 WORKDIR /app
 

--- a/docs/source/data_ingestion_and_preparation/running_a_data_preparation_job.md
+++ b/docs/source/data_ingestion_and_preparation/running_a_data_preparation_job.md
@@ -49,7 +49,7 @@ os_client_args = {
         "hosts": [{"host": "opensearch", "port": 9200}],
         "http_compress": True,
         "http_auth": ("admin", "admin"),
-        "use_ssl": False,
+        "use_ssl": True,
         "verify_certs": False,
         "ssl_assert_hostname": False,
         "ssl_show_warn": False,

--- a/docs/source/tutorials/conversational_memory_with_langchain.md
+++ b/docs/source/tutorials/conversational_memory_with_langchain.md
@@ -85,7 +85,7 @@ We can construct one like this:
 opensearch_client = OpenSearch(
 	hosts = [{'host': 'localhost', 'port': 9200}],
     http_compress = True, # enables gzip compression for request bodies
-    use_ssl = False,
+    use_ssl = True,
     verify_certs = False,
     ssl_assert_hostname = False,
     ssl_show_warn = False
@@ -237,7 +237,7 @@ prompt = PromptTemplate(
 opensearch_client = OpenSearch(
     hosts = [{'host': 'localhost', 'port': 9200}],
     http_compress = True, # enables gzip compression for request bodies
-    use_ssl = False,
+    use_ssl = True,
     verify_certs = False,
     ssl_assert_hostname = False,
     ssl_show_warn = False

--- a/docs/source/tutorials/sycamore-jupyter-dev-example.md
+++ b/docs/source/tutorials/sycamore-jupyter-dev-example.md
@@ -202,7 +202,7 @@ os_client_args = {
         "hosts": [{"host": "opensearch", "port": 9200}],
         "http_compress": True,
         "http_auth": ("admin", "admin"),
-        "use_ssl": False,
+        "use_ssl": True,
         "verify_certs": False,
         "ssl_assert_hostname": False,
         "ssl_show_warn": False,

--- a/examples/simple_config.py
+++ b/examples/simple_config.py
@@ -27,7 +27,7 @@ osrch_args = {
     "hosts": [{"host": "localhost", "port": 9200}],
     "http_compress": True,
     "http_auth": ("admin", "admin"),
-    "use_ssl": False,
+    "use_ssl": True,
     "verify_certs": False,
     "ssl_assert_hostname": False,
     "ssl_show_warn": False,

--- a/importer/docker_local_import.py
+++ b/importer/docker_local_import.py
@@ -374,7 +374,7 @@ def get_os_client_args():
         "hosts": [{"host": "localhost", "port": 9200}],
         "http_compress": True,
         "http_auth": ("admin", "admin"),
-        "use_ssl": False,
+        "use_ssl": True,
         "verify_certs": False,
         "ssl_assert_hostname": False,
         "ssl_show_warn": False,

--- a/importer/docker_local_import.py
+++ b/importer/docker_local_import.py
@@ -374,7 +374,7 @@ def get_os_client_args():
         "http_compress": True,
         "http_auth": ("admin", "admin"),
         "use_ssl": True,
-        "verify_certs": False,
+        "verify_certs": False,  # because we're using self-signed certificates
         "ssl_assert_hostname": False,
         "ssl_show_warn": False,
         "timeout": 120,

--- a/importer/docker_local_import.py
+++ b/importer/docker_local_import.py
@@ -244,11 +244,11 @@ def import_files(root, files):
 
 def wait_for_opensearch_ready():
     print("Waiting for opensearch to become ready...", end="")
-    # magic port number needs to match the status port from the aryn-opensearch.sh docker script
     while True:
         try:
-            r = requests.get("http://opensearch:43477/statusz")
-            if r.status_code == 200 and r.text == "OK\n":
+            r = requests.get("https://opensearch:9200/_cluster/settings",
+                             verify=False)
+            if r.status_code == 200 and "aryn_deploy_complete" in r.text:
                 print("Ready")
                 return True
             else:

--- a/importer/docker_local_import.py
+++ b/importer/docker_local_import.py
@@ -246,8 +246,7 @@ def wait_for_opensearch_ready():
     print("Waiting for opensearch to become ready...", end="")
     while True:
         try:
-            r = requests.get("https://opensearch:9200/_cluster/settings",
-                             verify=False)
+            r = requests.get("https://opensearch:9200/_cluster/settings", verify=False)
             if r.status_code == 200 and "aryn_deploy_complete" in r.text:
                 print("Ready")
                 return True

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -18,8 +18,8 @@ RUN mkdir -p /app/work/docker_volume /app/work/bind_dir /app/work/examples
 RUN touch /app/work/AAA_SEE_README_FOR_PERSISTENT_DATA_DIRECTORIES
 COPY jupyter/run-jupyter.sh ./
 COPY jupyter/README.md ./work
-COPY sycamore_local_dev_example.ipynb ./work/examples
-RUN perl -i -pe 's/localhost/opensearch/ if /9200/;s,tmp/sycamore/data,/app/work/docker_volume,' /app/work/examples/sycamore_local_dev_example.ipynb
+COPY notebooks/jupyter_dev_example.ipynb ./work/examples
+RUN perl -i -pe 's/localhost/opensearch/ if /9200/;s,tmp/sycamore/data,/app/work/docker_volume,' /app/work/examples/jupyter_dev_example.ipynb
 
 ARG GIT_BRANCH="unknown"
 ARG GIT_COMMIT="unknown"

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -5,12 +5,13 @@ FROM arynai/sycamore-importer:$TAG
 
 # TODO: eric - remove this once we switch other containers over to non-root
 # Note user/group should be 1000 to match with likely defaults on hosts.
+USER root
 COPY jupyter/docker-root-setup.sh /root
 RUN /bin/bash /root/docker-root-setup.sh
 COPY jupyter/sudoers /etc/sudoers
 COPY jupyter/fixuser.py /root/fixuser.py
 
-USER 1000
+USER app
 RUN poetry run pip install notebook ipywidgets 'opensearch-py>=2.4' && rm -rf /app/.cache
 RUN mkdir -p /app/work/docker_volume /app/work/bind_dir /app/work/examples
 RUN touch /app/work/AAA_SEE_README_FOR_PERSISTENT_DATA_DIRECTORIES

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -11,6 +11,7 @@ RUN /bin/bash /root/docker-root-setup.sh
 COPY jupyter/sudoers /etc/sudoers
 COPY jupyter/fixuser.py /root/fixuser.py
 
+# User 'app' must be id number 1000 (the default) for all to work properly.
 USER app
 RUN poetry run pip install notebook ipywidgets 'opensearch-py>=2.4' && rm -rf /app/.cache
 RUN mkdir -p /app/work/docker_volume /app/work/bind_dir /app/work/examples

--- a/jupyter/run-jupyter.sh
+++ b/jupyter/run-jupyter.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+die() {
+    echo "ERROR: " "$@" >&2
+    exit 1
+}
+
 mkdir -p $HOME/.jupyter
 JUPYTER_CONFIG_DOCKER=/app/work/docker_volume/jupyter_notebook_config.py
 
@@ -18,12 +24,13 @@ rm /app/.local/share/jupyter/runtime/jpserver-*-open.html 2>/dev/null
 
 : ${HOST:=localhost}
 SSLPFX="/app/work/docker_volume/${HOST}"
+SSLLOG="/app/work/docker_volume/openssl.err"
 if [[ (! -f ${SSLPFX}-key.pem) || (! -f ${SSLPFX}-cert.pem) ]]; then
     openssl req -batch -x509 -newkey rsa:4096 -days 10000 \
     -subj "/C=US/ST=California/O=Aryn.ai/CN=${HOST}" \
     -extensions v3_req -addext "subjectAltName=DNS:${HOST}" \
     -noenc -keyout "${SSLPFX}-key.pem" -out "${SSLPFX}-cert.pem" \
-    2> /dev/null
+    2>> "${SSLLOG}" || die "Failed to create ${HOST} certificate"
     echo "Created ${HOST} certificate"
 fi
 

--- a/jupyter/run-jupyter.sh
+++ b/jupyter/run-jupyter.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 die() {
-    echo "ERROR: " "$@" >&2
+    echo "ERROR:" "$@" >&2
     exit 1
 }
 
@@ -52,7 +52,7 @@ fi
     perl -ne 's,https://\S+:8888/tree,https://localhost:8888/tree,;print' < "${FILE}" >"${REDIRECT}"
     URL=$(perl -ne 'print $1 if m,url=(https://localhost:8888/tree\S+)",;' <"${REDIRECT}")
 
-    for i in $(seq 10); do
+    for i in {1..10}; do
         echo
         echo
         echo

--- a/notebooks/default-prep-script.ipynb
+++ b/notebooks/default-prep-script.ipynb
@@ -55,7 +55,7 @@
     "        \"hosts\": [{\"host\": \"opensearch\", \"port\": 9200}],\n",
     "        \"http_compress\": True,\n",
     "        \"http_auth\": (\"admin\", \"admin\"),\n",
-    "        \"use_ssl\": False,\n",
+    "        \"use_ssl\": True,\n",
     "        \"verify_certs\": False,\n",
     "        \"ssl_assert_hostname\": False,\n",
     "        \"ssl_show_warn\": False,\n",

--- a/notebooks/jupyter_dev_example.ipynb
+++ b/notebooks/jupyter_dev_example.ipynb
@@ -245,7 +245,7 @@
     "        \"hosts\": [{\"host\": \"localhost\", \"port\": 9200}],\n",
     "        \"http_compress\": True,\n",
     "        \"http_auth\": (\"admin\", \"admin\"),\n",
-    "        \"use_ssl\": False,\n",
+    "        \"use_ssl\": True,\n",
     "        \"verify_certs\": False,\n",
     "        \"ssl_assert_hostname\": False,\n",
     "        \"ssl_show_warn\": False,\n",

--- a/opensearch/Dockerfile
+++ b/opensearch/Dockerfile
@@ -2,6 +2,11 @@
 
 ARG TAG=2.11.0
 FROM opensearchproject/opensearch:$TAG
+
+USER root
+RUN yum install -yq openssl jq && yum clean all
+USER opensearch
+
 COPY opensearch/opensearch.yml /usr/share/opensearch/config/
 COPY opensearch/config.yml opensearch/roles_mapping.yml \
      /usr/share/opensearch/config/opensearch-security/
@@ -25,8 +30,7 @@ LABEL git_commit=${GIT_COMMIT}
 LABEL git_diff=${GIT_DIFF}
 
 USER root
-RUN yum install -yq openssl jq && yum clean all
-RUN chown 1000:1000 \
+RUN chown opensearch:opensearch \
     /usr/share/opensearch/sycamore-opensearch.sh \
     /usr/share/opensearch/config/*.yml
 RUN chmod 600 /usr/share/opensearch/config/*.yml

--- a/opensearch/Dockerfile
+++ b/opensearch/Dockerfile
@@ -2,13 +2,13 @@
 
 ARG TAG=2.11.0
 FROM opensearchproject/opensearch:$TAG
-USER 0
-RUN yum install -y jq && yum clean all
-USER 1000
 COPY opensearch/opensearch.yml /usr/share/opensearch/config/
-COPY opensearch/sycamore-opensearch.sh .
+COPY opensearch/config.yml opensearch/roles_mapping.yml \
+     /usr/share/opensearch/config/opensearch-security/
+COPY opensearch/sycamore-opensearch.sh /usr/share/opensearch/
+COPY opensearch/Dockerfile /
+
 ENV discovery.type=single-node
-ENV DISABLE_SECURITY_PLUGIN=true
 ENV DISABLE_INSTALL_DEMO_CONFIG=true
 
 ARG GIT_BRANCH="main"
@@ -24,4 +24,12 @@ LABEL git_branch=${GIT_BRANCH}
 LABEL git_commit=${GIT_COMMIT}
 LABEL git_diff=${GIT_DIFF}
 
-CMD ./sycamore-opensearch.sh
+USER root
+RUN yum install -yq openssl jq && yum clean all
+RUN chown 1000:1000 \
+    /usr/share/opensearch/sycamore-opensearch.sh \
+    /usr/share/opensearch/config/*.yml
+RUN chmod 600 /usr/share/opensearch/config/*.yml
+USER opensearch
+
+ENTRYPOINT ["/usr/share/opensearch/sycamore-opensearch.sh"]

--- a/opensearch/Dockerfile
+++ b/opensearch/Dockerfile
@@ -29,6 +29,7 @@ LABEL git_branch=${GIT_BRANCH}
 LABEL git_commit=${GIT_COMMIT}
 LABEL git_diff=${GIT_DIFF}
 
+# OpenSearch complains if these files have permissive modes.
 USER root
 RUN chown opensearch:opensearch \
     /usr/share/opensearch/sycamore-opensearch.sh \

--- a/opensearch/config.yml
+++ b/opensearch/config.yml
@@ -1,0 +1,8 @@
+_meta:
+  type: config
+  config_version: 2
+
+config:
+  dynamic:
+    http:
+      anonymous_auth_enabled: true

--- a/opensearch/config.yml
+++ b/opensearch/config.yml
@@ -2,6 +2,8 @@ _meta:
   type: config
   config_version: 2
 
+# Automatically authenticate clients without credentials as
+# 'opendistro_security_anonymous_backendrole'.
 config:
   dynamic:
     http:

--- a/opensearch/opensearch.yml
+++ b/opensearch/opensearch.yml
@@ -3,3 +3,13 @@ http.cors.enabled : true
 http.cors.allow-origin: "*"
 http.cors.allow-methods: OPTIONS,HEAD,GET,POST,PUT,DELETE
 http.cors.allow-headers: X-Requested-With,X-Auth-Token,Content-Type,Content-Length
+plugins.security.ssl.transport.enforce_hostname_verification: false
+plugins.security.ssl.transport.pemcert_filepath: node-cert.pem
+plugins.security.ssl.transport.pemkey_filepath: node-key.pem
+plugins.security.ssl.transport.pemtrustedcas_filepath: cacert.pem
+plugins.security.ssl.http.enabled: true
+plugins.security.ssl.http.pemcert_filepath: node-cert.pem
+plugins.security.ssl.http.pemkey_filepath: node-key.pem
+plugins.security.ssl.http.pemtrustedcas_filepath: cacert.pem
+plugins.security.authcz.admin_dn:
+  - 'CN=Admin,O=Aryn.ai,ST=California,C=US'

--- a/opensearch/opensearch.yml
+++ b/opensearch/opensearch.yml
@@ -3,6 +3,7 @@ http.cors.enabled : true
 http.cors.allow-origin: "*"
 http.cors.allow-methods: OPTIONS,HEAD,GET,POST,PUT,DELETE
 http.cors.allow-headers: X-Requested-With,X-Auth-Token,Content-Type,Content-Length
+# We are using self-signed certificates for now, so...
 plugins.security.ssl.transport.enforce_hostname_verification: false
 plugins.security.ssl.transport.pemcert_filepath: node-cert.pem
 plugins.security.ssl.transport.pemkey_filepath: node-key.pem

--- a/opensearch/roles_mapping.yml
+++ b/opensearch/roles_mapping.yml
@@ -1,0 +1,7 @@
+_meta:
+  type: rolesmapping
+  config_version: 2
+
+all_access:
+  backend_roles:
+  - opendistro_security_anonymous_backendrole

--- a/opensearch/sycamore-opensearch.sh
+++ b/opensearch/sycamore-opensearch.sh
@@ -37,8 +37,8 @@ main() {
 
     setup_transient
 
-    # Semaphore to signal completion.  This is transient and will go away
-    # after restart, which matches the longevity of model deployment.
+    # Semaphore to signal completion.  This must be transient, to go away
+    # after restart, matching the longevity of model deployment.
     _curl -X PUT "${BASE_URL}/_cluster/settings" -o /dev/null --json \
     '{"transient":{"cluster":{"metadata":{"aryn_deploy_complete":1}}}}'
 
@@ -74,7 +74,7 @@ wait_or_die() {
 }
 
 die() {
-    echo "ERROR: " "$@" 1>&2
+    echo "ERROR:" "$@" 1>&2
     exit 1
 }
 
@@ -96,7 +96,7 @@ opensearch_up_ssl() {
 
 opensearch_up_net() {
     # This checks for any activity at the host:port.  No error (zero return)
-    # is obviously good, but 52 meaning empty response is also indicative.
+    # is obviously good, but 52, meaning empty response, is also indicative.
     _curl http://localhost:9200/ -o /dev/null
     [[ ($? != 0) && ($? != 52) ]] && return 1
     return 0
@@ -104,6 +104,7 @@ opensearch_up_net() {
 
 _curl() {
     # Warning: some error output is suppressed by --silent
+    # We use --insecure due to self-signed certificates
     /usr/bin/curl --insecure --silent "$@"
 }
 

--- a/opensearch/sycamore-opensearch.sh
+++ b/opensearch/sycamore-opensearch.sh
@@ -37,7 +37,8 @@ main() {
 
     setup_transient
 
-    # Semaphore to signal completion, until next restart
+    # Semaphore to signal completion.  This is transient and will go away
+    # after restart, which matches the longevity of model deployment.
     _curl -X PUT "${BASE_URL}/_cluster/settings" -o /dev/null --json \
     '{"transient":{"cluster":{"metadata":{"aryn_deploy_complete":1}}}}'
 
@@ -497,7 +498,7 @@ setup_security() {
     -cd config/opensearch-security -icl -nhnv -cacert config/cacert.pem \
     -cert config/admin-cert.pem -key config/admin-key.pem
 
-    # Semaphore to signal completion
+    # Semaphore for SSL setup.  Useful for debugging and other scripts.
     _curl -X PUT "${BASE_URL}/_cluster/settings" -o /dev/null --json \
     '{"persistent":{"cluster":{"metadata":{"aryn_ssl_setup_complete":1}}}}'
 }


### PR DESCRIPTION
Using self-generated, self-signed certificates.  No longer using mini HTTP server for signaling; using OpenSearch cluster metadata instead.