### PR TITLE
Another approach to CUDA support in Docker, with less bloat.

### DIFF
--- a/apps/jupyter/fixuser.py
+++ b/apps/jupyter/fixuser.py
@@ -93,7 +93,7 @@ def install_cuda():
         aa = a.stdout.split()[0]
         bb = b.stdout.split()[0]
         if aa != bb:
-            print(f"WARNING: diverted version does not match installed version: {divert}")
+            print(f"WARNING: diverted version does not match installed version: {divert}", flush=True)
 
 
 def exec_run_jupyter(uid, gid):

--- a/apps/jupyter/fixuser.py
+++ b/apps/jupyter/fixuser.py
@@ -67,7 +67,13 @@ def install_cuda():
         return
     os.environ["DEBIAN_FRONTEND"] = "noninteractive"
     cmds = [
-        ["sed", "-i", "-e", "s/^Components: main/Components: main contrib non-free non-free-firmware/", "/etc/apt/sources.list.d/debian.sources"],
+        [
+            "sed",
+            "-i",
+            "-e",
+            "s/^Components: main/Components: main contrib non-free non-free-firmware/",
+            "/etc/apt/sources.list.d/debian.sources",
+        ],
         ["apt", "update"],
         ["dpkg-divert", "--no-rename", "/lib/firmware/nvidia/525.147.05/gsp_ad10x.bin"],
         ["dpkg-divert", "--no-rename", "/lib/firmware/nvidia/525.147.05/gsp_tu10x.bin"],

--- a/apps/jupyter/fixuser.py
+++ b/apps/jupyter/fixuser.py
@@ -29,6 +29,8 @@ def main():
     else:
         print("uid", app_stat.st_uid, "and gid", app_stat.st_gid, "already match between /app and /app/work/bind_dir")
 
+    install_cuda()
+
     exec_run_jupyter(bind_stat.st_uid, bind_stat.st_gid)
 
 
@@ -56,6 +58,25 @@ def fix_ids(uid, gid):
     # crawl data shouldn't be changed to our fancy user
     subprocess.run(["/bin/sh", "-c", "find /app -path /app/work/crawl_data -prune -o -print0 | xargs -0 chown app:app"])
     print("SUCCESS: uid & gid fixed", flush=True)
+
+
+def install_cuda():
+    try:
+        os.stat("/dev/nvidiactl")  # check gpu device is present
+    except FileNotFoundError:
+        return
+    os.environ["DEBIAN_FRONTEND"] = "noninteractive"
+    cmds = [
+        ["sed", "-i", "-e", "s/^Components: main/Components: main contrib non-free non-free-firmware/", "/etc/apt/sources.list.d/debian.sources"],
+        ["apt", "update"],
+        ["dpkg-divert", "--no-rename", "/lib/firmware/nvidia/525.147.05/gsp_ad10x.bin"],
+        ["dpkg-divert", "--no-rename", "/lib/firmware/nvidia/525.147.05/gsp_tu10x.bin"],
+        ["dpkg-divert", "--no-rename", "/usr/lib/x86_64-linux-gnu/libnvidia-compiler.so.525.147.05"],
+        ["dpkg-divert", "--no-rename", "/usr/bin/nvidia-persistenced"],
+        ["apt", "-y", "install", "nvidia-cuda-toolkit-gcc", "libnvidia-tesla-cuda1"],
+    ]
+    for cmd in cmds:
+        subprocess.run(cmd, check=True)
 
 
 def exec_run_jupyter(uid, gid):


### PR DESCRIPTION
The has the Janky `dpkg-divert` stuff to work around weird installation errors.  But, it saves 5.6GB in image size over the method in PR #448.