### PR TITLE
Fix model deserialization error

### DIFF
--- a/lib/sycamore/sycamore/transforms/partition.py
+++ b/lib/sycamore/sycamore/transforms/partition.py
@@ -390,10 +390,10 @@ class SycamorePartitioner(Partitioner):
         extract_table_structure=False,
         table_structure_extractor=DEFAULT_TABLE_STRUCTURE_EXTRACTOR,
         extract_images=False,
+        device=None,
     ):
-        from sycamore.transforms.detr_partitioner import SycamorePDFPartitioner
-
-        self._partitioner = SycamorePDFPartitioner(model_name_or_path)
+        self._model_name_or_path = model_name_or_path
+        self._device = device
         self._threshold = threshold
         self._use_ocr = use_ocr
         self._ocr_images = ocr_images
@@ -438,9 +438,12 @@ class SycamorePartitioner(Partitioner):
 
     def partition(self, document: Document) -> Document:
         binary = io.BytesIO(document.data["binary_representation"])
+        from sycamore.transforms.detr_partitioner import SycamorePDFPartitioner
+
+        partitioner = SycamorePDFPartitioner(self._model_name_or_path, device=self._device)
 
         try:
-            result = self._partitioner.partition_pdf(
+            result = partitioner.partition_pdf(
                 binary,
                 self._threshold,
                 use_ocr=self._use_ocr,


### PR DESCRIPTION
Looks like the driver/worker process model ser/de incompatible, move model instantiation inside worker process to get rid of the ser/de.
```
RuntimeError: Attempting to deserialize object on a CUDA device but
torch.cuda.is_available() is False. If you are running on a CPU-only
machine, please use torch.load with map_location=torch.device('cpu')
to map your storages to the CPU.
```