### PR TITLE
ensure unique uuids post explode via sequence numbers

### DIFF
--- a/lib/sycamore/sycamore/transforms/explode.py
+++ b/lib/sycamore/sycamore/transforms/explode.py
@@ -33,9 +33,9 @@ class Explode(SingleThreadUser, NonGPUUser, Transform):
 
             import uuid
 
-            for element in parent.elements:
+            for i, element in enumerate(parent.elements):
                 cur = Document(element.data)
-                cur.doc_id = str(uuid.uuid1())
+                cur.doc_id = str(uuid.uuid1(clock_seq=i))
                 cur.parent_id = parent.doc_id
                 for doc_property in parent.properties.keys():
                     if doc_property.startswith("_"):


### PR DESCRIPTION
I managed to get a bunch of docs with non-unique uuids post-explode, e.g.
```
fd9b2074-130f-11ef-a237-3a049e7f7082
fd9b2164-130f-11ef-a237-3a049e7f7082
fd9b2196-130f-11ef-a237-3a049e7f7082
...
```
Not sure how that happened, but this aims to make sure that the uuid1 function always has a different input. If we overflow the counter then we've pigeonholed ourselves anyway