### PR TITLE
Fix malformed text from beautiful soup.

### DIFF
--- a/lib/sycamore/sycamore/tests/unit/transforms/test_partition.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_partition.py
@@ -78,7 +78,7 @@ class TestPartition:
             (
                 HtmlPartitioner(),
                 TEST_DIR / "resources/data/htmls/wikipedia_binary_search.html",
-                76,
+                73,
             )
         ],
         indirect=["read_local_binary"],
@@ -93,7 +93,7 @@ class TestPartition:
             (
                 HtmlPartitioner(extract_tables=True),
                 TEST_DIR / "resources/data/htmls/wikipedia_binary_search.html",
-                77,
+                74,
                 1,
             )
         ],
@@ -121,7 +121,7 @@ class TestPartition:
         assert len(doc.elements) == partition_count
 
     @pytest.mark.parametrize(
-        "path, partition_count", [(TEST_DIR / "resources/data/htmls/wikipedia_binary_search.html", 76)]
+        "path, partition_count", [(TEST_DIR / "resources/data/htmls/wikipedia_binary_search.html", 73)]
     )
     def test_partition_html(self, mocker, path, partition_count) -> None:
         scan = mocker.Mock(spec=BinaryScan)

--- a/lib/sycamore/sycamore/transforms/partition.py
+++ b/lib/sycamore/sycamore/transforms/partition.py
@@ -298,7 +298,7 @@ class HtmlPartitioner(Partitioner):
 
         # chunk text and create text elements
         elements = []
-        text = soup.get_text()
+        text = soup.get_text(separator=" ", strip=True)
         tokens = self._tokenizer.tokenize(text)
         for chunk in self._text_chunker.chunk(tokens):
             content = "".join(chunk)


### PR DESCRIPTION
Seems the problem of below

```
<div><span>hello</span></div><div><span>world</span></div> ->
"helloworld" instead of "hello" "world"
```
is due to no separator is added when concatenate string when getting text