### PR TITLE
Change notebook working directory when running outside container.

### DIFF
--- a/notebooks/jupyter_dev_example.ipynb
+++ b/notebooks/jupyter_dev_example.ipynb
@@ -51,7 +51,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "work_dir = \"/app/work/docker_volume\""
+    "if os.path.exists(\"/.dockerenv\"):\n",
+    "    # Running in Docker.\n",
+    "    work_dir = \"/app/work/docker_volume\"\n",
+    "else:\n",
+    "    # Running outside of docker. This will land under notebooks/data/\n",
+    "    work_dir = \"./data\"\n",
+    "    "
    ]
   },
   {


### PR DESCRIPTION
This makes it easier to run the notebook integration tests locally and in Github Actions.