### PR TITLE
Remove mypy --explicit-package-bases flag and fix issues.

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run mypy
         run: |
           mkdir .mypy_cache/
-          poetry run mypy --install-types --explicit-package-bases --non-interactive .
+          poetry run mypy --install-types --non-interactive .
 
   lint:
     runs-on: ubuntu-latest

--- a/lib/sycamore/sycamore/transforms/detr_partitioner.py
+++ b/lib/sycamore/sycamore/transforms/detr_partitioner.py
@@ -210,6 +210,8 @@ def extract_ocr(
         page_elements = elements[i]
 
         for elem in page_elements:
+            if elem.bbox is None:
+                continue
             if elem.type == "Picture" and not ocr_images:
                 continue
             elif elem.type == "Table" and not ocr_tables:


### PR DESCRIPTION
Since the refactor, I've noticed that the Github actions mypy check was not catching all the mypy issues that I got when running `poetry run mypy .` locally. I believe it is the explicit-package-bases flag. Since we have __init__.py files in our main packages, we shouldn't need it, and it seems to be messing up the module path discovery.