### PR TITLE
TimeTrace: Fallback to RUSAGE_SELF when RUSAGE_THREAD isn't present.

### DIFF
--- a/apps/timetrace/Makefile
+++ b/apps/timetrace/Makefile
@@ -1,4 +1,4 @@
-CXX := g++ --std=c++23 -W -Wall -O3
+CXX := g++ --std=c++20 -W -Wall -O3
 
 EXES := ttviz
 

--- a/apps/timetrace/README.md
+++ b/apps/timetrace/README.md
@@ -1,0 +1,30 @@
+The ttviz program is a small utility for visualize the TimeTrace output for Sycamore scripts.
+
+## Basic Usage
+
+Compile ttviz
+
+    make
+
+Run a Scyamore script with TimeTrace enabled:
+
+    TIMETRACE=/path/to/output/ poetry run python my_scamore_script.py
+
+Run ttviz on output.
+
+    ./ttviz /path/to/output/*
+
+The visualization is written to `viz.png`
+
+## Mac OS X Setup Instructions
+
+This program depends on the `gd` utility. The easiest way to install this on the Mac is using Homebrew:
+
+    brew install libgd
+
+in order for the compiler to find the new library, you need to set the `CPATH` and `LIBRARY_PATH` environment variables to pick up Homebrew installed libraries. Depending on your shell and setup, the following may work
+
+    export CPATH=$HOMEBREW_PREFIX:$CPATH
+    export LIBRARY_PATH=$HOMEBREW_PREFIX:$LIBRARY_PATH
+
+Typically `HOMEBREW_PREFIX` should be set to `/opt/homebrew`.

--- a/lib/sycamore/sycamore/utils/time_trace.py
+++ b/lib/sycamore/sycamore/utils/time_trace.py
@@ -11,7 +11,7 @@ class TimeTrace:
     fd = -1
 
     try:
-        resource_type = resource.RUSAGE_THREAD # type: ignore
+        resource_type = resource.RUSAGE_THREAD  # type: ignore
     except AttributeError:
         resource_type = resource.RUSAGE_SELF
 


### PR DESCRIPTION
This is true on the Mac, for instance. Also, switch the ttviz Makefile to c++20 to be more accomodating to older compilers and add a README.