### PR TITLE
Upgrade test workflow to os 2.10

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -46,7 +46,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
     services:
       opensearch:
-        image: opensearchproject/opensearch:2.11.0
+        image: opensearchproject/opensearch:2.10.0
         env:
           discovery.type: "single-node"
         ports:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -46,7 +46,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
     services:
       opensearch:
-        image: opensearchproject/opensearch:2.9.0
+        image: opensearchproject/opensearch:2.11.0
         env:
           discovery.type: "single-node"
         ports:

--- a/notebooks/metadata-extraction.ipynb
+++ b/notebooks/metadata-extraction.ipynb
@@ -69,6 +69,7 @@
    "source": [
     "docset = (\n",
     "    ctx.read.binary(s3_path, parallelism=4, binary_format=\"pdf\")\n",
+    "    .limit(1) # limit this for testing performance\n",
     "    .partition(partitioner=UnstructuredPdfPartitioner(min_partition_length=200))\n",
     "    )"
    ]

--- a/sycamore/tests/integration/query/test_query_opensearch.py
+++ b/sycamore/tests/integration/query/test_query_opensearch.py
@@ -68,7 +68,7 @@ class TestQueryOpenSearch:
     def test_single_query(self):
         query_executor = OpenSearchQueryExecutor(self.OS_CLIENT_ARGS)
         query = OpenSearchQuery()
-        query.query = {"query": {"match_all": {}}, "size": 2}
+        query.query = {"query": {"match_all": {}}, "size": 1}
         query.index = self.INDEX
         result = query_executor.query(query)
         assert len(result.hits) > 0


### PR DESCRIPTION
Current default OS 2.9 is old and doesn't have hybrid search. 2.11 seems to have an http client issue which requires some additional config, but 2.12 seems to go back to 2.9 behavior. Keeping it 2.10 until we go to 2.12