### PR TITLE
Switch from uuid1() to uuid4() in explode.

### DIFF
--- a/lib/sycamore/sycamore/transforms/explode.py
+++ b/lib/sycamore/sycamore/transforms/explode.py
@@ -32,11 +32,9 @@ class Explode(SingleThreadUser, NonGPUUser, FlatMap):
 
         import uuid
 
-        assert uuid.uuid1().is_safe == uuid.SafeUUID.safe
-
         for i, element in enumerate(parent.elements):
             cur = Document(element.data)
-            cur.doc_id = str(uuid.uuid1(clock_seq=i))
+            cur.doc_id = str(uuid.uuid4())
             cur.parent_id = parent.doc_id
             for doc_property in parent.properties.keys():
                 if doc_property.startswith("_"):


### PR DESCRIPTION
uuid1().is_safe returns unknown on Mac, and it's posible that concurrent calls may produce collisions on the same host. This change just switches to uuid4 (random uuids) to reduce this risk.