### PR TITLE
add averaged_perceptron_tagger to nltk downloads

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -67,8 +67,8 @@ jobs:
       - name: Install sycamore
         run: poetry install
 
-      - name: Download nltk punkt
-        run: poetry run python -m nltk.downloader punkt
+      - name: Download nltk packages
+        run: poetry run python -m nltk.downloader punkt averaged_perceptron_tagger
 
       - name: Install poppler
         run: sudo apt-get install -y poppler-utils

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -78,7 +78,7 @@ class OpenAIClientWrapper:
                 raise ValueError("Can't set both api_base and azure_endpoint")
 
         # TODO: Add some parameter validation so we can fail fast. The openai library has a bunch of validation,
-        # but may not happen until much later in the job execution.
+        # but that may not happen until much later in the job execution.
 
         if client_type == OpenAIClientType.AZURE:
             if azure_endpoint is None:


### PR DESCRIPTION
looking at the integ test runs in the gh action it seems to be downloading this package now at runtime - this had caused some issues before, so let's pre-download it like we do with punkt