### PR TITLE
Set table object to None when no table is found.

### DIFF
--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -155,6 +155,10 @@ class TableTransformerStructureExtractor(TableStructureExtractor):
         # phases of postprocessing.
         table = table_transformers.objects_to_table(objects, tokens)
 
+        if table is None:
+            element.table = None
+            return element
+
         # Convert cell bounding boxes to be relative to the original image.
         for cell in table.cells:
             if cell.bbox is None:

--- a/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
@@ -100,7 +100,7 @@ DEFAULT_STRUCTURE_CLASS_THRESHOLDS = {
 }
 
 
-def objects_to_table(objects, tokens, structure_class_thresholds=DEFAULT_STRUCTURE_CLASS_THRESHOLDS) -> Table:
+def objects_to_table(objects, tokens, structure_class_thresholds=DEFAULT_STRUCTURE_CLASS_THRESHOLDS) -> Optional[Table]:
     structures = objects_to_structures(objects, tokens=tokens, class_thresholds=structure_class_thresholds)
 
     cells, _ = structure_to_cells(structures, tokens=tokens)
@@ -116,6 +116,9 @@ def objects_to_table(objects, tokens, structure_class_thresholds=DEFAULT_STRUCTU
                 bbox=BoundingBox(*cell["bbox"]),
             )
         )
+
+    if len(table_cells) == 0:
+        return None
 
     return Table(table_cells)
 


### PR DESCRIPTION
This happens when the DETR partitioning model finds a table, but the table structure extraction model does not identify rows or columns.

This change simple leaves the TableElement as is and sets the table attribute to be None.