### PR TITLE
Added -anon switch to S3 crawler for public buckets.

### DIFF
--- a/apps/crawler/crawler/s3/crawler/s3_crawler.py
+++ b/apps/crawler/crawler/s3/crawler/s3_crawler.py
@@ -126,6 +126,9 @@ if __name__ == "__main__":
     parser.add_argument("--anon", action="store_true", help="For accessing public buckets without credentials")
     args = parser.parse_args()
 
+    # We'd like to auto-detect when no credentials are present, instead of
+    # using --anon, but boto3 is clever finding creds and does so very late.
+
     if not args.bucket:
         args.bucket = "aryn-public"
         args.prefix = "sort-benchmark"

--- a/apps/crawler/crawler/s3/crawler/s3_crawler.py
+++ b/apps/crawler/crawler/s3/crawler/s3_crawler.py
@@ -51,7 +51,6 @@ class S3Crawler:
             self._s3_client = self._get_s3_client()
             self._find_and_download_new_objects()
 
-
     def _find_and_download_new_objects(self) -> None:
         paginator = self._s3_client.get_paginator("list_objects_v2")
         page_iterator = paginator.paginate(Bucket=self._bucket_location, Prefix=self._prefix)

--- a/apps/crawler/crawler/s3/tests/unit/test_s3_crawler.py
+++ b/apps/crawler/crawler/s3/tests/unit/test_s3_crawler.py
@@ -34,7 +34,7 @@ class TestS3Crawler:
         download.side_effect = mock_download_func
 
     def test_s3_crawler_first_crawl(self, mocker, tmp_path: Path):
-        s3_crawler = S3Crawler("bucket", "prefix")
+        s3_crawler = S3Crawler("bucket", "prefix", False)
         mock_page_iterator = [
             {
                 "Contents": [
@@ -50,7 +50,7 @@ class TestS3Crawler:
         assert len(mock_page_iterator[0]["Contents"]) == len(downloaded_objects)
 
     def test_s3_crawler_finds_new_object(self, mocker, tmp_path: Path):
-        s3_crawler = S3Crawler("bucket", "prefix")
+        s3_crawler = S3Crawler("bucket", "prefix", False)
         mock_page_iterator = [
             {
                 "Contents": [
@@ -77,7 +77,7 @@ class TestS3Crawler:
         assert len(mock_page_iterator[0]["Contents"]) == len(downloaded_objects) + 1
 
     def test_s3_crawler_nothing_to_crawl(self, mocker, tmp_path: Path):
-        s3_crawler = S3Crawler("bucket", "prefix")
+        s3_crawler = S3Crawler("bucket", "prefix", True)
 
         mock_page_iterator = [
             {

--- a/apps/crawler/crawler/s3/tests/unit/test_s3_crawler.py
+++ b/apps/crawler/crawler/s3/tests/unit/test_s3_crawler.py
@@ -9,6 +9,7 @@ from crawler.s3.crawler.s3_crawler import S3Crawler
 
 
 # TODO : Parth - investigate doing an integration test similar to the http one. Maybe using minio or localstack
+# TODO: Test anonymous mode; may need to be an integration test.
 class TestS3Crawler:
     def setup_mocks(
         self,


### PR DESCRIPTION
This is needed for the NDD blog post very soon.  It allows the crawling of public S3 buckets without AWS credentials.