### PR TITLE
Fix split_and_convert_to_image when some pages have no elements.

### DIFF
--- a/lib/sycamore/sycamore/functions/document.py
+++ b/lib/sycamore/sycamore/functions/document.py
@@ -47,12 +47,12 @@ def split_and_convert_to_image(doc: Document) -> list[Document]:
         page_number = e.properties["page_number"]
         elements_by_page.setdefault(page_number, []).append(e)
 
-    sorted_elements_by_page = sorted(elements_by_page.items(), key=lambda x: x[0])
     new_docs = []
-    for image, (page, elements) in zip(images, sorted_elements_by_page):
+    for page, image in enumerate(images):
+        elements = elements_by_page.get(page + 1, [])
         new_doc = Document(binary_representation=image.tobytes(), elements=elements)
         new_doc.properties.update(doc.properties)
-        new_doc.properties.update({"size": list(image.size), "mode": image.mode, "page_number": page})
+        new_doc.properties.update({"size": list(image.size), "mode": image.mode, "page_number": page + 1})
         new_docs.append(new_doc)
     return new_docs
 

--- a/lib/sycamore/sycamore/tests/integration/functions/test_document.py
+++ b/lib/sycamore/sycamore/tests/integration/functions/test_document.py
@@ -1,0 +1,34 @@
+from typing import Optional
+
+import sycamore
+from sycamore.data import Element
+from sycamore.functions.document import split_and_convert_to_image
+from sycamore.transforms.partition import UnstructuredPdfPartitioner
+from sycamore.tests.config import TEST_DIR
+
+
+def test_split_and_convert_to_image_empty_page():
+    def _drop_page2(element: Element) -> Optional[Element]:
+        if element.properties["page_number"] == 2:
+            return None
+        return element
+
+    path = TEST_DIR / "resources/data/pdfs/Ray.pdf"
+
+    context = sycamore.init()
+
+    # Remove all elements from page 2, and make sure that page2 still shows up in the output.
+    docs = (
+        context.read.binary(paths=[str(path)], binary_format="pdf")
+        .partition(partitioner=UnstructuredPdfPartitioner())
+        .map_elements(_drop_page2)
+        .flat_map(split_and_convert_to_image)
+        .take_all()
+    )
+
+    assert len(docs) == 17
+
+    page2_candidate = [d for d in docs if d.properties["page_number"] == 2]
+
+    assert len(page2_candidate) == 1
+    assert len(page2_candidate[0].elements) == 0


### PR DESCRIPTION
There was an edge case with the previous implementation where a page with no elements would cause images and elements to be misaligned. This fixes that problem by always counting pages based on pages (images) from the pdf rather than elements.