### PR TITLE
remove empty lists from documents in weaviate writer

### DIFF
--- a/examples/simple_weaviate.py
+++ b/examples/simple_weaviate.py
@@ -1,8 +1,8 @@
 import sys
 
-from weaviate.classes.config import Property, ReferenceProperty
+from weaviate.classes.config import ReferenceProperty
 from weaviate.client import AdditionalConfig, ConnectionParams
-from weaviate.collections.classes.config import Configure, DataType
+from weaviate.collections.classes.config import Configure
 from weaviate.config import Timeout
 
 # ruff: noqa: E402
@@ -39,26 +39,7 @@ wv_client_args = {
 collection_config_params = {
     "name": collection,
     "description": "A collection to demo data-prep with Sycamore",
-    "properties": [
-        Property(
-            name="properties",
-            data_type=DataType.OBJECT,
-            nested_properties=[
-                Property(
-                    name="links",
-                    data_type=DataType.OBJECT_ARRAY,
-                    nested_properties=[
-                        Property(name="text", data_type=DataType.TEXT),
-                        Property(name="url", data_type=DataType.TEXT),
-                        Property(name="start_index", data_type=DataType.NUMBER),
-                    ],
-                ),
-            ],
-        ),
-        Property(name="bbox", data_type=DataType.NUMBER_ARRAY),
-        Property(name="shingles", data_type=DataType.INT_ARRAY),
-    ],
-    "vectorizer_config": [Configure.NamedVectors.text2vec_transformers(name="embedding")],
+    "vectorizer_config": [Configure.NamedVectors.none(name="embedding")],
     "references": [ReferenceProperty(name="parent", target_collection=collection)],
 }
 model_name = "sentence-transformers/all-MiniLM-L6-v2"

--- a/lib/sycamore/sycamore/writers/weaviate_writer.py
+++ b/lib/sycamore/sycamore/writers/weaviate_writer.py
@@ -1,5 +1,4 @@
 import logging
-from types import NoneType
 from typing import Any, Iterable, Optional
 
 from ray.data import Dataset, Datasink
@@ -76,7 +75,7 @@ class WeaviateDatasink(Datasink):
     def _extract_weaviate_objects(block):
         # Weaviate doesn't like explicitly null values
         def not_none(x):
-            return not isinstance(x, NoneType)
+            return x is not None
 
         # Weaviate defaults empty lists to text[], which is often incorrect
         def not_empty_list(x):

--- a/lib/sycamore/sycamore/writers/weaviate_writer.py
+++ b/lib/sycamore/sycamore/writers/weaviate_writer.py
@@ -7,8 +7,6 @@ from ray.data._internal.execution.interfaces import TaskContext
 from ray.data.block import Block, BlockAccessor
 from sycamore.data.document import Document
 from sycamore.plan_nodes import Node, Write
-from weaviate import WeaviateClient
-from weaviate.collections.classes.data import DataReference
 
 
 class WeaviateWriter(Write):
@@ -39,6 +37,8 @@ class WeaviateDatasink(Datasink):
         self._collection_config = collection_config
 
     def on_write_start(self):
+        from weaviate import WeaviateClient
+
         with WeaviateClient(**self._client_params) as client:
             if self._collection_config is not None:
                 if client.collections.exists(self._collection_name):
@@ -50,6 +50,9 @@ class WeaviateDatasink(Datasink):
                     client.collections.create(**self._collection_config)
 
     def write(self, blocks: Iterable[Block], ctx: TaskContext) -> Any:
+        from weaviate import WeaviateClient
+        from weaviate.collections.classes.data import DataReference
+
         builder = DelegatingBlockBuilder()
         for block in blocks:
             builder.add_block(block)


### PR DESCRIPTION
Weaviate autoschema will parse empty lists as lists of strings and then refuse to ingest subsequent documents that prove this assumption wrong. But empty lists don't have any meaningful information in them, so we can simply drop them entirely from the record, so weaviate will not have problems. This means we have a much easier time specifying out the problematic fields ahead of time because there aren't any.