### PR TITLE
Fix for jupyter notebook tutorial

### DIFF
--- a/docs/source/tutorials/sycamore-jupyter-dev-example.md
+++ b/docs/source/tutorials/sycamore-jupyter-dev-example.md
@@ -108,7 +108,7 @@ for f in ["1706.03762", "2306.07303"]:
     if not Path(path).is_file():
         print("Downloading {} to {}".format(url, path))
         subprocess.run(["curl", "-o", path, url])
-    metadata[path] = { "_location": url }
+    metadata[path] = { "url": url }
 
 manifest_path = os.path.join(work_dir, "manifest.json")
 with open(manifest_path, "w") as f:

--- a/docs/source/tutorials/sycamore-jupyter-dev-example.md
+++ b/docs/source/tutorials/sycamore-jupyter-dev-example.md
@@ -103,11 +103,11 @@ S3 (common for enterprise data) or other locations accessible by the demo query 
 os.makedirs(work_dir, exist_ok = True)
 metadata = {}
 for f in ["1706.03762", "2306.07303"]:
-    path = os.path.join(work_dir, f)
+    path = os.path.join(work_dir, f+".pdf")
     url = os.path.join("https://arxiv.org/pdf", f)
     if not Path(path).is_file():
         print("Downloading {} to {}".format(url, path))
-        subprocess.run(["curl", "-o", path+".pdf", url])
+        subprocess.run(["curl", "-o", path, url])
     metadata[path] = { "_location": url }
 
 manifest_path = os.path.join(work_dir, "manifest.json")

--- a/docs/source/tutorials/sycamore-jupyter-dev-example.md
+++ b/docs/source/tutorials/sycamore-jupyter-dev-example.md
@@ -102,12 +102,12 @@ S3 (common for enterprise data) or other locations accessible by the demo query 
 ```python
 os.makedirs(work_dir, exist_ok = True)
 metadata = {}
-for f in ["1706.03762.pdf", "2306.07303.pdf"]:
+for f in ["1706.03762", "2306.07303"]:
     path = os.path.join(work_dir, f)
     url = os.path.join("https://arxiv.org/pdf", f)
     if not Path(path).is_file():
         print("Downloading {} to {}".format(url, path))
-        subprocess.run(["curl", "-o", path, url])
+        subprocess.run(["curl", "-o", path+".pdf", url])
     metadata[path] = { "_location": url }
 
 manifest_path = os.path.join(work_dir, "manifest.json")


### PR DESCRIPTION
Through going through the tutorial, the pdf's didn't download properly cause it accidently tried to pull from a arxiv link with ".pdf" on the end(making it invalid). This PR fixes this.