### PR TITLE
default opensearch to x86

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -32,6 +32,7 @@ services:
 
   opensearch:
     image: arynai/sycamore-opensearch:${OPENSEARCH_VERSION}
+    platform: linux/amd64
     ports:
       - 127.0.0.1:${OPENSEARCH_PORT}:9200 # opensearch port, directly accessed by UI
     volumes:


### PR DESCRIPTION
Due to a bug in ML-Commons, OpenSearch can't load models on Arm chips. This is a problem since Macbooks have Arm chips. So we'll set the opensearch container default architecture to amd64, which macs are pretty good at emulating and try to fix this bug in the next release of opensearch. 
Note, in my docker client, running the amd64/x86 image there's a red button that says "amd64" next to the container which looks kinda scary, but it's nbd.