### PR TITLE
Store element bbox as a tuple rather than BoundingBox.

### DIFF
--- a/lib/sycamore/sycamore/data/element.py
+++ b/lib/sycamore/sycamore/data/element.py
@@ -47,13 +47,7 @@ class Element(UserDict):
 
     @property
     def bbox(self) -> Optional[BoundingBox]:
-        bbox = self.data.get("bbox")
-        if bbox is None:
-            return None
-        elif isinstance(bbox, BoundingBox):
-            return bbox
-        else:
-            return BoundingBox(*self.data["bbox"])
+        return None if self.data.get("bbox") is None else BoundingBox(*self.data["bbox"])
 
     @bbox.setter
     def bbox(self, bbox: BoundingBox) -> None:

--- a/lib/sycamore/sycamore/transforms/detr_partitioner.py
+++ b/lib/sycamore/sycamore/transforms/detr_partitioner.py
@@ -180,7 +180,7 @@ class DeformableDetr(SycamoreObjectDetection):
         ):
             element = create_element(
                 type=self.labels[label],
-                bbox=BoundingBox(box[0] / w, box[1] / h, box[2] / w, box[3] / h),
+                bbox=BoundingBox(box[0] / w, box[1] / h, box[2] / w, box[3] / h).coordinates,
                 properties={"score": score},
             )
             elements.append(element)


### PR DESCRIPTION
This matches the behavior of Document and fixes issues serializing exploded elements for OpenSearch.