### PR TITLE
use unstructured in weaviate IT

### DIFF
--- a/lib/sycamore/sycamore/tests/integration/test_pdf_to_weaviate.py
+++ b/lib/sycamore/sycamore/tests/integration/test_pdf_to_weaviate.py
@@ -10,7 +10,7 @@ from sycamore.functions.tokenizer import HuggingFaceTokenizer
 from sycamore.llms import OpenAIModels, OpenAI
 from sycamore.transforms import COALESCE_WHITESPACE
 from sycamore.transforms.merge_elements import MarkedMerger
-from sycamore.transforms.partition import SycamorePartitioner
+from sycamore.transforms.partition import UnstructuredPdfPartitioner
 from sycamore.transforms.embed import SentenceTransformerEmbedder
 from sycamore.tests.config import TEST_DIR
 import time
@@ -81,7 +81,7 @@ def test_to_weaviate(wv_client_args):
 
     ds = (
         ctx.read.binary(paths, binary_format="pdf")
-        .partition(partitioner=SycamorePartitioner())
+        .partition(partitioner=UnstructuredPdfPartitioner())
         .regex_replace(COALESCE_WHITESPACE)
         .mark_bbox_preset(tokenizer=tokenizer)
         .merge(merger=MarkedMerger())


### PR DESCRIPTION
weird inconsistencies happen because of cuda, so we'll just use unstructured here