### PR TITLE
Increase default model deployment stability

### DIFF
--- a/opensearch/sycamore-opensearch.sh
+++ b/opensearch/sycamore-opensearch.sh
@@ -101,6 +101,10 @@ debug() { # <msg> <file>
     fi
 }
 
+info() {
+    echo "INFO $@" >&2
+}
+
 opensearch_up_insecure() {
     local out=$(_curl http://localhost:9200/)
     [[ -z ${out} ]] && return 1
@@ -383,12 +387,17 @@ deploy_model() {
     [[ -z "${task_id}" ]] && die "ERROR missing task_id"
     [[ -z "${name}" ]] && die "ERROR missing name"
 
+    if model_is_deployed "${EMBEDDING_MODEL_ID}"; then
+        info "Model $1 for $3 already deployed"
+        return 0
+    fi
+
     if [[ -z "${model_id}" ]]; then
         wait_task "${task_id}" "$name model to become ready"
         model_id="${GET_TASK_MODEL_ID}"
-        echo "Fetched $name model id $model_id for task_id $task_id" >&2
+        info "Fetched $name model id $model_id for task_id $task_id"
     else
-        echo "Using existing model id ${model_id}" >&2
+        info "Using existing model id ${model_id}"
     fi
 
     # Create deploy task
@@ -408,12 +417,12 @@ deploy_model() {
         debug "${status}"
         # Case 1: RUNNING / state not found. Task is still running so wait.
         if [[ "${status}" == 'null' || "${status}" == 'RUNNING' || "${status}" == 'CREATED' ]]; then
-            echo "Waiting for ${name} to deploy... ${i}/${max_reps}" >&2
+            info "Waiting for ${name} to deploy... ${i}/${max_reps}"
             sleep 1
             continue
         # Case 2: COMPLETED. Task is completed, so exit
         elif [[ "${status}" == 'COMPLETED' ]]; then
-            echo "Deployed ${name} successfully" >&2
+            info "Deployed ${name} successfully"
             MODEL_ID="${model_id}"
             return 0
         # Case 3: FAILED. Handle some error cases, fail in unrecognized ones.
@@ -439,11 +448,11 @@ handle_deploy_error() {
     local worker_node="$(jq -r '.worker_node[0]' "${deploy_status_file}")"
     local error_message="$(jq -r ".\"${worker_node}\"" <<< ${error})"
     debug "${error_message}"
-    echo "Deploy task failed for ${name}: ${error_message}" >&2
+    info "Deploy task failed for ${name}: ${error_message}"
     # Memory Circuit Breaker error: wait 20 seconds and the try to deploy again
     if [[ "${error_message}" = *Memory*Circuit*Breaker* ]]; then
         local wait_time=5
-        echo "Waiting for ${wait_time}s while GC runs before retrying deploy" >&2
+        info "Waiting for ${wait_time}s while GC runs before retrying deploy"
         sleep ${wait_time}
         spawn_deploy_model_task "${name}" "${model_id}"
     # Duplicate Deploy Task error: set task id I'm watching to the RUNNING task
@@ -474,7 +483,7 @@ END
         if [[ $(jq -r '.hits.total.value' "${deploy_task_search_file}") ]]; then
             debug "No running deploy task for ${model_id}. => check whether it's deployed"
             model_is_deployed "${model_id}" && return 0
-            echo "${model_id} failed to deploy. Try again after 1 sec" >&2
+            info "${model_id} failed to deploy. Try again after 1 sec"
             spawn_deploy_model_task "${name}" "${model_id}"
             sleep 1
         else
@@ -500,28 +509,6 @@ spawn_deploy_model_task() {
     _curl -X POST "${BASE_URL}/_plugins/_ml/models/${model_id}/_deploy" \
           -o "${deploy_model_log_file}"
     debug "" "${deploy_model_log_file}"
-}
-
-
-deploy_model_old() {
-    local model_id="$1" # if empty will be derived from task
-    local task_id="$2"
-    local name="$3"
-    [[ -z "${task_id}" ]] && die "ERROR missing task_id"
-    [[ -z "${name}" ]] && die "ERROR missing name"
-
-    if [[ -z "${model_id}" ]]; then
-        wait_task "${task_id}" "$name model to become ready"
-        model_id="${GET_TASK_MODEL_ID}"
-        echo "Fetched $name model id $model_id for task_id $task_id" >&2
-    else
-        echo "Using existing model id ${model_id}" >&2
-    fi
-    MODEL_ID="${model_id}"
-    DEPLOY_MODEL_LOG_FILE="${ARYN_STATUSDIR}/curl.deploy_model_task.${name}"
-    wait_or_die deploy_model_try "deploy of model ${MODEL_ID}, task ${task_id}, name ${name}" 60
-    wait_task "${DEPLOY_MODEL_DEP_TASK_ID}" "$name model to deploy"
-    # TODO: https://github.com/aryn-ai/sycamore/issues/153 - debug task waiting
 }
 
 wait_task() {
@@ -660,12 +647,9 @@ setup_transient() {
     _curl "${BASE_URL}/_cluster/settings" \
     | grep -Fq aryn_deploy_complete && die "aryn_deploy_complete already set"
 
-    model_is_deployed "${EMBEDDING_MODEL_ID}" ||
-        deploy_model "${EMBEDDING_MODEL_ID}" "${EMBEDDING_TASK_ID}" "embedding"
-    model_is_deployed "${OPENAI_MODEL_ID}" ||
-        deploy_model "${OPENAI_MODEL_ID}" "${OPENAI_TASK_ID}" "OpenAI"
-    model_is_deployed "${RERANKING_MODEL_ID}" ||
-        deploy_model "${RERANKING_MODEL_ID}" "${RERANKING_TASK_ID}" "reranking"
+    deploy_model "${EMBEDDING_MODEL_ID}" "${EMBEDDING_TASK_ID}" "embedding"
+    deploy_model "${OPENAI_MODEL_ID}" "${OPENAI_TASK_ID}" "OpenAI"
+    deploy_model "${RERANKING_MODEL_ID}" "${RERANKING_TASK_ID}" "reranking"
     # Semaphore to signal completion.  This must be transient, to go away
     # after restart, matching the longevity of model deployment.
     _curl -X PUT "${BASE_URL}/_cluster/settings" -o /dev/null --json \

--- a/opensearch/sycamore-opensearch.sh
+++ b/opensearch/sycamore-opensearch.sh
@@ -213,14 +213,13 @@ sp_setup_embedding_model() {
 }
 END
 
-
     debug "" "${file}"
     local id=$(jq -r '.task_id' "${file}")
     [[ -z "${id}" || "${id}" == "null" ]] && die "No embedding task ID"
     EMBEDDING_TASK_ID="${id}"
     echo "EMBEDDING_TASK_ID='${EMBEDDING_TASK_ID}'" >>"${PERSISTENT_ENV_TMP}"
 
-    deploy_model_better "" "${EMBEDDING_TASK_ID}" "embedding"
+    deploy_model "" "${EMBEDDING_TASK_ID}" "embedding"
     EMBEDDING_MODEL_ID="${MODEL_ID}"
     echo "EMBEDDING_MODEL_ID=${EMBEDDING_MODEL_ID}" >>"${PERSISTENT_ENV_TMP}"
 }
@@ -292,7 +291,7 @@ END
     GET_TASK_ID="${RERANKING_TASK_ID}"
     wait_or_die get_task "reranking model to register" 240
 
-    deploy_model_better "" "${RERANKING_TASK_ID}" "reranking"
+    deploy_model "" "${RERANKING_TASK_ID}" "reranking"
     RERANKING_MODEL_ID="${MODEL_ID}"
     echo "RERANKING_MODEL_ID=${RERANKING_MODEL_ID}" >>"${PERSISTENT_ENV_TMP}"
 }
@@ -301,7 +300,7 @@ sp_setup_openai_model() {
     [[ -z "${OPENAI_API_KEY}" ]] && die "No OPENAI_API_KEY set"
     wait_or_die sp_create_openai_connector 'creation of OpenAI connector' 60
     sp_register_openai_model
-    deploy_model_better "" "${OPENAI_TASK_ID}" "OpenAI"
+    deploy_model "" "${OPENAI_TASK_ID}" "OpenAI"
     OPENAI_MODEL_ID="${MODEL_ID}"
     echo "OPENAI_MODEL_ID=${OPENAI_MODEL_ID}" >>"${PERSISTENT_ENV_TMP}"
 }
@@ -377,7 +376,7 @@ END
     echo "OPENAI_TASK_ID=${OPENAI_TASK_ID}" >>"${PERSISTENT_ENV_TMP}"
 }
 
-deploy_model_better() {
+deploy_model() {
     local model_id="$1" # if empty will be derived from task
     local task_id="$2"
     local name="$3"
@@ -387,9 +386,9 @@ deploy_model_better() {
     if [[ -z "${model_id}" ]]; then
         wait_task "${task_id}" "$name model to become ready"
         model_id="${GET_TASK_MODEL_ID}"
-        echo "Fetched $name model id $model_id for task_id $task_id"
+        echo "Fetched $name model id $model_id for task_id $task_id" >&2
     else
-        echo "Using existing model id ${model_id}"
+        echo "Using existing model id ${model_id}" >&2
     fi
 
     # Create deploy task
@@ -402,39 +401,36 @@ deploy_model_better() {
     local deploy_status_file="${ARYN_STATUSDIR}/curl.deploy_task_status.${name}"
     local deploy_task_search_file="${ARYN_STATUSDIR}/curl.deploy_task_search_result.${name}"
     local i
-    local max_reps=40
+    local max_reps=60
     for i in $(seq "${max_reps}"); do
         _curl "${BASE_URL}/_plugins/_ml/tasks/${deploy_task_id}" -o "${deploy_status_file}"
         local status="$(jq -r '.state' "${deploy_status_file}")"
         debug "${status}"
         # Case 1: RUNNING / state not found. Task is still running so wait.
         if [[ "${status}" == 'null' || "${status}" == 'RUNNING' || "${status}" == 'CREATED' ]]; then
-            echo "Waiting for ${name} to deploy... ${i}/${max_reps}"
+            echo "Waiting for ${name} to deploy... ${i}/${max_reps}" >&2
             sleep 1
+            continue
         # Case 2: COMPLETED. Task is completed, so exit
         elif [[ "${status}" == 'COMPLETED' ]]; then
-            echo "Deployed ${name} successfully"
+            echo "Deployed ${name} successfully" >&2
             MODEL_ID="${model_id}"
             return 0
-        # Case 3: FAILED. Handle Memory Circuit Breaker error by waiting a bit but otherwise fail out
+        # Case 3: FAILED. Handle some error cases, fail in unrecognized ones.
         elif [[ "${status}" == 'FAILED' ]]; then
             # handle error
             debug "Deploy task failed for ${name}"
             local error="$(jq -r '.error' "${deploy_status_file}")"
             debug "${error}"
             local worker_node="$(jq -r '.worker_node[0]' "${deploy_status_file}")"
-            local error_message="$(echo "${error}" | jq -r ".${worker_node}")"
+            local error_message="$(jq -r ".\"${worker_node}\"" <<< ${error})"
             debug "${error_message}"
-            echo "Deploy task failed for ${name}: ${error_message}"
+            echo "Deploy task failed for ${name}: ${error_message}" >&2
             # Memory Circuit Breaker error: wait 20 seconds and the try to deploy again
-            if [[ "${error_message}" = "Memory Circuit Breaker is open, please check your resources!" ]]; then
-                local wait_time=20
-                echo "Waiting for ${wait_time}s while GC runs before retrying deploy"
-                for j in $(seq "${wait_time}"); do
-                    echo -n "."
-                    sleep 1
-                done
-                echo ""
+            if [[ "${error_message}" = *Memory*Circuit*Breaker* ]]; then
+                local wait_time=5
+                echo "Waiting for ${wait_time}s while GC runs before retrying deploy" >&2
+                sleep ${wait_time}
                 spawn_deploy_model_task "${name}" "${model_id}"
                 deploy_task_id="$(jq -r '.task_id' "${deploy_model_log_file}")"
             # Duplicate Deploy Task error: set task id I'm watching to the RUNNING task
@@ -465,14 +461,19 @@ END
                 if [[ $(jq -r '.hits.total.value' "${deploy_task_search_file}") ]]; then
                     debug "No running deploy task for ${model_id}. => check whether it's deployed"
                     model_is_deployed "${model_id}" && return 0
-                    echo "${model_id} failed to deploy. Try again after 1 sec"
-                    sleep 1
+                    echo "${model_id} failed to deploy. Try again after 1 sec" >&2
                     spawn_deploy_model_task "${name}" "${model_id}"
                     deploy_task_id="$(jq -r '.task_id' "${deploy_model_log_file}")"
+                    sleep 1
                 else
                     deploy_task_id="$(jq -r '.hits.hits[0]._id' "${deploy_task_search_file}")"
                     debug "Reset watched task id to ${deploy_task_id}"
                 fi
+            # OrtEnvironment (thread pool) issue: try again and wait a sec
+            elif [[ "${error_message}" = *OrtEnvironment* ]]; then
+                spawn_deploy_model_task "${name}" "${model_id}"
+                deploy_task_id="$(jq -r '.task_id' "${deploy_model_log_file}")"
+                sleep 1
             else
                 die "Unknown error message: ${error_message}. Failing"
             fi
@@ -494,7 +495,7 @@ spawn_deploy_model_task() {
 }
 
 
-deploy_model() {
+deploy_model_old() {
     local model_id="$1" # if empty will be derived from task
     local task_id="$2"
     local name="$3"
@@ -504,9 +505,9 @@ deploy_model() {
     if [[ -z "${model_id}" ]]; then
         wait_task "${task_id}" "$name model to become ready"
         model_id="${GET_TASK_MODEL_ID}"
-        echo "Fetched $name model id $model_id for task_id $task_id"
+        echo "Fetched $name model id $model_id for task_id $task_id" >&2
     else
-        echo "Using existing model id ${model_id}"
+        echo "Using existing model id ${model_id}" >&2
     fi
     MODEL_ID="${model_id}"
     DEPLOY_MODEL_LOG_FILE="${ARYN_STATUSDIR}/curl.deploy_model_task.${name}"
@@ -652,11 +653,11 @@ setup_transient() {
     | grep -Fq aryn_deploy_complete && die "aryn_deploy_complete already set"
 
     model_is_deployed "${EMBEDDING_MODEL_ID}" ||
-        deploy_model_better "${EMBEDDING_MODEL_ID}" "${EMBEDDING_TASK_ID}" "embedding"
+        deploy_model "${EMBEDDING_MODEL_ID}" "${EMBEDDING_TASK_ID}" "embedding"
     model_is_deployed "${OPENAI_MODEL_ID}" ||
-        deploy_model_better "${OPENAI_MODEL_ID}" "${OPENAI_TASK_ID}" "OpenAI"
+        deploy_model "${OPENAI_MODEL_ID}" "${OPENAI_TASK_ID}" "OpenAI"
     model_is_deployed "${RERANKING_MODEL_ID}" ||
-        deploy_model_better "${RERANKING_MODEL_ID}" "${RERANKING_TASK_ID}" "reranking"
+        deploy_model "${RERANKING_MODEL_ID}" "${RERANKING_TASK_ID}" "reranking"
     # Semaphore to signal completion.  This must be transient, to go away
     # after restart, matching the longevity of model deployment.
     _curl -X PUT "${BASE_URL}/_cluster/settings" -o /dev/null --json \


### PR DESCRIPTION
This handles a number of errors we were previously failing on
- when using both torch script and onnx models, funky pytorch internal methods get into a bad state and crash. Only use ONNX.
- when restarting the node, models are often redeployed automatically. Check that they are not deployed before trying to deploy them again (in sp_setup_transient)
- sometimes the deploy task fails due to ml memory circuit breaker tripping. Detect this, wait a couple seconds for GC to run, and then try again
- sometimes the deploy task fails due to duplicate deploy task. Detect this and watch the task we should be watching. If there is no running task, try to deploy again.

Note: We still don't handle the case where the memory circuit breaker trips during the register step

Another note: There's some cleaning up to do here but if y'all could check this out and tell me how it breaks that would be good