### PR TITLE
Bind mount to convey SSL cert/key to Jupyter & UI

### DIFF
--- a/apps/demo-ui/run-ui.sh
+++ b/apps/demo-ui/run-ui.sh
@@ -15,8 +15,7 @@ if [[ -f /.dockerenv ]]; then
     PROXYDIR=/home/pn/py-proxy
     UIDIR=/home/pn/js-ui
 else
-    cd $(dirname $0)
-    DIR=$(pwd)
+    DIR=$(cd "$(dirname "$0")"; pwd)
     PROXYDIR="${DIR}/openai-proxy"
     UIDIR="${DIR}/ui"
 fi
@@ -29,7 +28,7 @@ cd "${PROXYDIR}"
 : ${HOST:=localhost}
 SELFSIGNED="${HOST}_ss"
 SSLNAME="${SELFSIGNED}"
-ARYN_DIR=/etc/opt/aryn
+ARYN_ETC=/etc/opt/aryn
 
 if [[ (! -f ${SELFSIGNED}-key.pem) || (! -f ${SELFSIGNED}-cert.pem) ]]; then
     openssl req -batch -x509 -newkey rsa:4096 -days 10000 \
@@ -40,11 +39,11 @@ if [[ (! -f ${SELFSIGNED}-key.pem) || (! -f ${SELFSIGNED}-cert.pem) ]]; then
     echo "Created ${HOST} certificate"
 fi
 
-if [[ -f ${ARYN_DIR}/hostcert.pem && -f ${ARYN_DIR}/hostkey.pem ]]; then
-    cp -p "${ARYN_DIR}/hostcert.pem" "${HOST}-cert.pem"
-    cp -p "${ARYN_DIR}/hostkey.pem" "${HOST}-key.pem"
+if [[ -f ${ARYN_ETC}/hostcert.pem && -f ${ARYN_ETC}/hostkey.pem ]]; then
+    cp -p "${ARYN_ETC}/hostcert.pem" "${HOST}-cert.pem"
+    cp -p "${ARYN_ETC}/hostkey.pem" "${HOST}-key.pem"
     SSLNAME="${HOST}"
-    echo "Copied certificate from ${ARYN_DIR}"
+    echo "Copied certificate from ${ARYN_ETC}"
 fi
 
 if [[ ${SSL} == 0 ]]; then

--- a/apps/demo-ui/run-ui.sh
+++ b/apps/demo-ui/run-ui.sh
@@ -27,20 +27,33 @@ function cleanup {
 
 cd "${PROXYDIR}"
 : ${HOST:=localhost}
-if [[ (! -f ${HOST}-key.pem) || (! -f ${HOST}-cert.pem) ]]; then
+SELFSIGNED="${HOST}_ss"
+SSLNAME="${SELFSIGNED}"
+ARYN_DIR=/etc/opt/aryn
+
+if [[ (! -f ${SELFSIGNED}-key.pem) || (! -f ${SELFSIGNED}-cert.pem) ]]; then
     openssl req -batch -x509 -newkey rsa:4096 -days 10000 \
     -subj "/C=US/ST=California/O=Aryn.ai/CN=${HOST}" \
     -extensions v3_req -addext "subjectAltName=DNS:${HOST}" \
-    -noenc -keyout "${HOST}-key.pem" -out "${HOST}-cert.pem" 2> /dev/null
+    -noenc -keyout "${SELFSIGNED}-key.pem" \
+    -out "${SELFSIGNED}-cert.pem" 2> /dev/null
     echo "Created ${HOST} certificate"
 fi
+
+if [[ -f ${ARYN_DIR}/hostcert.pem && -f ${ARYN_DIR}/hostkey.pem ]]; then
+    cp -p "${ARYN_DIR}/hostcert.pem" "${HOST}-cert.pem"
+    cp -p "${ARYN_DIR}/hostkey.pem" "${HOST}-key.pem"
+    SSLNAME="${HOST}"
+    echo "Copied certificate from ${ARYN_DIR}"
+fi
+
 if [[ ${SSL} == 0 ]]; then
     BASEURL="http://${HOST}:3000"
 else
     BASEURL="https://${HOST}:3000"
 fi
 
-poetry run python py_proxy/proxy.py "${HOST}" &
+poetry run python py_proxy/proxy.py "${SSLNAME}" &
 PROXYPID=$!
 trap cleanup EXIT
 
@@ -59,9 +72,11 @@ cd "${UIDIR}"
 # Running the UI this way means that the html is unminified and hence easy to read
 # Since the UI is open source, there's little downside of doing this and it helps with
 # debugging.
+# See this link for why we're using RSA self-signed certificates for npm:
+# https://community.letsencrypt.org/t/ecdsa-certificates-not-supported-by-create-react-app/201387/9
 BROWSER=none PORT=3001 WDS_SOCKET_PORT=3000 HTTPS=true \
-SSL_CRT_FILE="${PROXYDIR}/${HOST}-cert.pem" \
-SSL_KEY_FILE="${PROXYDIR}/${HOST}-key.pem" \
+SSL_CRT_FILE="${PROXYDIR}/${SELFSIGNED}-cert.pem" \
+SSL_KEY_FILE="${PROXYDIR}/${SELFSIGNED}-key.pem" \
 npm start | cat
 
 # These are the steps that would build the UI and serve it minified.  We

--- a/apps/jupyter/run-jupyter.sh
+++ b/apps/jupyter/run-jupyter.sh
@@ -6,9 +6,18 @@ die() {
 }
 
 mkdir -p $HOME/.jupyter
-BIND_DIR=/app/work/bind_dir
-ARYN_DIR=/etc/opt/aryn
-JUPYTER_CONFIG_DOCKER=/app/work/docker_volume/jupyter_notebook_config.py
+if [[ -f /.dockerenv ]]; then
+    APP_DIR=/app
+else
+    APP_DIR=$(cd "$(dirname "$0")"; pwd)
+fi
+WORK_DIR="${APP_DIR}/work"
+BIND_DIR="${WORK_DIR}/bind_dir"
+VOLUME="${WORK_DIR}/docker_volume"
+RUNTIME_DIR="${HOME}/.local/share/jupyter/runtime"
+ARYN_ETC=/etc/opt/aryn
+JUPYTER_CONFIG_DOCKER="${VOLUME}/jupyter_notebook_config.py"
+mkdir -p "${BIND_DIR}" "${VOLUME}"
 
 if [[ ! -f "${JUPYTER_CONFIG_DOCKER}" ]]; then
     TOKEN=$(openssl rand -hex 24)
@@ -22,18 +31,18 @@ EOF
 fi
 ln -snf "${JUPYTER_CONFIG_DOCKER}" $HOME/.jupyter
 
-rm /app/.local/share/jupyter/runtime/jpserver-*-open.html 2>/dev/null
+find "${RUNTIME_DIR}" -type f -name 'jpserver-*-open.html' -delete 2>/dev/null
 
 if [[ ${SSL} == 0 ]]; then
     echo "Jupyter not serving over SSL."
-    SSLARG=
-elif [[ -f ${ARYN_DIR}/hostcert.pem && -f ${ARYN_DIR}/hostkey.pem ]]; then
-    echo "Using SSL certificate from ${ARYN_DIR}"
-    SSLARG="--certfile=\"${ARYN_DIR}/hostcert.pem\" --keyfile=\"${ARYN_DIR}/hostkey.pem\""
+    SSLARG=()
+elif [[ -f ${ARYN_ETC}/hostcert.pem && -f ${ARYN_ETC}/hostkey.pem ]]; then
+    echo "Using SSL certificate from ${ARYN_ETC}"
+    SSLARG=("--certfile=\"${ARYN_ETC}/hostcert.pem\"" "--keyfile=\"${ARYN_ETC}/hostkey.pem\"")
 else
     : ${HOST:=localhost}
-    SSLPFX="/app/work/docker_volume/${HOST}"
-    SSLLOG="/app/work/docker_volume/openssl.err"
+    SSLPFX="${VOLUME}/${HOST}"
+    SSLLOG="${VOLUME}/openssl.err"
     if [[ (! -f ${SSLPFX}-key.pem) || (! -f ${SSLPFX}-cert.pem) ]]; then
         openssl req -batch -x509 -newkey rsa:4096 -days 10000 \
         -subj "/C=US/ST=California/O=Aryn.ai/CN=${HOST}" \
@@ -42,19 +51,20 @@ else
         2>> "${SSLLOG}" || die "Failed to create ${HOST} certificate"
         echo "Created ${HOST} certificate"
     fi
-    SSLARG="--certfile=\"${SSLPFX}-cert.pem\" --keyfile=\"${SSLPFX}-key.pem\""
+    SSLARG=("--certfile=\"${SSLPFX}-cert.pem\"" "--keyfile=\"${SSLPFX}-key.pem\"")
 fi
 
 (
-    while [[ $(ls /app/.local/share/jupyter/runtime/jpserver-*-open.html 2>/dev/null | wc -w) = 0 ]]; do
+    while [[ $(find "${RUNTIME_DIR}" -type f -name 'jpserver-*-open.html' 2>/dev/null | wc -l) = 0 ]]; do
         echo "Waiting for jpserver-*-open.html to appear"
         sleep 1
     done
-    FILE="$(ls /app/.local/share/jupyter/runtime/jpserver-*-open.html)"
-    if [[ $(echo "${FILE}" | wc -w) != 1 ]]; then
-        echo "ERROR: got '${FILE}' for jpserver files"
-        ls /app/.local/share/jupyter/runtime
-        echo "ERROR: Multiple jpsterver-*-open.html files"
+    FILE="$(find "${RUNTIME_DIR}" -type f -name 'jpserver-*-open.html')"
+    if [[ $(wc -l <<< ${FILE}) != 1 ]]; then
+        CONCAT=$(xargs -r <<< ${FILE})
+        echo "ERROR: got '${CONCAT}' for jpserver files"
+        ls "${RUNTIME_DIR}"
+        echo "ERROR: Multiple jpserver-*-open.html files"
         exit 1
     fi
 
@@ -77,5 +87,7 @@ fi
     done
 ) &
 
-cd /app/work
-poetry run jupyter notebook ${SSLARG} --no-browser --ip 0.0.0.0 "$@"
+trap "kill $!" EXIT
+
+cd "${WORK_DIR}"
+poetry run jupyter notebook "${SSLARG[@]}" --no-browser --ip 0.0.0.0 "$@"

--- a/apps/jupyter/run-jupyter.sh
+++ b/apps/jupyter/run-jupyter.sh
@@ -63,7 +63,7 @@ fi
     if [[ $(wc -l <<< ${FILE}) != 1 ]]; then
         CONCAT=$(xargs -r <<< ${FILE})
         echo "ERROR: got '${CONCAT}' for jpserver files"
-        ls "${RUNTIME_DIR}"
+        ls -R "${RUNTIME_DIR}"
         echo "ERROR: Multiple jpserver-*-open.html files"
         exit 1
     fi

--- a/apps/jupyter/run-jupyter.sh
+++ b/apps/jupyter/run-jupyter.sh
@@ -61,8 +61,7 @@ fi
     done
     FILE="$(find "${RUNTIME_DIR}" -type f -name 'jpserver-*-open.html')"
     if [[ $(wc -l <<< ${FILE}) != 1 ]]; then
-        CONCAT=$(xargs -r <<< ${FILE})
-        echo "ERROR: got '${CONCAT}' for jpserver files"
+        echo "ERROR: got '${FILE}' for jpserver files"
         ls -R "${RUNTIME_DIR}"
         echo "ERROR: Multiple jpserver-*-open.html files"
         exit 1

--- a/compose.yaml
+++ b/compose.yaml
@@ -29,6 +29,9 @@ services:
       - SSL # Set to 1 if you want self-signed certificates
     volumes:
       - crawl_data:/app/.scrapy
+      - type: bind
+        source: ${JUPYTER_BIND_DIR}
+        target: /etc/opt/aryn
 
   opensearch:
     image: arynai/sycamore-opensearch:${OPENSEARCH_VERSION}
@@ -80,6 +83,9 @@ services:
       - type: bind
         source: ${JUPYTER_BIND_DIR}
         target: /app/work/bind_dir
+      - type: bind
+        source: ${JUPYTER_BIND_DIR}
+        target: /etc/opt/aryn
     environment:
       - OPENAI_API_KEY
       - AWS_ACCESS_KEY_ID

--- a/compose.yaml
+++ b/compose.yaml
@@ -29,9 +29,6 @@ services:
       - SSL # Set to 1 if you want self-signed certificates
     volumes:
       - crawl_data:/app/.scrapy
-      - type: bind
-        source: ${JUPYTER_BIND_DIR}
-        target: /etc/opt/aryn
 
   opensearch:
     image: arynai/sycamore-opensearch:${OPENSEARCH_VERSION}
@@ -83,9 +80,6 @@ services:
       - type: bind
         source: ${JUPYTER_BIND_DIR}
         target: /app/work/bind_dir
-      - type: bind
-        source: ${JUPYTER_BIND_DIR}
-        target: /etc/opt/aryn
     environment:
       - OPENAI_API_KEY
       - AWS_ACCESS_KEY_ID


### PR DESCRIPTION
To test, put two files in apps/jupyter/bind_dir:
- hostcert.pem
- hostkey.pem

Then, run like:
- VERSION=test SSL=1 docker compose up

Jupyter and the UI should come up with the specified certificate, probably still with a warning, as we're not using fully-qualified domain names yet.