### PR TITLE
Refactor drawing code to support additional formats.

### DIFF
--- a/lib/sycamore/sycamore/data/table.py
+++ b/lib/sycamore/sycamore/data/table.py
@@ -223,17 +223,6 @@ class Table:
            target: An Image or ImageDraw objects on which to draw this table.
               If target is an Image, an ImageDraw object will be created.
         """
+        from sycamore.utils.image_utils import try_draw_boxes
 
-        if isinstance(target, ImageDraw.ImageDraw):
-            canvas = target
-            width, height = target.im.size
-        elif isinstance(target, Image.Image):
-            canvas = ImageDraw.Draw(target)
-            width, height = target.size
-
-        for cell in self.cells:
-            if cell.bbox is not None:
-                coords = cell.bbox.to_absolute(width, height).coordinates
-                canvas.rectangle(coords, outline="red")  # TODO color
-
-        return target
+        return try_draw_boxes(target, self.cells, color_fn=lambda _: "red", text_fn=lambda _, i: None)

--- a/lib/sycamore/sycamore/tests/integration/test_image_utils.py
+++ b/lib/sycamore/sycamore/tests/integration/test_image_utils.py
@@ -1,0 +1,95 @@
+import pytest
+
+import pdf2image
+from PIL import Image
+
+
+import sycamore
+from sycamore.data import BoundingBox
+from sycamore.utils.image_utils import try_draw_boxes
+from sycamore.tests.config import TEST_DIR
+from sycamore.transforms.partition import SycamorePartitioner
+
+
+path = str(TEST_DIR / "resources/data/pdfs/Ray_page11.pdf")
+
+
+@pytest.fixture(scope="module")
+def image_boxes() -> list[BoundingBox]:
+    context = sycamore.init()
+    docs = (
+        context.read.binary(paths=[path], binary_format="pdf")
+        .partition(partitioner=SycamorePartitioner())
+        .explode()
+        .take_all()
+    )
+    return [d.bbox for d in docs if d.bbox is not None]
+
+
+@pytest.fixture(scope="module")
+def source_image() -> Image.Image:
+    images = pdf2image.convert_from_path(path)
+    return images[0].convert(mode="RGBA")
+
+
+# Checks that the image contains blue pixels. This is of course an imperfect check, but
+# it at least will tell us if we drew some bounding boxes. on the image. Won't work
+# if the image contains blue pixels to begin with. Image must have mode RGBA.
+def check_image(image: Image.Image, expected_color=(0, 0, 255, 255)) -> None:
+    raw_colors = image.getcolors(64_000)
+    assert expected_color in set((color_tup[1] for color_tup in raw_colors))
+
+
+def test_draw_boxes_bbox(source_image, image_boxes):
+    output: Image.Image = try_draw_boxes(source_image, image_boxes)
+    check_image(output)
+
+
+def test_draw_boxes_object_bbox(source_image, image_boxes):
+    class BBoxHolder:
+        def __init__(self, bbox):
+            self._bbox = bbox
+
+        @property
+        def bbox(self):
+            return self._bbox
+
+    boxes = [BBoxHolder(b) for b in image_boxes]
+    output: Image.Image = try_draw_boxes(source_image, boxes)
+    check_image(output)
+
+
+def test_draw_boxes_coord_list(source_image, image_boxes):
+    boxes = [b.coordinates for b in image_boxes]
+    output: Image.Image = try_draw_boxes(source_image, boxes)
+    check_image(output)
+
+
+def test_draw_boxes_point_list(source_image, image_boxes):
+    boxes = [[(b.x1, b.y1), (b.x2, b.y1), (b.x2, b.y2), (b.x1, b.y2)] for b in image_boxes]
+    output: Image.Image = try_draw_boxes(source_image, boxes)
+    check_image(output)
+
+
+def test_draw_boxes_two_points(source_image, image_boxes):
+    boxes = [((b.x1, b.y1), (b.x2, b.y2)) for b in image_boxes]
+    output: Image.Image = try_draw_boxes(source_image, boxes)
+    check_image(output)
+
+
+def test_draw_boxes_dict(source_image, image_boxes):
+    boxes = [{"bbox": b.coordinates} for b in image_boxes]
+    output: Image.Image = try_draw_boxes(source_image, boxes)
+    check_image(output)
+
+
+def test_invalid_list(source_image, image_boxes):
+    boxes = [[b.coordinates] for b in image_boxes]
+    with pytest.raises(ValueError):
+        try_draw_boxes(source_image, boxes)
+
+
+def test_invalid_dict(source_image, image_boxes):
+    boxes = [{"bboxes": b.coordinates} for b in image_boxes]
+    with pytest.raises(ValueError):
+        try_draw_boxes(source_image, boxes)

--- a/lib/sycamore/sycamore/utils/image_utils.py
+++ b/lib/sycamore/sycamore/utils/image_utils.py
@@ -1,10 +1,8 @@
 import base64
 from io import BytesIO
-from typing import Optional
-
-from PIL import Image
-
-from sycamore.data import BoundingBox
+from typing import Any, Callable, Optional, TypeVar, Union
+from PIL import Image, ImageDraw, ImageFont
+from sycamore.data.bbox import BoundingBox
 
 DEFAULT_PADDING = 10
 
@@ -58,3 +56,142 @@ def base64_data_url(image: Image.Image) -> str:
 
     encoded_image = image_to_bytes(image, "PNG")
     return f"data:image/png/;base64,{base64.b64encode(encoded_image).decode('utf-8')}"
+
+
+def _is_pair(val, target_type=float):
+    return (
+        isinstance(val, (list, tuple))
+        and len(val) == 2
+        and isinstance(val[0], target_type)
+        and isinstance(val[1], target_type)
+    )
+
+
+def _default_coord_fn(box) -> tuple[float, float, float, float]:
+    """Tries to heuristically extract rectangular coordinates from an object.
+
+    We attempt to pull coordinates from the following formats:
+
+    - BoundingBoxes
+
+    - An object with a 'bbox' attr (like a Document or Element).
+
+    - Lists or tuples of the form:
+      - [x_1, y_1, x_2, y_2]
+      - [[x_1, y_1], [x_2, y_2]]
+      - [[x_1, y_1], [x_3, y_3], [x_2, y_2], [x_4, y_4]]
+
+    - Dictionaries with a key "bbox" and a value that is one of preceding types.
+
+    This particular function does not attempt to distinguish between relative and absolute
+    coordinates. That's done in the calling context where we have access to the image size.
+    """
+
+    if isinstance(box, BoundingBox):
+        return box.coordinates
+    elif hasattr(box, "bbox"):
+        return _default_coord_fn(box.bbox)
+    elif isinstance(box, dict):
+        if "bbox" not in box:
+            raise ValueError(f"Unable to extract coordinates from dict {box}.")
+        return _default_coord_fn(box["bbox"])
+    elif isinstance(box, (list, tuple)):
+        if len(box) == 2:
+            if _is_pair(box[0], float) and _is_pair(box[1], float):
+                return (box[0][0], box[0][1], box[1][0], box[1][1])
+            raise ValueError(f"Unable to extract coordinates from sequence {box}")
+
+        elif len(box) == 4:
+            if all(_is_pair(coord, float) for coord in box):
+                return (box[0][0], box[0][1], box[2][0], box[2][1])
+            elif all(isinstance(c, float) for c in box):
+                return tuple(box)
+            raise ValueError(f"Unable to extract coordinates from sequence {box}")
+
+        else:
+            raise ValueError(f"Unrecognized list format {box}")
+    else:
+        raise ValueError(f"Unable to extract coordinates from {box}")
+
+
+def _default_text_fn(box, index) -> Optional[str]:
+    return str(index)
+
+
+def _default_color_fn(box) -> str:
+    return "blue"
+
+
+U = TypeVar("U", bound=Union[Image.Image, ImageDraw.ImageDraw])
+
+
+def try_draw_boxes(
+    target: U,
+    boxes: Any,
+    coord_fn: Callable[[Any], tuple[float, float, float, float]] = _default_coord_fn,
+    text_fn: Callable[[Any, int], Optional[str]] = _default_text_fn,
+    color_fn: Callable[[Any], str] = _default_color_fn,
+    font_path: Optional[str] = None,
+) -> U:
+    """Convenience method to visualize bounding boxes on a PIL image.
+
+    It is often desirable to visualize bounding boxes on a document image to evaluate
+    partitioning and OCR techniques. The DrawBoxes function provides this functionality
+    for DocSets after partitioning, but over time it has been useful to have this available
+    more broadly for testing new libraries or methods.
+
+    This method attempts to "do the right thing" for a variety of bounding box formats and is
+    customizable so it can work in a variety of contexts.
+
+    Args:
+        target: The Image or ImageDraw instance on which to draw the boxes.
+        boxes: Sequence of boxes to draw on the target. The box can be specfiied in a variety of ways,
+            and will be interpreted by the methods passed in below.
+        coord_fn: Function that takes a box and returns a tuple of coordinates in the form (x1, y1, x2, y2).
+            The default attempts to infer the coordinates from a variety of list/dict formats.
+        text_fn: Function that takes a box and returns text to display next to each bounding box.
+            If text_fn returns None, no text will be rendered.
+        color_fn: Function that takes a box and returns the color to draw the box.
+        font_path: Path to a TrueType font for rendering text. Deafults to PIL's default font.
+    """
+
+    if isinstance(target, ImageDraw.ImageDraw):
+        canvas = target
+        width, height = target.im.size
+
+    elif isinstance(target, Image.Image):
+        canvas = ImageDraw.Draw(target)
+        width, height = target.size
+
+    if font_path is not None:
+        font = ImageFont.truetype(font_path, 20)
+    else:
+        font = ImageFont.load_default(size=20)
+
+    for i, box in enumerate(boxes):
+        raw_coords = coord_fn(box)
+
+        # If the coordinates are all less than or equal to 1.0, then we treat them
+        # as relative coordinates, and we convert them to absolute coordinates.
+        if all(c <= 1.0 for c in raw_coords):
+            coords = BoundingBox(*raw_coords).to_absolute_self(width, height).coordinates
+        else:
+            coords = raw_coords
+
+        canvas.rectangle(coords, outline=color_fn(box), width=3)
+
+        text = text_fn(box, i)
+
+        if text is not None:
+            text_location = (coords[0] - width / 100, coords[1] - height / 100)
+            font_box = canvas.textbbox(text_location, text, font=font)
+            canvas.rectangle(font_box, fill="yellow")
+            canvas.text(
+                text_location,
+                text,
+                fill="black",
+                font=font,
+                align="left",
+            )
+
+    return target


### PR DESCRIPTION
This commit introduces a new utility function to draw a collection of boxes on a PIL image. This is used in both the DrawBoxes class and the table drawing code. In general it is useful for testing new OCR/detection methods, even when outside of DocSets.

This change should not impact existing public sycamore code.