### PR TITLE
Add .profile to container so that we get poetry python not container python

### DIFF
--- a/apps/jupyter/Dockerfile.buildx
+++ b/apps/jupyter/Dockerfile.buildx
@@ -28,6 +28,7 @@ COPY apps/jupyter/fixuser.py /root
 
 # User 'app' must be id number 1000 (the default) for all to work properly.
 USER app
+COPY apps/jupyter/profile ./.profile
 RUN --mount=type=cache,target=/app/.cache,sharing=locked \
     poetry run pip install notebook ipywidgets 'opensearch-py>=2.4'
 RUN mkdir -p /app/work/docker_volume /app/work/bind_dir /app/work/examples

--- a/apps/jupyter/profile
+++ b/apps/jupyter/profile
@@ -1,0 +1,1 @@
+PATH=/app/.venv/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games


### PR DESCRIPTION
Without this, terminals need to do poetry run python to get things like pytesseract