### PR TITLE
convert opensearch writer to use base writer 1/3

### DIFF
--- a/lib/sycamore/sycamore/data/document.py
+++ b/lib/sycamore/sycamore/data/document.py
@@ -40,7 +40,7 @@ class Document(UserDict):
 
     @property
     def doc_id(self) -> Optional[str]:
-        """A unique identifier for the document. Defaults to a uuid."""
+        """A unique identifier for the document. Defaults to None."""
         return self.data.get("doc_id")
 
     @doc_id.setter

--- a/lib/sycamore/sycamore/tests/integration/test_html_to_opensearch.py
+++ b/lib/sycamore/sycamore/tests/integration/test_html_to_opensearch.py
@@ -1,6 +1,7 @@
 import json
 import tempfile
 
+from opensearchpy import OpenSearch
 import sycamore
 from sycamore.scans.file_scan import JsonManifestMetadataProvider
 from sycamore.tests.config import TEST_DIR
@@ -25,7 +26,7 @@ def test_html_to_opensearch():
             "settings": {"index.knn": True, "number_of_shards": 5, "number_of_replicas": 1},
             "mappings": {
                 "properties": {
-                    "embeddings": {
+                    "embedding": {
                         "type": "knn_vector",
                         "dimension": 384,
                         "method": {"name": "hnsw", "engine": "faiss"},
@@ -71,3 +72,4 @@ def test_html_to_opensearch():
         ds.write.opensearch(os_client_args=os_client_args, index_name="toyindex", index_settings=index_settings)
     finally:
         tmp_manifest.close()
+        OpenSearch(**os_client_args).indices.delete("toyindex")

--- a/lib/sycamore/sycamore/tests/integration/test_pdf_to_opensearch.py
+++ b/lib/sycamore/sycamore/tests/integration/test_pdf_to_opensearch.py
@@ -8,6 +8,8 @@ from sycamore.transforms.partition import UnstructuredPdfPartitioner
 from sycamore.tests.config import TEST_DIR
 from sycamore.transforms.merge_elements import GreedyTextElementMerger
 
+from opensearchpy import OpenSearch
+
 
 def test_pdf_to_opensearch():
     os_client_args = {
@@ -118,3 +120,5 @@ def test_pdf_to_opensearch():
         index_name="toyindex",
         index_settings=index_settings,
     )
+
+    OpenSearch(**os_client_args).indices.delete("toyindex")

--- a/lib/sycamore/sycamore/tests/unit/test_rewriter.py
+++ b/lib/sycamore/sycamore/tests/unit/test_rewriter.py
@@ -3,6 +3,7 @@ from sycamore.scans import BinaryScan
 from sycamore.transforms import Partition, Explode
 from sycamore.transforms.partition import UnstructuredPdfPartitioner
 from sycamore.writers import OpenSearchWriter
+from sycamore.writers.opensearch import OpenSearchClientParams, OpenSearchTargetParams
 
 
 class TestRewriter:
@@ -10,7 +11,7 @@ class TestRewriter:
         scan = BinaryScan("path", binary_format="pdf")
         partition = Partition(scan, UnstructuredPdfPartitioner())
         explode = Explode(partition)
-        writer = OpenSearchWriter(explode, "test", os_client_args={"a": 1, "b": "str"})
+        writer = OpenSearchWriter(explode, OpenSearchClientParams(), OpenSearchTargetParams(index_name="test"))
 
         rule = EnforceResourceUsage()
         writer.traverse_down(rule)

--- a/lib/sycamore/sycamore/tests/unit/writers/test_base.py
+++ b/lib/sycamore/sycamore/tests/unit/writers/test_base.py
@@ -53,6 +53,9 @@ class FakeTargetParams(BaseDBWriter.TargetParams):
     dirname: str
     mode: str
 
+    def compatible_with(self, other: BaseDBWriter.TargetParams) -> bool:
+        return self == other
+
 
 class FakeWriter(BaseDBWriter):
     Client = FakeClient

--- a/lib/sycamore/sycamore/writer.py
+++ b/lib/sycamore/sycamore/writer.py
@@ -1,6 +1,12 @@
 from typing import Callable, Optional, TYPE_CHECKING
 
 from pyarrow.fs import FileSystem
+import sys
+
+if sys.version < "3.10":
+    from typing_extensions import TypeGuard
+else:
+    from typing import TypeGuard
 
 from sycamore import Context
 from sycamore.plan_nodes import Node
@@ -86,7 +92,7 @@ class DocSetWriter:
         """
 
         from sycamore.writers.opensearch import OpenSearchWriter, OpenSearchClientParams, OpenSearchTargetParams
-        from typing import TypeGuard, Any, Union
+        from typing import Any, Union
         import copy
 
         # We mutate os_client_args, so mutate a copy

--- a/lib/sycamore/sycamore/writer.py
+++ b/lib/sycamore/sycamore/writer.py
@@ -86,30 +86,34 @@ class DocSetWriter:
         """
 
         from sycamore.writers.opensearch import OpenSearchWriter, OpenSearchClientParams, OpenSearchTargetParams
-        from typing import Any, Union
-        from typing_extensions import TypeGuard
+        from typing import Any
         import copy
 
         # We mutate os_client_args, so mutate a copy
         os_client_args = copy.deepcopy(os_client_args)
 
         # Type narrowing for hosts joy
-        def _validate_hosts_arg(hostlist: Any) -> TypeGuard[list[dict[str, Union[str, int]]]]:
+        def _convert_to_host_port_list(hostlist: Any) -> list[HostAndPort]:
             if not isinstance(hostlist, list):
-                return False
+                raise ValueError('OpenSearch client args "hosts" param must be a list of hosts')
             for h in hostlist:
-                if not isinstance(h, dict):
-                    return False
-                if "host" not in h or not isinstance(h["host"], str):
-                    return False
-                if "port" not in h or not isinstance(h["port"], int):
-                    return False
-            return True
+                if (
+                    not isinstance(h, dict)
+                    or "host" not in h
+                    or not isinstance(h["host"], str)
+                    or "port" not in h
+                    or not isinstance(h["port"], int)
+                ):
+                    raise ValueError(
+                        'OpenSearch client args "hosts" objects must consist of dicts of '
+                        "the form {'host': '<address>', 'port': <port num>}\n"
+                        f"Found: {h}"
+                    )
+            return [HostAndPort(host=h["host"], port=h["port"]) for h in hostlist]
 
         hosts = os_client_args.get("hosts", None)
         if hosts is not None:
-            _validate_hosts_arg(hosts)
-            os_client_args["hosts"] = [HostAndPort(**h) for h in hosts]
+            os_client_args["hosts"] = _convert_to_host_port_list(hosts)
         client_params = OpenSearchClientParams(**os_client_args)
 
         target_params: OpenSearchTargetParams

--- a/lib/sycamore/sycamore/writer.py
+++ b/lib/sycamore/sycamore/writer.py
@@ -127,6 +127,10 @@ class DocSetWriter:
         os = OpenSearchWriter(
             self.plan, client_params=client_params, target_params=target_params, name="opensearch_write", **kwargs
         )
+        # We will probably want to break this at some point so that write
+        # doesn't execute automatically, and instead you need to say something
+        # like docset.write.opensearch().execute(), allowing sensible writes
+        # to multiple locations and post-write operations.
         if execute:
             # If execute, force execution
             os.execute().materialize()

--- a/lib/sycamore/sycamore/writer.py
+++ b/lib/sycamore/sycamore/writer.py
@@ -1,12 +1,6 @@
 from typing import Callable, Optional, TYPE_CHECKING
 
 from pyarrow.fs import FileSystem
-import sys
-
-if sys.version < "3.10":
-    from typing_extensions import TypeGuard
-else:
-    from typing import TypeGuard
 
 from sycamore import Context
 from sycamore.plan_nodes import Node
@@ -93,6 +87,7 @@ class DocSetWriter:
 
         from sycamore.writers.opensearch import OpenSearchWriter, OpenSearchClientParams, OpenSearchTargetParams
         from typing import Any, Union
+        from typing_extensions import TypeGuard
         import copy
 
         # We mutate os_client_args, so mutate a copy

--- a/lib/sycamore/sycamore/writers/base.py
+++ b/lib/sycamore/sycamore/writers/base.py
@@ -83,4 +83,5 @@ class BaseDBWriter(MapBatch, Write):
             with TimeTrace(self._name):
                 return self.write_docs(docs)
         else:
-            return self.write_docs(docs)
+            with TimeTrace("UnknownWriter"):
+                return self.write_docs(docs)

--- a/lib/sycamore/sycamore/writers/common.py
+++ b/lib/sycamore/sycamore/writers/common.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass
+from typing import Iterator, Union, Iterable, Tuple, Any
+
+
+@dataclass
+class HostAndPort:
+    host: str
+    port: int
+
+
+def _add_key_to_prefix(prefix, key):
+    if len(prefix) == 0:
+        return str(key)
+    else:
+        return f"{prefix}.{key}"
+
+
+def flatten_data(
+    data: Union[dict, list, tuple],
+    prefix: str = "",
+    allowed_list_types: list[type] = [],
+    homogeneous_lists: bool = True,
+) -> Iterable[Tuple[Any, Any]]:
+    iterator: Union[Iterator[tuple[str, Any]], enumerate[Any]] = iter([])
+    if isinstance(data, dict):
+        iterator = iter(data.items())
+    if isinstance(data, (list, tuple)):
+        iterator = enumerate(data)
+    items = []
+    for k, v in iterator:
+        if isinstance(v, (dict, list, tuple)):
+            if isinstance(v, (list, tuple)) and (
+                (not homogeneous_lists and all(any(isinstance(innerv, t) for t in allowed_list_types) for innerv in v))
+                or (homogeneous_lists and any(all(isinstance(innerv, t) for innerv in v) for t in allowed_list_types))
+            ):
+                # Lists of strings are allowed
+                items.append((_add_key_to_prefix(prefix, k), v))
+            else:
+                inner_values = flatten_data(v, _add_key_to_prefix(prefix, k), allowed_list_types, homogeneous_lists)
+                items.extend([(innerk, innerv) for innerk, innerv in inner_values])
+        elif v is not None:
+            items.append((_add_key_to_prefix(prefix, k), v))
+    return items

--- a/lib/sycamore/sycamore/writers/common.py
+++ b/lib/sycamore/sycamore/writers/common.py
@@ -33,7 +33,7 @@ def flatten_data(
                 (not homogeneous_lists and all(any(isinstance(innerv, t) for t in allowed_list_types) for innerv in v))
                 or (homogeneous_lists and any(all(isinstance(innerv, t) for innerv in v) for t in allowed_list_types))
             ):
-                # Lists of strings are allowed
+                # Allow lists of the allowed_list_types
                 items.append((_add_key_to_prefix(prefix, k), v))
             else:
                 inner_values = flatten_data(v, _add_key_to_prefix(prefix, k), allowed_list_types, homogeneous_lists)

--- a/lib/sycamore/sycamore/writers/opensearch.py
+++ b/lib/sycamore/sycamore/writers/opensearch.py
@@ -1,12 +1,7 @@
 from dataclasses import asdict, dataclass, field
 import logging
 from typing import Any, Optional
-import sys
-
-if sys.version < "3.10":
-    from typing_extensions import TypeGuard
-else:
-    from typing import TypeGuard
+from typing_extensions import TypeGuard
 
 from opensearchpy import OpenSearch
 from opensearchpy.exceptions import RequestError

--- a/lib/sycamore/sycamore/writers/opensearch.py
+++ b/lib/sycamore/sycamore/writers/opensearch.py
@@ -10,7 +10,6 @@ from opensearchpy.helpers import parallel_bulk
 from sycamore.data import Document
 from sycamore.writers.base import BaseDBWriter
 from sycamore.writers.common import HostAndPort, flatten_data
-import re
 
 log = logging.getLogger(__name__)
 
@@ -131,8 +130,10 @@ class OpenSearchClient(BaseDBWriter.Client):
                     return False
                 elif obj.isnumeric():
                     return int(obj)
-                elif re.fullmatch("-?[0-9]+\.[0-9]+", obj):
+                try:
                     return float(obj)
+                except ValueError:
+                    return obj
             return obj
 
         assert isinstance(

--- a/lib/sycamore/sycamore/writers/opensearch.py
+++ b/lib/sycamore/sycamore/writers/opensearch.py
@@ -1,77 +1,183 @@
+from dataclasses import asdict, dataclass, field
 import logging
-from typing import Any, Optional, Iterable
+from typing import Any, Optional, TypeGuard
 
 from opensearchpy import OpenSearch
+from opensearchpy.exceptions import RequestError
 from opensearchpy.helpers import parallel_bulk
-from ray.data import Datasink, Dataset
-from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
-from ray.data.block import Block, BlockAccessor
-from ray.data._internal.execution.interfaces import TaskContext
 
-from sycamore.data import Document, MetadataDocument
-from sycamore.plan_nodes import Node, Write
-from sycamore.utils.time_trace import timetrace
+from sycamore.data import Document
+from sycamore.writers.base import BaseDBWriter
+from sycamore.writers.common import HostAndPort, flatten_data
+import re
 
 log = logging.getLogger(__name__)
 
 
-class OpenSearchWriter(Write):
-    def __init__(
-        self,
-        plan: Node,
-        index_name: str,
-        *,
-        os_client_args: dict,
-        index_settings: Optional[dict] = None,
-        number_of_allowed_failures_per_block: int = 100,
-        collect_failures_file_path: str = "failures.txt",
-        **ray_remote_args,
-    ):
-        super().__init__(plan, **ray_remote_args)
-        self.index_name = index_name
-        self.index_settings = index_settings
-        self.os_client_args = os_client_args
-        self.number_of_allowed_failures_per_block = number_of_allowed_failures_per_block
-        self.collect_failures_file_path = collect_failures_file_path
+@dataclass
+class OpenSearchClientParams(BaseDBWriter.ClientParams):
+    hosts: list[HostAndPort] = field(default_factory=lambda: [HostAndPort(host="localhost", port=9200)])
+    http_compress: bool = True
+    http_auth: tuple[str, str] = ("admin", "admin")
+    use_ssl: bool = True
+    verify_certs: bool = True
+    ssl_assert_hostname: bool = True
+    ssl_show_warn: bool = True
+    timeout: Optional[int] = None
+    number_of_allowed_failures_per_block: int = 100
+    collect_failures_filepath: str = "failures.txt"
 
-    def execute(self) -> Dataset:
-        dataset = self.child().execute()
-        try:
-            client = OpenSearch(**self.os_client_args)
-            if not client.indices.exists(self.index_name):
-                if self.index_settings is not None:
-                    client.indices.create(self.index_name, **self.index_settings)
+
+@dataclass
+class OpenSearchTargetParams(BaseDBWriter.TargetParams):
+    index_name: str
+    settings: dict[str, Any] = field(default_factory=lambda: {"index.knn": True})
+    mappings: dict[str, Any] = field(
+        default_factory=lambda: {
+            "properties": {
+                "embedding": {
+                    "type": "knn_vector",
+                    "dimension": 384,
+                    "method": {"name": "hnsw", "engine": "faiss"},
+                },
+            }
+        }
+    )
+
+    def compatible_with(self, other: "BaseDBWriter.TargetParams") -> bool:
+        """
+        OpenSearchTargetParams A is compatible with OpenSearchTargetParams B if
+        all the keys in A are also in B, and if the values of the intersecting
+        keys are the same. We don't check symmetry here, because B might include
+        a bunch of other stuff, like creation time or UUID, where we don't want to
+        demand equality. We also flatten for consistency.
+        """
+        if not isinstance(other, OpenSearchTargetParams):
+            return False
+        if self.index_name != other.index_name:
+            return False
+        my_flat_settings = dict(flatten_data(self.settings))
+        other_flat_settings = dict(flatten_data(other.settings))
+        for k in my_flat_settings:
+            other_k = k
+            if k not in other_flat_settings:
+                if "index." + k in other_flat_settings:
+                    # You can specify index params without the "index" part and
+                    # they'll come back with the "index" part
+                    other_k = "index." + k
                 else:
-                    client.indices.create(self.index_name)
-
-        except Exception as e:
-            raise RuntimeError("Exception occurred while creating an index", e)
-
-        dataset.write_datasink(
-            OSDataSink(
-                index_name=self.index_name,
-                os_client_args=self.os_client_args,
-                number_of_allowed_failures_per_block=self.number_of_allowed_failures_per_block,
-                collect_failures_file_path=self.collect_failures_file_path,
-            ),
-            ray_remote_args=self.resource_args,
-        )
-
-        return dataset
+                    return False
+            if my_flat_settings[k] != other_flat_settings[other_k]:
+                return False
+        my_flat_mappings = dict(flatten_data(self.mappings))
+        other_flat_mappings = dict(flatten_data(other.mappings))
+        for k in my_flat_mappings:
+            if k not in other_flat_mappings:
+                return False
+            if my_flat_mappings[k] != other_flat_mappings[k]:
+                return False
+        return True
 
 
-class OSDataSink(Datasink):
-    def __init__(self, index_name, os_client_args, number_of_allowed_failures_per_block, collect_failures_file_path):
-        self.index_name = index_name
-        self.os_client_args = os_client_args
-        self.number_of_allowed_failures_per_block = number_of_allowed_failures_per_block
-        self.collect_failures_file_path = collect_failures_file_path
+class OpenSearchClient(BaseDBWriter.Client):
+    def __init__(self, os_client: OpenSearch, allowed_failures_per_block: int, failure_filepath: str):
+        self._client = os_client
+        self._allowed_failures_per_block = allowed_failures_per_block
+        self._failure_filepath = failure_filepath
 
-    # todo: make this type specific to extract properties
-    @staticmethod
-    def extract_os_document(data):
+    @classmethod
+    def from_client_params(cls, params: BaseDBWriter.ClientParams) -> "OpenSearchClient":
+        assert isinstance(
+            params, OpenSearchClientParams
+        ), f"Provided params was not of type OpenSearchClientParams:\n{params}"
+        paramsdict = asdict(params)
+        allowed_failures_per_block = paramsdict.pop("number_of_allowed_failures_per_block")
+        failures_fp = paramsdict.pop("collect_failures_filepath")
+        os_client = OpenSearch(**paramsdict)
+        os_client.ping()
+        return OpenSearchClient(os_client, allowed_failures_per_block, failures_fp)
+
+    def write_many_records(self, records: list[BaseDBWriter.Record], target_params: BaseDBWriter.TargetParams):
+        assert isinstance(
+            target_params, OpenSearchTargetParams
+        ), f"Provided target_params was not of type OpenSearchTargetParams:\n{target_params}"
+        assert _narrow_list_of_os_records(records), f"A provided record was not of type OpenSearchRecord:\n{records}"
+        failures = []
+        for success, info in parallel_bulk(self._client, [asdict(r) for r in records]):
+            if not success:
+                log.error("A Document failed to upload", info)
+                failures.append(info)
+
+        if len(failures) > self._allowed_failures_per_block:
+            with open(self._failure_filepath, "a") as f:
+                for doc in failures:
+                    f.write(f"{doc}\n")
+            raise RuntimeError(
+                f"{self._allowed_failures_per_block} documents failed to index. " f"Refer to {self._failure_filepath}."
+            )
+
+    def create_target_idempotent(self, target_params: BaseDBWriter.TargetParams):
+        assert isinstance(
+            target_params, OpenSearchTargetParams
+        ), f"Provided target_params was not of type OpenSearchTargetParams:\n{target_params}"
+        index_name = target_params.index_name
+        try:
+            self._client.indices.create(
+                index_name, body={"mappings": target_params.mappings, "settings": target_params.settings}
+            )
+        except RequestError as e:
+            if e.error != "resource_already_exists_exception":
+                raise e
+
+    def get_existing_target_params(self, target_params: BaseDBWriter.TargetParams) -> OpenSearchTargetParams:
+        def _string_values_to_python_types(obj: Any):
+            if isinstance(obj, dict):
+                for k in obj:
+                    obj[k] = _string_values_to_python_types(obj[k])
+                return obj
+            if isinstance(obj, list):
+                for i in range(len(obj)):
+                    obj[i] = _string_values_to_python_types(obj[i])
+                return obj
+            if isinstance(obj, str):
+                if obj == "true":
+                    return True
+                elif obj == "false":
+                    return False
+                elif obj.isnumeric():
+                    return int(obj)
+                elif re.match("[0-9]+\.[0-9]+", obj):
+                    return float(obj)
+            return obj
+
+        assert isinstance(
+            target_params, OpenSearchTargetParams
+        ), f"Provided target_params was not of type OpenSearchTargetParams:\n{target_params}"
+        index_name = target_params.index_name
+        response = self._client.indices.get(index_name)
+        mappings = _string_values_to_python_types(response.get(index_name, {}).get("mappings", {}))
+        assert isinstance(mappings, dict)
+        settings = _string_values_to_python_types(response.get(index_name, {}).get("settings", {}))
+        assert isinstance(settings, dict)
+        return OpenSearchTargetParams(index_name=index_name, mappings=mappings, settings=settings)
+
+
+@dataclass
+class OpenSearchRecord(BaseDBWriter.Record):
+    _source: dict[str, Any]
+    _index: str
+    _id: str
+
+    @classmethod
+    def from_doc(cls, document: Document, target_params: BaseDBWriter.TargetParams) -> "OpenSearchRecord":
+        assert isinstance(
+            target_params, OpenSearchTargetParams
+        ), f"Provided target_params was not of type OpenSearchTargetParams:\n{target_params}"
+        assert (
+            document.doc_id is not None
+        ), f"Cannot create opensearch record from Document without a doc_id:\n{document}"
         result = dict()
-        default = {
+        default: dict[str, Any] = {
             "doc_id": None,
             "type": None,
             "text_representation": None,
@@ -82,65 +188,21 @@ class OSDataSink(Datasink):
             "bbox": None,
             "shingles": None,
         }
+        data = document.data
         for k, v in default.items():
             if k in data:
                 result[k] = data[k]
             else:
                 result[k] = v
-        return result
+        return OpenSearchRecord(_index=target_params.index_name, _id=document.doc_id, _source=result)
 
-    @timetrace("OsrchWrite")
-    def write(self, blocks: Iterable[Block], ctx: TaskContext) -> Any:
-        builder = DelegatingBlockBuilder()
-        for block in blocks:
-            builder.add_block(block)
-        block = builder.build()
 
-        self.write_block(
-            block,
-            os_client_args=self.os_client_args,
-            index_name=self.index_name,
-            collect_failures_file_path=self.collect_failures_file_path,
-            number_of_allowed_failures_per_block=self.number_of_allowed_failures_per_block,
-        )
+def _narrow_list_of_os_records(records: list[BaseDBWriter.Record]) -> TypeGuard[list[OpenSearchRecord]]:
+    return all(isinstance(r, OpenSearchRecord) for r in records)
 
-        return "ok"
 
-    @staticmethod
-    def write_block(
-        block: Block,
-        *,
-        os_client_args: dict,
-        index_name: str,
-        collect_failures_file_path: str,
-        number_of_allowed_failures_per_block: int,
-    ):
-        client = OpenSearch(**os_client_args)
-
-        block = BlockAccessor.for_block(block).to_arrow().to_pylist()
-
-        def create_actions():
-            for i, row in enumerate(block):
-                doc = Document.from_row(row)
-                if isinstance(doc, MetadataDocument):
-                    continue
-                osdoc = OSDataSink.extract_os_document(doc)
-                action = {"_index": index_name, "_id": doc["doc_id"], "_source": osdoc}
-                yield action
-
-        failures = []
-        for success, info in parallel_bulk(client, create_actions()):
-            if not success:
-                log.error("A Document failed to upload", info)
-                failures.append(info)
-
-                if len(failures) > number_of_allowed_failures_per_block:
-                    with open(collect_failures_file_path, "a") as f:
-                        for doc in failures:
-                            f.write(f"{doc}\n")
-                    raise RuntimeError(
-                        f"{number_of_allowed_failures_per_block} documents failed to index. "
-                        f"Refer to {collect_failures_file_path}."
-                    )
-
-        log.info("All the documents have been ingested!")
+class OpenSearchWriter(BaseDBWriter):
+    Client = OpenSearchClient
+    ClientParams = OpenSearchClientParams
+    Record = OpenSearchRecord
+    TargetParams = OpenSearchTargetParams

--- a/lib/sycamore/sycamore/writers/opensearch.py
+++ b/lib/sycamore/sycamore/writers/opensearch.py
@@ -1,6 +1,12 @@
 from dataclasses import asdict, dataclass, field
 import logging
-from typing import Any, Optional, TypeGuard
+from typing import Any, Optional
+import sys
+
+if sys.version < "3.10":
+    from typing_extensions import TypeGuard
+else:
+    from typing import TypeGuard
 
 from opensearchpy import OpenSearch
 from opensearchpy.exceptions import RequestError

--- a/lib/sycamore/sycamore/writers/opensearch.py
+++ b/lib/sycamore/sycamore/writers/opensearch.py
@@ -25,8 +25,6 @@ class OpenSearchClientParams(BaseDBWriter.ClientParams):
     ssl_assert_hostname: bool = True
     ssl_show_warn: bool = True
     timeout: Optional[int] = None
-    number_of_allowed_failures_per_block: int = 100
-    collect_failures_filepath: str = "failures.txt"
 
 
 @dataclass
@@ -81,10 +79,8 @@ class OpenSearchTargetParams(BaseDBWriter.TargetParams):
 
 
 class OpenSearchClient(BaseDBWriter.Client):
-    def __init__(self, os_client: OpenSearch, allowed_failures_per_block: int, failure_filepath: str):
+    def __init__(self, os_client: OpenSearch):
         self._client = os_client
-        self._allowed_failures_per_block = allowed_failures_per_block
-        self._failure_filepath = failure_filepath
 
     @classmethod
     def from_client_params(cls, params: BaseDBWriter.ClientParams) -> "OpenSearchClient":
@@ -92,30 +88,18 @@ class OpenSearchClient(BaseDBWriter.Client):
             params, OpenSearchClientParams
         ), f"Provided params was not of type OpenSearchClientParams:\n{params}"
         paramsdict = asdict(params)
-        allowed_failures_per_block = paramsdict.pop("number_of_allowed_failures_per_block")
-        failures_fp = paramsdict.pop("collect_failures_filepath")
         os_client = OpenSearch(**paramsdict)
         os_client.ping()
-        return OpenSearchClient(os_client, allowed_failures_per_block, failures_fp)
+        return OpenSearchClient(os_client)
 
     def write_many_records(self, records: list[BaseDBWriter.Record], target_params: BaseDBWriter.TargetParams):
         assert isinstance(
             target_params, OpenSearchTargetParams
         ), f"Provided target_params was not of type OpenSearchTargetParams:\n{target_params}"
         assert _narrow_list_of_os_records(records), f"A provided record was not of type OpenSearchRecord:\n{records}"
-        failures = []
         for success, info in parallel_bulk(self._client, [asdict(r) for r in records]):
             if not success:
                 log.error("A Document failed to upload", info)
-                failures.append(info)
-
-        if len(failures) > self._allowed_failures_per_block:
-            with open(self._failure_filepath, "a") as f:
-                for doc in failures:
-                    f.write(f"{doc}\n")
-            raise RuntimeError(
-                f"{self._allowed_failures_per_block} documents failed to index. " f"Refer to {self._failure_filepath}."
-            )
 
     def create_target_idempotent(self, target_params: BaseDBWriter.TargetParams):
         assert isinstance(
@@ -147,7 +131,7 @@ class OpenSearchClient(BaseDBWriter.Client):
                     return False
                 elif obj.isnumeric():
                     return int(obj)
-                elif re.match("[0-9]+\.[0-9]+", obj):
+                elif re.fullmatch("-?[0-9]+\.[0-9]+", obj):
                     return float(obj)
             return obj
 


### PR DESCRIPTION
also fixed the query tests to actually run their ingest pipeline so they don't depend on going after other opensearch ITs (which now clean up after themselves)