### PR TITLE
Improve recall metrics

### DIFF
--- a/sycamore/evaluation/datasets.py
+++ b/sycamore/evaluation/datasets.py
@@ -1,15 +1,19 @@
-from typing import Union, Optional, Callable
+from typing import Union, Optional, Callable, Any
 
 from datasets import IterableDataset
 from ray.data import Dataset, from_huggingface
 
+from sycamore.evaluation import EvaluationDataPoint
 from sycamore import DocSet, Context
 from sycamore.scans import MaterializedScan
 
 
 class HuggingFaceScan(MaterializedScan):
     def __init__(
-        self, dataset: Union[Dataset, IterableDataset], doc_extractor: Optional[Callable] = None, **resource_args
+        self,
+        dataset: Union[Dataset, IterableDataset],
+        doc_extractor: Callable[[dict[str, Any]], dict[str, EvaluationDataPoint]],
+        **resource_args
     ):
         super().__init__(**resource_args)
         self._dataset = dataset
@@ -30,7 +34,10 @@ class EvaluationDataSetReader:
         self._context = context
 
     def huggingface(
-        self, dataset: Union[Dataset, IterableDataset], doc_extractor: Optional[Callable] = None, **resource_args
+        self,
+        dataset: Union[Dataset, IterableDataset],
+        doc_extractor: Callable[[dict[str, Any]], dict[str, EvaluationDataPoint]],
+        **resource_args
     ) -> DocSet:
         json_scan = HuggingFaceScan(dataset=dataset, doc_extractor=doc_extractor, **resource_args)
         return DocSet(self._context, json_scan)

--- a/sycamore/evaluation/datasets.py
+++ b/sycamore/evaluation/datasets.py
@@ -1,4 +1,4 @@
-from typing import Union, Optional, Callable, Any
+from typing import Union, Callable, Any
 
 from datasets import IterableDataset
 from ray.data import Dataset, from_huggingface

--- a/sycamore/evaluation/metrics.py
+++ b/sycamore/evaluation/metrics.py
@@ -23,10 +23,10 @@ class EvaluationMetric:
 
 
 class DocumentRetrievalMetrics(EvaluationMetric):
-    def __init__(self, recall_k: int = 10, match_any_page: bool = True) -> None:
+    def __init__(self, recall_k: int = 10, enforce_full_uri: bool = False) -> None:
         super().__init__()
         self._recall_k = recall_k
-        self._match_any_page = match_any_page
+        self._enforce_full_uri = enforce_full_uri
 
     def metric_name(self) -> str:
         return "DocumentRetrievalMetrics"
@@ -34,38 +34,56 @@ class DocumentRetrievalMetrics(EvaluationMetric):
     def evaluate(self, datapoint: EvaluationDataPoint) -> dict[str, Any]:
         result: dict[str, float] = {}
         correct_doc_count = 0
+        partial_correct_page_count = 0
         correct_page_count = 0
         doc_mrr_sum = 0.0
         page_mrr_sum = 0.0
+        partial_page_mrr_sum = 0.0
         logger.debug("Processing datapoint: " + str(datapoint))
 
         # we only support 1 source document currently
         for ground_truth_document in datapoint.ground_truth_source_documents[:1]:
             for i, document in enumerate(datapoint.generated_source_documents[: self._recall_k]):
-                # only use filename currently, can enforce full url here if required
-                doc_path = Path(document.properties["_location"]).name
-                ground_truth_path = Path(ground_truth_document.properties["_location"]).name
-                ground_truth_page_number = ground_truth_document.properties["page_number"]
+                doc_path = (
+                    document.properties["_location"]
+                    if self._enforce_full_uri
+                    else Path(document.properties["_location"]).name
+                )
+                ground_truth_path = (
+                    ground_truth_document.properties["_location"]
+                    if self._enforce_full_uri
+                    else Path(ground_truth_document.properties["_location"]).name
+                )
+
+                ground_truth_page_number = ground_truth_document.properties.get("page_number", -1)
+                ground_truth_page_numbers = set(
+                    ground_truth_document.properties.get("page_numbers", [ground_truth_page_number])
+                )
+                retrieved_page_number = document.properties.get("page_number", -1)
+                retrieved_page_numbers = set(document.properties.get("page_numbers", [retrieved_page_number]))
 
                 if doc_path == ground_truth_path:
                     result["correct_position"] = result.get("correct_position", i + 1)
                     doc_mrr_sum += 1.0 / (i + 1.0)
                     correct_doc_count += 1
-                    in_page_numbers = self._match_any_page and ground_truth_page_number in document.properties.get(
-                        "page_numbers", {}
-                    )
-                    if (
-                        in_page_numbers
-                        or document.properties.get("page_number", -1) == ground_truth_document.properties["page_number"]
-                    ):
+
+                    if ground_truth_page_numbers.issubset(retrieved_page_numbers):
+                        correct_page_count += 1
                         result["correct_page_position"] = result.get("correct_page_position", i + 1)
                         page_mrr_sum += 1.0 / (i + 1.0)
-                        correct_page_count += 1
+
+                    # any page matches
+                    if len(retrieved_page_numbers.intersection(ground_truth_page_numbers)) > 0:
+                        partial_correct_page_count += 1
+                        result["partial_correct_page_position"] = result.get("partial_correct_page_position", i + 1)
+                        partial_page_mrr_sum += 1.0 / (i + 1.0)
 
         result["doc_recall"] = 1.0 if correct_doc_count > 0 else 0.0
         result["page_recall"] = 1.0 if correct_page_count > 0 else 0.0
+        result["partial_page_recall"] = 1.0 if partial_correct_page_count > 0 else 0.0
         result["doc_mrr"] = min(1.0, doc_mrr_sum / len(datapoint.ground_truth_source_documents))
         result["page_mrr"] = min(1.0, page_mrr_sum / len(datapoint.ground_truth_source_documents))
+        result["partial_page_mrr"] = min(1.0, partial_page_mrr_sum / len(datapoint.ground_truth_source_documents))
         return result
 
 

--- a/sycamore/tests/integration/evaluation/test_pipeline.py
+++ b/sycamore/tests/integration/evaluation/test_pipeline.py
@@ -1,21 +1,43 @@
+from typing import Any
+
 import datasets
 import pytest
 
 import sycamore
+from sycamore.data import Element
+from sycamore.evaluation import EvaluationDataPoint
 from sycamore.evaluation import document_retrieval_metrics, generated_answer_metrics
 from sycamore.evaluation.datasets import EvaluationDataSetReader
 from sycamore.evaluation.pipeline import EvaluationPipeline
 from sycamore.transforms.query import OpenSearchQueryExecutor
 
 
+def _hf_to_qa_datapoint(data: dict[str, Any]) -> dict[str, Any]:
+    mapping = {
+        "question": "question",
+        "ground_truth_answer": "answer",
+        "_location": "doc_link",
+        "page_number": "page_number",
+    }
+    document = EvaluationDataPoint()
+    for k, v in mapping.items():
+        document[k] = data[v]
+
+    document.ground_truth_source_documents = [
+        Element({"properties": {"_location": data[mapping["_location"]], "page_number": data[mapping["page_number"]]}})
+    ]
+    document["raw"] = data
+    return {"doc": document.serialize()}
+
+
 class TestEvaluationPipeline:
-    INDEX = "toyindex"
+    INDEX = "test1"
 
     OS_CLIENT_ARGS = {
         "hosts": [{"host": "localhost", "port": 9200}],
         "http_compress": True,
         "http_auth": ("admin", "admin"),
-        "use_ssl": True,
+        "use_ssl": False,
         "verify_certs": False,
         "ssl_assert_hostname": False,
         "ssl_show_warn": False,
@@ -25,7 +47,7 @@ class TestEvaluationPipeline:
     OS_CONFIG = {
         "size": 10,
         "neural_search_k": 100,
-        "embedding_model_id": "pZabXI0BwnxcM6YnF2QF",
+        "embedding_model_id": "yrJIzY0BAL0TXCC7hRwd",
         "search_pipeline": "hybrid_rag_pipeline",
         "llm": "gpt-3.5-turbo",
         "context_window": "5",
@@ -35,16 +57,15 @@ class TestEvaluationPipeline:
     def test_hf(self):
         context = sycamore.init()
         reader = EvaluationDataSetReader(context)
-        mapping = {"question": "question", "ground_truth_answer": "answer", "ground_truth_document_url": "doc_link"}
         hf_dataset = datasets.load_dataset("PatronusAI/financebench", split=datasets.Split.TRAIN)
-        input_docset = reader.huggingface(hf_dataset, field_mapping=mapping)
+        input_docset = reader.huggingface(hf_dataset, doc_extractor=_hf_to_qa_datapoint)
 
         pipeline = EvaluationPipeline(
-            context,
-            [document_retrieval_metrics, generated_answer_metrics],
             index=self.INDEX,
-            query_executor=OpenSearchQueryExecutor(self.OS_CLIENT_ARGS),
             os_config=self.OS_CONFIG,
+            metrics=[document_retrieval_metrics, generated_answer_metrics],
+            query_executor=OpenSearchQueryExecutor(self.OS_CLIENT_ARGS),
         )
         query_level_metrics, aggregated_metrics = pipeline.execute(input_docset.limit(2))
-        query_level_metrics.show()
+        taken = query_level_metrics.take()
+        print(taken)

--- a/sycamore/transforms/query.py
+++ b/sycamore/transforms/query.py
@@ -28,7 +28,7 @@ class OpenSearchQueryExecutor(QueryExecutor):
         self._os_client_args = os_client_args
 
     def query(self, query: OpenSearchQuery) -> OpenSearchQueryResult:
-        logger.info("Executing OS query: " + str(query["query"]))
+        logger.debug("Executing OS query: " + str(query))
         client = OpenSearch(**self._os_client_args)
 
         os_result = client.transport.perform_request(

--- a/sycamore/transforms/query.py
+++ b/sycamore/transforms/query.py
@@ -29,7 +29,6 @@ class OpenSearchQueryExecutor(QueryExecutor):
 
     def query(self, query: OpenSearchQuery) -> OpenSearchQueryResult:
         logger.info("Executing OS query: " + str(query["query"]))
-        # logger.info("Executing OS query: " + str(query))
         client = OpenSearch(**self._os_client_args)
 
         os_result = client.transport.perform_request(
@@ -39,7 +38,6 @@ class OpenSearchQueryExecutor(QueryExecutor):
             headers=query.get("headers", None),
             body=query["query"],
         )
-        time.sleep(2)
         result = OpenSearchQueryResult(query)
         result.result = os_result
         result.hits = [Element(hit["_source"]) for hit in os_result["hits"]["hits"]]
@@ -59,5 +57,5 @@ class Query(NonCPUUser, NonGPUUser, Transform):
 
     def execute(self) -> Dataset:
         input_ds = self.child().execute()
-        output_ds = input_ds.map(generate_map_function(self._query_executor.query), num_cpus=1, concurrency=1)
+        output_ds = input_ds.map(generate_map_function(self._query_executor.query))
         return output_ds

--- a/sycamore/transforms/query.py
+++ b/sycamore/transforms/query.py
@@ -1,4 +1,3 @@
-import time
 from abc import abstractmethod, ABC
 from typing import Any
 


### PR DESCRIPTION
This change let's you handle input datapoints where there are multiple page numbers. It returns 2 types of page_recall metrics, 1 where all pages are retrieved, and 1 where there is partial success.