### PR TITLE
Build Jupyter image with CUDA stuff included.

### DIFF
--- a/apps/jupyter/jupyter-docker-root-setup.sh
+++ b/apps/jupyter/jupyter-docker-root-setup.sh
@@ -22,6 +22,6 @@ EOF
 fi
 
 export DEBIAN_FRONTEND=noninteractive
-
+sed -i -e 's/^Components: main/Components: main contrib non-free non-free-firmware/' /etc/apt/sources.list.d/debian.sources
 apt update
-apt -y install --no-install-recommends fonts-liberation less sudo groff-base
+apt -y install --no-install-recommends fonts-liberation less sudo groff-base nvidia-cuda-toolkit-gcc libnvidia-tesla-cuda1


### PR DESCRIPTION
Beware that this increases the size of the image `arynai/sycamore-jupyter` from 7.06GB to 12.7GB.  We should probably look for a more efficient way to do this.  But, in the meantime, this PR is available if people need it.