### PR TITLE
Fix cross-test error

### DIFF
--- a/lib/sycamore/sycamore/tests/unit/transforms/test_sketcher.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_sketcher.py
@@ -1,8 +1,13 @@
+import ray
 import ray.data
 
 from sycamore.data import Document
 from sycamore.transforms.sketcher import Sketcher, SketchUniquify
 from sycamore.plan_nodes import Node
+
+
+def tearDownModule():
+    ray.shutdown()
 
 
 class FakeNode(Node):


### PR DESCRIPTION
Without the shutdown, running:

poetry run pytest lib/sycamore/sycamore/tests/unit/transforms/test_ske*.py lib/sycamore/sycamore/tests/unit/transforms/test_random_sample.py

yields:

RuntimeError: Maybe you called ray.init twice by accident? This error can be suppressed by passing in 'ignore_reinit_error=True' or by calling 'ray.shutdown()' prior to 'ray.init()'

Unclear why it's only needed here.