### PR TITLE
fix ui error when no title is extracted and we're not in ntsb setting

### DIFF
--- a/apps/demo-ui/ui/src/Doclist.tsx
+++ b/apps/demo-ui/ui/src/Doclist.tsx
@@ -51,7 +51,7 @@ const DocumentItem = ({ document }: { document: SearchResultDocument }) => {
                             <Badge size="xs" color="gray" variant="filled" sx={{ overflow: "visible" }} > {document.index}</Badge>
                             <Text size="sm" c={hovered ? theme.colors.blue[8] : theme.colors.dark[8]} truncate>
                                 {document.title != "Untitled" ? document.title :
-                                    document.properties.entity.accidentNumber ?? "Untitled"}
+                                    (document.properties.entity ? document.properties.entity.accidentNumber ?? "Untitled": "Untitled")}
                             </Text>
                         </Group>
                         <Group p="xs" noWrap spacing="xs">


### PR DESCRIPTION
If we're not in ntsb setting and we didn't extract a title entity in our ingest, we get a "properties.entity is undefined" when reading properties.entity.accidentNumber

This fixes that so if properties.entity is undefined then we set the title to "Untitled"