### PR TITLE
Run poetry lock in openai-proxy with poetry-lock-all.sh

### DIFF
--- a/lib/poetry-lock/poetry-lock-all.sh
+++ b/lib/poetry-lock/poetry-lock-all.sh
@@ -21,12 +21,20 @@ done
 
 for i in ${tomls}; do
     # Demo UI needs 0.28, rest of sycamore needs 1.x
-    [[ $i = *openai-proxy* ]] && continue
+    if [[ $i = *openai-proxy* ]]; then
+        (
+            echo "--------------------- special casing in $i"
+            cd $(dirname "$i")
+            poetry lock --no-update || exit 1
+            # Do not apply the consistency logic, it can't do anything useful.
+        ) || exit 1
+        continue
+    fi
     (
         echo "--------------------- processing in $i"
         cd $(dirname "$i")
         poetry lock --no-update || exit 1
         poetry install 2>&1 | tee /tmp/poetry-install.out || exit 1
         perl -ne 'print qq{$1 = "$2"\n} if /Downgrading (\S+) \((\S+) ->/o;' </tmp/poetry-install.out
-    )
+    ) || exit 1
 done


### PR DESCRIPTION
We haven't fixed the proxy to be consistent, so fix the script to special case that directory. Fixes issue with the poetry.lock file not being updated when it needs to be.