### PR TITLE
Fix integ test import error.

### DIFF
--- a/sycamore/tests/integration/evaluation/test_datasets.py
+++ b/sycamore/tests/integration/evaluation/test_datasets.py
@@ -21,6 +21,8 @@ def _hf_to_qa_datapoint(data: dict[str, Any]) -> dict[str, Any]:
 
 class TestEvaluationDataSetReader:
     def test_hf(self):
+        from sycamore.tests.integration.evaluation.test_datasets import _hf_to_qa_datapoint
+
         context = sycamore.init()
         reader = EvaluationDataSetReader(context)
         hf_dataset = datasets.load_dataset("PatronusAI/financebench", split=datasets.Split.TRAIN)


### PR DESCRIPTION
This matches what we do in other integ tests and makes sure the pickled representation of the function has the absolute path to the module so that it can be imported.