### PR TITLE
Provide better error messages on *Map mis-use

### DIFF
--- a/lib/sycamore/sycamore/scans/materialized_scan.py
+++ b/lib/sycamore/sycamore/scans/materialized_scan.py
@@ -33,6 +33,11 @@ class ArrowScan(MaterializedScan):
 class DocScan(MaterializedScan):
     def __init__(self, docs: list[Document], **resource_args):
         super().__init__(**resource_args)
+        if not isinstance(docs, list):
+            raise ValueError("docs should be a list")
+        for d in docs:
+            if not isinstance(d, Document):
+                raise ValueError("each entry in list should be a document")
         self._docs = docs
 
     def execute(self) -> Dataset:

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_mapping.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_mapping.py
@@ -62,6 +62,31 @@ class TestMapping:
         assert dicts[0]["index"] == 2
         assert dicts[1]["index"] == 3
 
+    class Empty:
+        def __init__(self):
+            pass
+
+    class Callable:
+        def __init__(self):
+            pass
+
+        def __call__(self):
+            pass
+
+    def test_map_typecheck(self):
+        Map(None, f=lambda x: x)
+        Map(None, f=TestMapping.Callable)
+        Map(None, f=TestMapping.Callable())
+
+        with pytest.raises(ValueError):
+            Map(None, f={})
+
+        with pytest.raises(ValueError):
+            Map(None, f=TestMapping.Empty)
+
+        with pytest.raises(ValueError):
+            Map(None, f=TestMapping.Empty())
+
     class FlatMapClass:
         def __call__(self, doc: Document) -> List[Document]:
             assert isinstance(doc, Document)
@@ -86,6 +111,20 @@ class TestMapping:
         dicts = output_dataset.take()
         assert len(dicts) == 4
 
+    def test_flatmap_typecheck(self):
+        FlatMap(None, f=lambda x: x)
+        FlatMap(None, f=TestMapping.Callable)
+        FlatMap(None, f=TestMapping.Callable())
+
+        with pytest.raises(ValueError):
+            FlatMap(None, f={})
+
+        with pytest.raises(ValueError):
+            FlatMap(None, f=TestMapping.Empty)
+
+        with pytest.raises(ValueError):
+            FlatMap(None, f=TestMapping.Empty())
+
     class MapBatchClass:
         def __call__(self, docs: List[Document]) -> List[Document]:
             for doc in docs:
@@ -106,6 +145,20 @@ class TestMapping:
         output_dataset = mapping.execute()
         dicts = [Document.from_row(doc).data for doc in output_dataset.take()]
         assert dicts[0]["index"] == 2 and dicts[1]["index"] == 3
+
+    def test_map_batch_typecheck(self):
+        MapBatch(None, f=lambda x: x)
+        MapBatch(None, f=TestMapping.Callable)
+        MapBatch(None, f=TestMapping.Callable())
+
+        with pytest.raises(ValueError):
+            MapBatch(None, f={})
+
+        with pytest.raises(ValueError):
+            MapBatch(None, f=TestMapping.Empty)
+
+        with pytest.raises(ValueError):
+            MapBatch(None, f=TestMapping.Empty())
 
     def test_flat_map_conflict(self, mocker) -> None:
         def func(doc: Document) -> List[Document]:

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_merge_elements.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_merge_elements.py
@@ -1,5 +1,7 @@
+import pytest
 import ray.data
 
+import sycamore
 from sycamore.data import Document
 from sycamore.transforms.merge_elements import GreedyTextElementMerger, Merge
 from sycamore.functions.tokenizer import HuggingFaceTokenizer
@@ -114,3 +116,15 @@ class TestMergeElements:
         merge = Merge(node, merger)
         output_dataset = merge.execute()
         output_dataset.show()
+
+    def test_docset_greedy(self):
+        ray.shutdown()
+
+        context = sycamore.init()
+        tokenizer = HuggingFaceTokenizer("sentence-transformers/all-MiniLM-L6-v2")
+        context.read.document([self.doc]).merge(GreedyTextElementMerger(tokenizer, 120)).show()
+
+        # Verify that GreedyTextElementMerger can't be an argument for map.
+        # We may want to change this in the future.
+        with pytest.raises(ValueError):
+            sycamore.init().read.document([self.doc]).map(GreedyTextElementMerger(tokenizer, 120))

--- a/lib/sycamore/sycamore/transforms/base.py
+++ b/lib/sycamore/sycamore/transforms/base.py
@@ -24,6 +24,28 @@ def rename(new_function_name: str):
     return decorator
 
 
+def get_name_from_callable(f):
+    # check this condition first. A type will have a __name__ but might not have __call__
+    if isinstance(f, type):
+        if "__call__" in dir(f):
+            return f.__name__
+        else:
+            raise ValueError("f argument is a class without an __call__ method")
+
+    # Can't do "__name__" in dir(f), dir(f) doesn't always list __name__, so try to use it and fail
+    try:
+        return f.__name__
+    except AttributeError:
+        pass
+
+    if "__call__" in dir(f):
+        return f.__class__.__name__
+    else:
+        raise ValueError("f argument is an object without an __call__ method")
+
+    raise ValueError(f"Unable to extract name from {f}, dir(f): {dir(f)}")
+
+
 class BaseMapTransform(UnaryNode):
     """
     BaseMapTransform abstracts away MetadataDocuments from all other transforms.
@@ -70,12 +92,7 @@ class BaseMapTransform(UnaryNode):
 
         super().__init__(child, **resource_args)
         if name is None:
-            if "__name__" in dir(f):
-                name = f.__name__
-            elif "__class__" in dir(f):
-                name = f.__class__.__name__
-            else:
-                raise ValueError(f"Unable to extract name from {f}, all members: {dir(f)}")
+            name = get_name_from_callable(f)
 
         self._f = f
         self._name = name

--- a/lib/sycamore/sycamore/transforms/map.py
+++ b/lib/sycamore/sycamore/transforms/map.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Iterable, Optional
 
 from sycamore.data import Document
 from sycamore.plan_nodes import Node
-from sycamore.transforms.base import BaseMapTransform
+from sycamore.transforms.base import BaseMapTransform, get_name_from_callable
 
 
 class Map(BaseMapTransform):
@@ -22,7 +22,7 @@ class Map(BaseMapTransform):
     """
 
     def __init__(self, child: Optional[Node], *, f: Any, **resource_args):
-        super().__init__(child, f=Map.wrap(f), name=f.__name__, **resource_args)
+        super().__init__(child, f=Map.wrap(f), name=get_name_from_callable(f), **resource_args)
 
     @staticmethod
     def wrap(f: Any) -> Callable[[list[Document]], list[Document]]:
@@ -74,7 +74,7 @@ class FlatMap(BaseMapTransform):
     """
 
     def __init__(self, child: Optional[Node], *, f: Callable[[Document], list[Document]], **resource_args):
-        super().__init__(child, f=FlatMap.wrap(f), name=f.__name__, **resource_args)
+        super().__init__(child, f=FlatMap.wrap(f), name=get_name_from_callable(f), **resource_args)
 
     @staticmethod
     def wrap(f: Callable[[Document], list[Document]]) -> Callable[[list[Document]], list[Document]]:


### PR DESCRIPTION
If you pass in a not-callable, the error message can be obscure (__name__ not found) Instead check for the property that we want that the callable is properly named.

Discovered by trying to use map + GreedyTextElementMerger.

Also verify that the names we calculate are correct. They were not before.