### PR TITLE
Add remote model server support

### DIFF
--- a/lib/sycamore/sycamore/transforms/detr_partitioner.py
+++ b/lib/sycamore/sycamore/transforms/detr_partitioner.py
@@ -227,17 +227,13 @@ class DeformableDetr(SycamoreObjectDetection):
             files = [("metadata", gzip.compress(metadata_string.encode("utf-8")))] + [
                 ("images", gzip.compress(image.tobytes())) for image in images
             ]
-            try:
-                response = requests.post(endpoint, files=files)
-                results = response.json()
-            except Exception:
-                results = None
-            if results:
-                for result in results:
-                    for k, v in result.items():
-                        result[k] = base64.b64decode(v)
-                        result[k] = pickle.loads(result[k])
-        if not model_server_endpoint or not results:
+            response = requests.post(endpoint, files=files)
+            results = response.json()
+            for result in results:
+                for k, v in result.items():
+                    result[k] = base64.b64decode(v)
+                    result[k] = pickle.loads(result[k])
+        else:
             results = []
             for image in images:
                 inputs = self.processor(images=image, return_tensors="pt").to(self._get_device())

--- a/lib/sycamore/sycamore/transforms/detr_partitioner.py
+++ b/lib/sycamore/sycamore/transforms/detr_partitioner.py
@@ -15,6 +15,7 @@ import requests
 import json
 import pickle
 import os
+import gzip
 
 import torch
 
@@ -221,7 +222,9 @@ class DeformableDetr(SycamoreObjectDetection):
             endpoint = MODEL_SERVER_ENDPOINT + self._model_name_or_path
             metadata = {"threshold": threshold, "modes": [image.mode], "sizes": [image.size]}
             metadata_string = json.dumps(metadata)
-            files = [("metadata", metadata_string.encode("utf-8"))] + [("images", image.tobytes())]
+            files = [("metadata", gzip.compress(metadata_string.encode("utf-8")))] + [
+                ("images", gzip.compress(image.tobytes()))
+            ]
             try:
                 response = requests.post(endpoint, files=files)
                 results = response.json()[0]
@@ -283,7 +286,9 @@ class DeformableDetr(SycamoreObjectDetection):
                 "sizes": [image.size for image in images],
             }
             metadata_string = json.dumps(metadata)
-            files = [("metadata", metadata_string.encode("utf-8"))] + [("images", image.tobytes()) for image in images]
+            files = [("metadata", gzip.compress(metadata_string.encode("utf-8")))] + [
+                ("images", gzip.compress(image.tobytes())) for image in images
+            ]
             try:
                 response = requests.post(endpoint, files=files)
                 results = response.json()

--- a/lib/sycamore/sycamore/transforms/partition.py
+++ b/lib/sycamore/sycamore/transforms/partition.py
@@ -390,6 +390,8 @@ class SycamorePartitioner(Partitioner):
         extract_table_structure=False,
         table_structure_extractor=DEFAULT_TABLE_STRUCTURE_EXTRACTOR,
         extract_images=False,
+        model_server_endpoint=None,
+        batch_size: int = 10,
     ):
         from sycamore.transforms.detr_partitioner import SycamorePDFPartitioner
 
@@ -401,6 +403,8 @@ class SycamorePartitioner(Partitioner):
         self._extract_table_structure = extract_table_structure
         self._table_structure_extractor = table_structure_extractor
         self._extract_images = extract_images
+        self._model_server_endpoint = model_server_endpoint
+        self._batch_size = batch_size
 
     # For now, we reorder elements based on page, left/right column, y axle position then finally x axle position
     @staticmethod
@@ -438,7 +442,6 @@ class SycamorePartitioner(Partitioner):
 
     def partition(self, document: Document) -> Document:
         binary = io.BytesIO(document.data["binary_representation"])
-
         try:
             result = self._partitioner.partition_pdf(
                 binary,
@@ -449,6 +452,8 @@ class SycamorePartitioner(Partitioner):
                 extract_table_structure=self._extract_table_structure,
                 table_structure_extractor=self._table_structure_extractor,
                 extract_images=self._extract_images,
+                model_server_endpoint=self._model_server_endpoint,
+                batch_size=self._batch_size,
             )
         except Exception as e:
             path = document.properties["path"]


### PR DESCRIPTION
Adds client side code to use a remote model server.  When a the parameter `model_server_endpoint` is specified to `SycamorePartitioner` or `DeformableDetr.infer`, it will attempt to use the model server for acceleration; otherwise there is no change in behavior.

### How to Use
To use a locally running model server on port 8000 with a `SycamorePartitioner` from within a docker container: `SycamorePartitioner("Aryn/deformable-detr-DocLayNet", model_server_endpoint="http://host.docker.internal:8000/")`

Or use the `DeformableDetr` model directly: 
`from PIL import Image`
`import requests`
`example_url = "https://huggingface.co/Aryn/deformable-detr-DocLayNet/resolve/main/examples/doclaynet_example_1.png"`
`image = Image.open(requests.get(example_url, stream=True).raw)`
`d.infer((image,), 0.7, model_server_endpoint="http://example.com")`