### PR TITLE
Cleanup metrics classes + bug fixes

### DIFF
--- a/sycamore/evaluation/__init__.py
+++ b/sycamore/evaluation/__init__.py
@@ -1,4 +1,3 @@
-from sycamore.evaluation.data import EvaluationDataPoint
-from sycamore.evaluation.metrics import EvaluationMetric, document_retrieval_metrics, generated_answer_metrics
+from sycamore.evaluation.data import EvaluationDataPoint, EvaluationMetric
 
-__all__ = ["EvaluationMetric", "EvaluationDataPoint", "document_retrieval_metrics", "generated_answer_metrics"]
+__all__ = ["EvaluationDataPoint", "EvaluationMetric"]

--- a/sycamore/evaluation/data.py
+++ b/sycamore/evaluation/data.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from typing import Optional, Any
 
 from sycamore.data import Element
@@ -135,3 +136,16 @@ class EvaluationSummary(Document):
         from pickle import loads
 
         return EvaluationSummary(loads(raw))
+
+
+class EvaluationMetric:
+    def __init__(self) -> None:
+        super().__init__()
+
+    @abstractmethod
+    def metric_name(self) -> str:
+        pass
+
+    @abstractmethod
+    def evaluate(self, datapoint: EvaluationDataPoint) -> dict[str, Any]:
+        pass

--- a/sycamore/evaluation/metrics/__init__.py
+++ b/sycamore/evaluation/metrics/__init__.py
@@ -1,0 +1,4 @@
+from sycamore.evaluation.metrics.generated_answer import rouge_metrics
+from sycamore.evaluation.metrics.retrieval import document_retrieval_metrics
+
+__all__ = ["document_retrieval_metrics", "rouge_metrics"]

--- a/sycamore/evaluation/metrics/generated_answer.py
+++ b/sycamore/evaluation/metrics/generated_answer.py
@@ -1,0 +1,26 @@
+from rouge import rouge
+
+from sycamore.evaluation import EvaluationDataPoint, EvaluationMetric
+
+
+class RougeMetrics(EvaluationMetric):
+    def __init__(self, rouge_metrics_types=None) -> None:
+        super().__init__()
+        if rouge_metrics_types is None:
+            rouge_metrics_types = ["rouge-1", "rouge-2", "rouge-l"]
+        self._rouge_evaluator = rouge.Rouge(metrics=rouge_metrics_types)
+
+    def metric_name(self) -> str:
+        return "GeneratedAnswerMetrics"
+
+    def evaluate(self, datapoint: EvaluationDataPoint) -> dict[str, str]:
+        scores = self._rouge_evaluator.get_scores(datapoint.generated_answer, datapoint.ground_truth_answer)[0]
+        result = {
+            "rouge-1": scores["rouge-1"]["f"],
+            "rouge-2": scores["rouge-2"]["f"],
+            "rouge-l": scores["rouge-l"]["f"],
+        }
+        return result
+
+
+rouge_metrics = RougeMetrics()

--- a/sycamore/evaluation/metrics/retrieval.py
+++ b/sycamore/evaluation/metrics/retrieval.py
@@ -1,25 +1,8 @@
-from abc import abstractmethod
 from pathlib import Path
 from typing import Any
 
-from rouge import rouge
-from sycamore.evaluation import EvaluationDataPoint
-import logging
-
-logger = logging.getLogger("ray")
-
-
-class EvaluationMetric:
-    def __init__(self) -> None:
-        super().__init__()
-
-    @abstractmethod
-    def metric_name(self) -> str:
-        pass
-
-    @abstractmethod
-    def evaluate(self, datapoint: EvaluationDataPoint) -> dict[str, Any]:
-        pass
+from sycamore.docset import logger
+from sycamore.evaluation import EvaluationDataPoint, EvaluationMetric
 
 
 class DocumentRetrievalMetrics(EvaluationMetric):
@@ -87,25 +70,4 @@ class DocumentRetrievalMetrics(EvaluationMetric):
         return result
 
 
-class GeneratedAnswerMetrics(EvaluationMetric):
-    def __init__(self, rouge_metrics=None) -> None:
-        super().__init__()
-        if rouge_metrics is None:
-            rouge_metrics = ["rouge-1", "rouge-2", "rouge-l"]
-        self._rouge_evaluator = rouge.Rouge(metrics=rouge_metrics)
-
-    def metric_name(self) -> str:
-        return "GeneratedAnswerMetrics"
-
-    def evaluate(self, datapoint: EvaluationDataPoint) -> dict[str, str]:
-        scores = self._rouge_evaluator.get_scores(datapoint.generated_answer, datapoint.ground_truth_answer)[0]
-        result = {
-            "rouge-1": scores["rouge-1"]["f"],
-            "rouge-2": scores["rouge-2"]["f"],
-            "rouge-l": scores["rouge-l"]["f"],
-        }
-        return result
-
-
 document_retrieval_metrics = DocumentRetrievalMetrics()
-generated_answer_metrics = GeneratedAnswerMetrics()

--- a/sycamore/functions/tokenizer.py
+++ b/sycamore/functions/tokenizer.py
@@ -1,9 +1,18 @@
+import tiktoken
 from transformers import AutoTokenizer
 
 
 class Tokenizer:
     def tokenize(self, text: str):
         pass
+
+
+class OpenAITokenizer(Tokenizer):
+    def __init__(self, model_name: str):
+        self._tk = tiktoken.encoding_for_model(model_name)
+
+    def tokenize(self, text: str):
+        return self._tk.encode(text)
 
 
 class CharacterTokenizer(Tokenizer):

--- a/sycamore/tests/integration/evaluation/test_pipeline.py
+++ b/sycamore/tests/integration/evaluation/test_pipeline.py
@@ -6,7 +6,7 @@ import pytest
 import sycamore
 from sycamore.data import Element
 from sycamore.evaluation import EvaluationDataPoint
-from sycamore.evaluation import document_retrieval_metrics, generated_answer_metrics
+from sycamore.evaluation.metrics import document_retrieval_metrics, rouge_metrics
 from sycamore.evaluation.datasets import EvaluationDataSetReader
 from sycamore.evaluation.pipeline import EvaluationPipeline
 from sycamore.transforms.query import OpenSearchQueryExecutor
@@ -63,7 +63,7 @@ class TestEvaluationPipeline:
         pipeline = EvaluationPipeline(
             index=self.INDEX,
             os_config=self.OS_CONFIG,
-            metrics=[document_retrieval_metrics, generated_answer_metrics],
+            metrics=[document_retrieval_metrics, rouge_metrics],
             query_executor=OpenSearchQueryExecutor(self.OS_CLIENT_ARGS),
         )
         query_level_metrics, aggregated_metrics = pipeline.execute(input_docset.limit(2))

--- a/sycamore/tests/unit/evaluation/test_metrics.py
+++ b/sycamore/tests/unit/evaluation/test_metrics.py
@@ -2,7 +2,8 @@ from rouge import rouge
 
 from sycamore.data import Element
 from sycamore.evaluation import EvaluationDataPoint
-from sycamore.evaluation.metrics import DocumentRetrievalMetrics, GeneratedAnswerMetrics
+from sycamore.evaluation.metrics.retrieval import DocumentRetrievalMetrics
+from sycamore.evaluation.metrics.generated_answer import RougeMetrics
 
 
 def test_document_retrieval_metrics():
@@ -104,7 +105,7 @@ def test_document_retrieval_metrics_multi_page_indexed_and_gold():
 
 def test_generated_answer_metrics():
     rouge_impl = rouge.Rouge(metrics=["rouge-1", "rouge-2", "rouge-l"])
-    metrics = GeneratedAnswerMetrics()
+    metrics = RougeMetrics()
     # Enforce metric name is class name
     assert metrics.metric_name() == "GeneratedAnswerMetrics"
 


### PR DESCRIPTION
1. Moved metric implementations to separate classes
2. Use `os_config` to configure opensearch query parameters. `os_client_args` are client configs we send directly to opensearch-py
3. Add OpenAI tokenizer 