### PR TITLE
Fix notebooks -- proper protocol, truncate output.

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -26,6 +26,7 @@ services:
     environment:
       - OPENAI_API_KEY
       - OPENSEARCH_HOST=opensearch
+      - SSL # Set to 1 if you want self-signed certificates
     volumes:
       - crawl_data:/app/.scrapy
 
@@ -37,7 +38,6 @@ services:
       - opensearch_data:/usr/share/opensearch/data
     environment:
       - OPENAI_API_KEY
-      - SSL # Set to 1 if you want self-signed certificates
       # To help with debugging issues with opensearch starting.
       - DEBUG
       - NOEXIT

--- a/compose.yaml
+++ b/compose.yaml
@@ -37,6 +37,7 @@ services:
       - opensearch_data:/usr/share/opensearch/data
     environment:
       - OPENAI_API_KEY
+      - SSL # Set to 1 if you want self-signed certificates
       # To help with debugging issues with opensearch starting.
       - DEBUG
       - NOEXIT
@@ -119,6 +120,7 @@ services:
       - AWS_SECRET_ACCESS_KEY
       - AWS_SESSION_TOKEN
       - AWS_CREDENTIAL_EXPIRATION
+      - SSL # Set to 1 if you want self-signed certificates
 
 volumes:
   opensearch_data:

--- a/notebooks/default-prep-script.ipynb
+++ b/notebooks/default-prep-script.ipynb
@@ -253,7 +253,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"Visit https://localhost:3000 and use the\", index, \"index to query these results in the UI\")"
+    "protocol = \"http\"\n",
+    "if os.environ.get(\"SSL\") == \"1\":\n",
+    "    protocol = \"https\"\n",
+    "print(f\"Visit {protocol}://localhost:3000 and use the {index} index to query these results in the UI\")"
    ]
   },
   {

--- a/notebooks/jupyter_dev_example.ipynb
+++ b/notebooks/jupyter_dev_example.ipynb
@@ -3,6 +3,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1867d47c-b124-4ae2-93c1-390d9c8578c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "e1666a1c-8c22-4643-8e15-a9a9f863893f",
    "metadata": {},
    "outputs": [],
@@ -206,7 +217,7 @@
    "outputs": [],
    "source": [
     "merged_docset = entity_docset.merge(GreedyTextElementMerger(tokenizer=HuggingFaceTokenizer(\"sentence-transformers/all-MiniLM-L6-v2\"), max_tokens=512))\n",
-    "merged_docset.show(show_binary = False)"
+    "merged_docset.show(show_binary = False, show_elements = False)"
    ]
   },
   {
@@ -217,7 +228,7 @@
    "outputs": [],
    "source": [
     "exploded_docset = merged_docset.explode()\n",
-    "exploded_docset.show(show_binary = False)"
+    "exploded_docset.show(show_binary = False, truncate_content = True, limit = 5)"
    ]
   },
   {
@@ -229,7 +240,7 @@
    "source": [
     "st_embed_docset = (exploded_docset\n",
     "              .embed(embedder=SentenceTransformerEmbedder(batch_size=100, model_name=\"sentence-transformers/all-MiniLM-L6-v2\")))\n",
-    "st_embed_docset.show(show_binary = False)"
+    "st_embed_docset.show(show_binary = False, truncate_content = True, limit = 5)"
    ]
   },
   {
@@ -285,8 +296,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"Visit https://localhost:3000 and use the\", index, \" index to query these results in the UI\")"
+    "protocol = \"http\"\n",
+    "if os.environ.get(\"SSL\") == \"1\":\n",
+    "    protocol = \"https\"\n",
+    "print(f\"Visit {protocol}://localhost:3000 and use the {index} index to query these results in the UI\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a45cd0e8-caad-45c8-a7db-57483a006d4b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -305,7 +327,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/jupyter_dev_example.ipynb
+++ b/notebooks/jupyter_dev_example.ipynb
@@ -301,7 +301,8 @@
     "    protocol = \"https\"\n",
     "print(f\"Visit {protocol}://localhost:3000 and use the {index} index to query these results in the UI\")"
    ]
-  },
+  }
+ ],
  "metadata": {
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",

--- a/notebooks/jupyter_dev_example.ipynb
+++ b/notebooks/jupyter_dev_example.ipynb
@@ -302,15 +302,6 @@
     "print(f\"Visit {protocol}://localhost:3000 and use the {index} index to query these results in the UI\")"
    ]
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a45cd0e8-caad-45c8-a7db-57483a006d4b",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
- ],
  "metadata": {
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",


### PR DESCRIPTION
* Pass SSL env var in via docker so people could enable SSL.
* Update jupyter dev example to truncate content and limit output -- running the notebook was getting tons of output.
* Update jupyter dev example to print the right URL.
* Update show operation in docset to not show binary in elements and truncate content in elements if we would do that in the main document. Slightly refactor to avoid duplicated code.