### PR TITLE
Use chown in our copy commands to make sure all files are owned by app

### DIFF
--- a/apps/importer/Dockerfile.buildx
+++ b/apps/importer/Dockerfile.buildx
@@ -22,13 +22,13 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     /bin/bash /app/importer-root-setup.sh
 
 USER app
-COPY lib/sycamore lib/sycamore
-COPY lib/poetry-lock lib/poetry-lock
+COPY --chown=app:app lib/sycamore lib/sycamore
+COPY --chown=app:app lib/poetry-lock lib/poetry-lock
 
-COPY apps/importer/pyproject.toml apps/importer/poetry.lock apps/importer/README.md \
+COPY --chown=app:app apps/importer/pyproject.toml apps/importer/poetry.lock apps/importer/README.md \
      ./
 RUN mkdir -p importer/docker
-COPY apps/importer/importer/docker/docker-poetry-packages.sh \
+COPY --chown=app:app apps/importer/importer/docker/docker-poetry-packages.sh \
      importer/docker/docker-poetry-packages.sh
 
 RUN --mount=type=cache,id=cache_poetry_1000,target=/tmp/poetry_cache,uid=1000,gid=1000,sharing=locked \
@@ -36,10 +36,15 @@ RUN --mount=type=cache,id=cache_poetry_1000,target=/tmp/poetry_cache,uid=1000,gi
       install --only main,sycamore_library,docker --no-root -v
 
 # syntax=docker/dockerfile:1.7-labs
-COPY apps/importer ./
-COPY examples/simple_config.py ./
+COPY --chown=app:app apps/importer ./
+COPY --chown=app:app examples/simple_config.py ./
 
 RUN /bin/bash ./importer/docker/docker-poetry-packages.sh install --only-root -v -v -v
+
+# Make sure we don't get more unexpected files owned by root
+RUN find . -uid 0 -ls
+RUN find . -uid 0 -print | wc -w
+RUN /bin/bash -c '[[ $(find . -uid 0 -print | wc -w) = 1 ]]'
 
 ARG GIT_BRANCH="unknown"
 ARG GIT_COMMIT="unknown"

--- a/apps/jupyter/Dockerfile.buildx
+++ b/apps/jupyter/Dockerfile.buildx
@@ -2,9 +2,12 @@
 
 # Note: This dockerfile is intended to work with docker buildx build -f Dockerfile.buildx .
 
+ARG REGISTRY=docker.io
 ARG TAG=stable
 
-FROM arynai/sycamore-importer:$TAG
+# FOO1
+
+FROM ${REGISTRY}/arynai/sycamore-importer:$TAG
 
 ARG GIT_BRANCH="unknown"
 ARG GIT_COMMIT="unknown"
@@ -18,7 +21,7 @@ ENV SSL=0
 
 WORKDIR /app
 
-USER root
+USER 0
 COPY apps/jupyter/jupyter-docker-root-setup.sh /app
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
@@ -26,17 +29,22 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 COPY apps/jupyter/sudoers /etc/sudoers
 COPY apps/jupyter/fixuser.py /root
 
-# User 'app' must be id number 1000 (the default) for all to work properly.
+# Must use numeric uid. Otherwise we will randomly get files owned by uid 0 that should be uid 1000
 USER app
-COPY apps/jupyter/profile ./.profile
+COPY --chown=app:app apps/jupyter/profile ./.profile
 RUN --mount=type=cache,target=/app/.cache,sharing=locked \
     poetry run pip install notebook ipywidgets 'opensearch-py>=2.4'
 RUN mkdir -p /app/work/docker_volume /app/work/bind_dir /app/work/examples
 RUN touch /app/work/AAA_SEE_README_FOR_PERSISTENT_DATA_DIRECTORIES
-COPY apps/jupyter/run-jupyter.sh ./
-COPY apps/jupyter/README.md ./work
-COPY notebooks/jupyter_dev_example.ipynb notebooks/default-prep-script.ipynb notebooks/ndd_example.ipynb ./work/examples/
+COPY --chown=app:app apps/jupyter/run-jupyter.sh ./
+COPY --chown=app:app apps/jupyter/README.md ./work
+COPY --chown=app:app notebooks/jupyter_dev_example.ipynb notebooks/default-prep-script.ipynb notebooks/ndd_example.ipynb ./work/examples/
 RUN perl -i -pe 's/localhost/opensearch/ if /9200/;s,tmp/sycamore/data,/app/work/docker_volume,' /app/work/examples/jupyter_dev_example.ipynb
+
+# Make sure we don't get more unexpected files owned by root
+RUN find . -uid 0 -ls
+RUN find . -uid 0 -print | wc -w
+RUN /bin/bash -c '[[ $(find . -uid 0 -print | wc -w) = 2 ]]'
 
 LABEL org.opencontainers.image.authors="opensource@aryn.ai"
 LABEL git_branch=${GIT_BRANCH}

--- a/apps/jupyter/Dockerfile.buildx
+++ b/apps/jupyter/Dockerfile.buildx
@@ -2,12 +2,9 @@
 
 # Note: This dockerfile is intended to work with docker buildx build -f Dockerfile.buildx .
 
-ARG REGISTRY=docker.io
 ARG TAG=stable
 
-# FOO1
-
-FROM ${REGISTRY}/arynai/sycamore-importer:$TAG
+FROM arynai/sycamore-importer:$TAG
 
 ARG GIT_BRANCH="unknown"
 ARG GIT_COMMIT="unknown"
@@ -21,7 +18,7 @@ ENV SSL=0
 
 WORKDIR /app
 
-USER 0
+USER root
 COPY apps/jupyter/jupyter-docker-root-setup.sh /app
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
@@ -29,7 +26,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 COPY apps/jupyter/sudoers /etc/sudoers
 COPY apps/jupyter/fixuser.py /root
 
-# Must use numeric uid. Otherwise we will randomly get files owned by uid 0 that should be uid 1000
 USER app
 COPY --chown=app:app apps/jupyter/profile ./.profile
 RUN --mount=type=cache,target=/app/.cache,sharing=locked \


### PR DESCRIPTION
Also add check to Dockerfile to make sure that remains true.