### PR TITLE
Cache entire Amazon Textract response

### DIFF
--- a/lib/sycamore/sycamore/tests/integration/textractor/test_textractor.py
+++ b/lib/sycamore/sycamore/tests/integration/textractor/test_textractor.py
@@ -26,7 +26,7 @@ class TestTextExtraction:
         docset = context.read.binary("s3://aryn-textract/10q-excerpt.pdf", binary_format="pdf", filesystem=get_s3_fs())
         document = docset.take(1)[0]
         table_extractor = TextractTableExtractor(region_name="us-east-1")
-        tables = table_extractor._extract(document)
+        tables = table_extractor.extract_tables(document)
         assert len(tables) == 2
 
     def test_docset_extract_tables(self):

--- a/lib/sycamore/sycamore/tests/integration/textractor/test_textractor.py
+++ b/lib/sycamore/sycamore/tests/integration/textractor/test_textractor.py
@@ -26,8 +26,8 @@ class TestTextExtraction:
         docset = context.read.binary("s3://aryn-textract/10q-excerpt.pdf", binary_format="pdf", filesystem=get_s3_fs())
         document = docset.take(1)[0]
         table_extractor = TextractTableExtractor(region_name="us-east-1")
-        tables = table_extractor.extract_tables(document)
-        assert len(tables) == 2
+        document = table_extractor.extract_tables(document)
+        assert len([element for element in document.elements if element.type == "Table"]) == 2
 
     def test_docset_extract_tables(self):
         context = sycamore.init()

--- a/lib/sycamore/sycamore/transforms/extract_table.py
+++ b/lib/sycamore/sycamore/transforms/extract_table.py
@@ -1,17 +1,22 @@
+import io
+import json
+import logging
 from abc import abstractmethod, ABC
 from collections import OrderedDict
-import io
 from typing import Optional
 
+import PyPDF2
 import boto3
 from botocore.exceptions import ClientError
-import json
-import PyPDF2
 from textractor import Textractor
 from textractor.data.constants import TextractFeatures
+from textractor.entities.document import Document as TextractorDocument
+from textractor.entities.table import Table
+from textractor.parsers import response_parser
 
 from sycamore.data import BoundingBox, Document, Element
 
+logger = logging.getLogger("sycamore")
 
 class MissingS3UploadPath(Exception):
     "Raised when an S3 upload path is needed but one wasn't provided"
@@ -47,21 +52,18 @@ class TextractTableExtractor(TableExtractor):
     """
 
     def __init__(
-        self,
-        profile_name: Optional[str] = None,
-        region_name: Optional[str] = None,
-        kms_key_id: str = "",
-        s3_upload_root: str = "",
+            self,
+            profile_name: Optional[str] = None,
+            region_name: Optional[str] = None,
+            kms_key_id: str = "",
+            s3_upload_root: str = "",
     ):
         self._profile_name = profile_name
         self._region_name = region_name
         self._kms_key_id: str = kms_key_id
         self._s3_upload_root: str = s3_upload_root
 
-    def _extract(self, document: Document) -> list[Element]:
-        # https://docs.aws.amazon.com/textract/latest/dg/API_BoundingBox.html
-        def bbox_to_coord(bbox):
-            return bbox.x, bbox.y, bbox.x + bbox.width, bbox.y + bbox.height
+    def get_textract_result(self, document: Document) -> list[Table]:
 
         extractor = Textractor(self._profile_name, self._region_name, self._kms_key_id)
         path = document.properties["path"]
@@ -79,14 +81,18 @@ class TextractTableExtractor(TableExtractor):
 
             # os.path.join("s3://foo", "/abc") -> "/abc"; which is not what we want.
             dest = self._s3_upload_root + tmp_path
-
             result = extractor.start_document_analysis(
-                document.properties["path"], TextractFeatures.TABLES, s3_upload_path=dest
-            )
+                document.properties["path"], TextractFeatures.TABLES, s3_upload_path=dest)
+        return result.tables
 
+    @staticmethod
+    def get_tables_from_textract_result(result: list[Table]):
+        # https://docs.aws.amazon.com/textract/latest/dg/API_BoundingBox.html
+        def bbox_to_coord(bbox):
+            return bbox.x, bbox.y, bbox.x + bbox.width, bbox.y + bbox.height
         # map page_number -> list of tables on that page number
         all_tables = []
-        for table in result.tables:
+        for table in result:
             element = Element()
             element.type = "Table"
             properties = element.properties
@@ -107,51 +113,29 @@ class TextractTableExtractor(TableExtractor):
                 element.text_representation = element.text_representation + footer.text + "\n"
 
             all_tables.append(element)
-
         return all_tables
 
     def extract_tables(self, document: Document) -> Document:
-        tables = self._extract(document)
+        textract_result = self.get_textract_result(document)
+        tables = self.get_tables_from_textract_result(textract_result)
         document.elements = document.elements + tables
         return document
 
 
-class CachedTextractTableExtractor(TableExtractor):
+class CachedTextractTableExtractor(TextractTableExtractor):
     """
-    TextractTableExtractor with S3 based cache support
+    Extends TextractTableExtractor with S3 based cache support for raw Textract results.
 
-    For each document, CachedTextractTableExtractor follows a series of steps for table extraction
-     1. if cache exists for current document, get from cache and return, otherwise, go to step 2
-     2. if run_full_textract is enabled, call textractor on the whole document and go to step 5; otherwise, go to step 3
-     3. if any element in the document is not marked table, return, otherwise, go to step 4.
-     4. clip pages which contain tables and run table extraction using textractor
-     5. update cache accordingly based on textractor result, return updated document
-
-    Cached table is in Json format as below:
-    {
-      "tables": [
-        {
-          "page_number": xx,
-          "title": "xxxx",
-          "content": "xxx"
-          "bbox": [xxx, xxx, xxx, xxx],
-          "footers": ["xxx", "xxx"]
-        },
-        ...
-      ]
-    }
-    bbox format is in [left/width, top/height, right/width, bottom/height]
+    CachedTextractTableExtractor overrides the 'get_textract_result' method by doing the following:
+     1. if cache hit for current document, get from cache and return, otherwise continue
+     2. if run_full_textract is enabled, call textractor on the whole document and go to step 4
+     3. else clip pages which contain tables and run table extraction using textractor
+     5. update cache accordingly based on textractor result and return result
     """
 
-    def __init__(
-        self,
-        s3_cache_location,
-        run_full_textract: bool = False,
-        s3_textract_upload_path: str = "",
-        profile_name: Optional[str] = None,
-        region_name: Optional[str] = None,
-        kms_key_id: str = "",
-    ):
+    def __init__(self, s3_cache_location, run_full_textract: bool = False, s3_textract_upload_path: str = "",
+                 profile_name: Optional[str] = None, region_name: Optional[str] = None, kms_key_id: str = ""):
+        super().__init__(profile_name, region_name, kms_key_id)
         self._s3_cache_location = s3_cache_location
         self._run_full_textract = run_full_textract
         self._s3_textract_upload_path = s3_textract_upload_path
@@ -159,72 +143,28 @@ class CachedTextractTableExtractor(TableExtractor):
         self._region_name = region_name
         self._kms_key_id = kms_key_id
 
-    @staticmethod
-    def _parse(json_data):
-        """
-        Parse json format cache into a list of table elements
-        """
-        tables = []
-        for table in json_data["tables"]:
-            element = Element()
-            element.type = "Table"
-            properties = element.properties
-            properties["page_number"] = table["page_number"]
-            element.properties = properties
-
-            text_list = []
-            if table.get("title"):
-                text_list.append(table["title"])
-            text_list.append(table["content"])
-            element.bbox = BoundingBox(*table["bbox"])
-            text_list.extend(table.get("footers", []))
-
-            element.text_representation = "\n".join(text_list)
-            tables.append(element)
-        return tables
-
-    @staticmethod
-    def _wrap(result, table_pages):
-        """
-        Wrap textract return data into json format
-        """
-        cached_tables = []
-        for table in result.tables:
-            t = {
-                "content": table.to_csv(),
-                "page_number": table_pages[table.page - 1] if table_pages else table.page,
-                "bbox": [table.bbox.x, table.bbox.y, table.bbox.x + table.bbox.width, table.bbox.y + table.bbox.height],
-            }
-            if table.title:
-                t["title"] = table.title.text
-            footers = [footer.text for footer in table.footers]
-            if footers:
-                t["footers"] = footers
-            cached_tables.append(t)
-        return {"tables": cached_tables}
-
-    def _get_table(self, s3, cache_id) -> Optional[list[Element]]:
+    def _get_cached_textract_result(self, s3, cache_id: str) -> TextractorDocument:
         """Get cache from S3"""
         try:
             parts = self._s3_cache_location.replace("s3://", "").strip("/").split("/", 1)
             bucket = parts[0]
             key = "/".join([parts[1], cache_id]) if len(parts) == 2 else cache_id
             response = s3.get_object(Bucket=bucket, Key=key)
+            return response_parser.parse(json.loads(response['Body'].read()))
+            # return TextractorDocument.open(self._s3_cache_location + "/" + cache_id)
         except ClientError as e:
             if e.response["Error"]["Code"] == "NoSuchKey":
                 return None
             else:
                 raise
 
-        tables = self._parse(json.loads(response["Body"].read()))
-        return tables
-
-    def _put_table(self, s3, cache_id: str, table: dict):
+    def _cache_textract_result(self, s3, cache_id: str, result: TextractorDocument):
+        logger.warn("Caching:" + str(result))
         """Put table into S3"""
         parts = self._s3_cache_location.replace("s3://", "").strip("/").split("/", 1)
         bucket = parts[0]
         key = "/".join([parts[1], cache_id]) if len(parts) == 2 else cache_id
-        json_str = json.dumps(table, indent=2)
+        json_str = json.dumps(result.response)
         s3.put_object(Body=json_str, Bucket=bucket, Key=key)
 
     @staticmethod
@@ -234,61 +174,58 @@ class CachedTextractTableExtractor(TableExtractor):
         cache_id = response["ETag"].replace('"', "")
         return cache_id
 
-    def extract_tables(self, document: Document) -> Document:
+    def get_textract_result(self, document: Document) -> list[Table]:
+        table_pages = [element.properties["page_number"] for element in document.elements if element.type == "Table"]
+
+        if not self._run_full_textract and not table_pages:
+            return []
+
         s3 = boto3.client("s3")
         cache_id = self._cache_id(s3, document.properties["path"])
-        tables = self._get_table(s3, cache_id)
+        textract_result = self._get_cached_textract_result(s3, cache_id)
 
-        if tables:
-            document.elements = document.elements + tables
-            return document
-
-        if tables is not None:
-            return document
+        if textract_result:
+            logger.info(f"Textract cache hit for {document.properties['path']}")
+            return textract_result.tables
 
         # cache miss
+        logger.info(f"Textract cache miss for {document.properties['path']}")
         extractor = Textractor(self._profile_name, self._region_name, self._kms_key_id)
         if self._run_full_textract:
-            result = extractor.start_document_analysis(
+            textract_result = extractor.start_document_analysis(
                 document.properties["path"],
                 TextractFeatures.TABLES,
                 s3_upload_path=self._s3_textract_upload_path,
                 save_image=False,
             )
-            json_data = self._wrap(result, [])
         else:
-            # a list holding 1 based page number
-            table_pages = [
-                element.properties["page_number"] for element in document.elements if element.type == "Table"
-            ]
-            if not table_pages:
-                json_data = {"tables": []}
-            else:
-                # When no s3 upload path exists, it's assumed textractor won't run even cache miss
-                if not self._s3_textract_upload_path:
-                    raise RuntimeError("Missing textract upload path")
+            # When no s3 upload path exists, it's assumed textractor won't run even cache miss
+            if not self._s3_textract_upload_path:
+                raise RuntimeError("Missing textract upload path")
 
-                # Clip the pages which have tables into a new tmp pdf and upload for textract
-                table_pages = list(OrderedDict.fromkeys(table_pages))
-                binary = io.BytesIO(document.data["binary_representation"])
-                pdf_reader = PyPDF2.PdfReader(binary)
-                pdf_writer = PyPDF2.PdfWriter()
-                for page_number in table_pages:
-                    page = pdf_reader.pages[page_number - 1]  # Page numbers start from 0
-                    pdf_writer.add_page(page)
-                output_pdf_stream = io.BytesIO()
-                pdf_writer.write(output_pdf_stream)
+            # Clip the pages which have tables into a new tmp pdf and upload for textract
+            table_pages = list(OrderedDict.fromkeys(table_pages))
+            binary = io.BytesIO(document.data["binary_representation"])
+            pdf_reader = PyPDF2.PdfReader(binary)
+            pdf_writer = PyPDF2.PdfWriter()
+            for page_number in table_pages:
+                page = pdf_reader.pages[page_number - 1]  # Page numbers start from 0
+                pdf_writer.add_page(page)
+            output_pdf_stream = io.BytesIO()
+            pdf_writer.write(output_pdf_stream)
 
-                # Do textract
-                result = extractor.start_document_analysis(
-                    output_pdf_stream.getvalue(),
-                    TextractFeatures.TABLES,
-                    s3_upload_path=self._s3_textract_upload_path,
-                    save_image=False,
-                )
-                json_data = self._wrap(result, table_pages)
+            # Do textract
+            textract_result = extractor.start_document_analysis(
+                output_pdf_stream.getvalue(),
+                TextractFeatures.TABLES,
+                s3_upload_path=self._s3_textract_upload_path,
+                save_image=False,
+            )
 
-        # parse table into table element and update cache
-        self._put_table(s3, cache_id, json_data)
-        document.elements = document.elements + self._parse(json_data)
-        return document
+            # put back actual page numbers
+            for table in textract_result.tables:
+                table.page = table_pages[table.page - 1] if table_pages else table.page
+
+        self._cache_textract_result(s3, cache_id, textract_result)
+
+        return textract_result.tables


### PR DESCRIPTION
Store the entire DocumentAnalysis json response from Textract instead of our parsed Table objects. This lets you use the textractor interface to access fields we hadn't previously used in a typed way (e.g. individual row elements).

I validated this by running the following on a single doc:
1. regular TextractTableExtractor
2. CachedTextractTableExtractor for the first time
3. CachedTextractTableExtractor for the second time

We can likely add integration tests validating that caching is working but I don't want to combine it here.