### PR TITLE
Adjust assertion for batch_size resource_arg.

### DIFF
--- a/lib/sycamore/sycamore/transforms/embed.py
+++ b/lib/sycamore/sycamore/transforms/embed.py
@@ -277,7 +277,14 @@ class Embed(MapBatch):
         self.resource_args = resource_args
         if "batch_size" not in self.resource_args:
             self.resource_args["batch_size"] = embedder.batch_size
-            assert self.resource_args["batch_size"] > 0
+
+            # Batch size can be an integer, None, or the string "default" per
+            # https://docs.ray.io/en/latest/data/api/doc/ray.data.Dataset.map_batches.html
+            assert (
+                self.resource_args["batch_size"] is None
+                or self.resource_args["batch_size"] > 0
+                or self.resource_args["batch_size"] == "default"
+            )
 
         if embedder.device == "cuda":
             if "num_gpus" not in self.resource_args:

--- a/lib/sycamore/sycamore/transforms/embed.py
+++ b/lib/sycamore/sycamore/transforms/embed.py
@@ -280,9 +280,10 @@ class Embed(MapBatch):
 
             # Batch size can be an integer, None, or the string "default" per
             # https://docs.ray.io/en/latest/data/api/doc/ray.data.Dataset.map_batches.html
+            batch_size = self.resource_args["batch_size"]
             assert (
-                self.resource_args["batch_size"] is None
-                or self.resource_args["batch_size"] > 0
+                batch_size is None
+                or (isinstance(batch_size, int) and batch_size > 0)
                 or self.resource_args["batch_size"] == "default"
             )
 


### PR DESCRIPTION
This parameter is used by Ray to control how it batches records for map_batches. We recently added an assertion that this is a positive integer, but None and the literal string "default" are also valid options for Ray. This was causing some of our integration tests to fail.