### PR TITLE
Make it possible to pass in a schema for property extraction.

### DIFF
--- a/lib/sycamore/sycamore/tests/unit/transforms/test_schema.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_schema.py
@@ -139,3 +139,22 @@ class TestSchema:
         doc = property_extractor.extract_properties(doc)
 
         assert doc.properties["entity"]["accidentNumber"] == "FTW95FA129"
+
+    def test_extract_properties_fixed_json(self, mocker):
+        llm = mocker.Mock(spec=LLM)
+        generate = mocker.patch.object(llm, "generate")
+        generate.return_value = '{"accidentNumber": "FTW95FA129"}'
+
+        doc = Document()
+        element1 = Element()
+        element1.text_representation = "".join(random.choices(string.ascii_letters, k=10))
+        element2 = Element()
+        element2.text_representation = "".join(random.choices(string.ascii_letters, k=20))
+        doc.elements = [element1, element2]
+
+        property_extractor = OpenAIPropertyExtractor(
+            llm, schema_name="AircraftIncident", schema={"accidentNumber": "string"}
+        )
+        doc = property_extractor.extract_properties(doc)
+
+        assert doc.properties["entity"]["accidentNumber"] == "FTW95FA129"

--- a/lib/sycamore/sycamore/transforms/extract_schema.py
+++ b/lib/sycamore/sycamore/transforms/extract_schema.py
@@ -136,11 +136,15 @@ class OpenAIPropertyExtractor(PropertyExtractor):
         self,
         # properties: list[str],
         llm: LLM,
+        schema_name: Optional[str] = None,
+        schema: Optional[dict[str, str]] = None,
         num_of_elements: int = 10,
         prompt_formatter: Callable[[list[Element]], str] = element_list_formatter,
     ):
         super().__init__()
         self._llm = llm
+        self._schema_name = schema_name
+        self._schema = schema
         self._num_of_elements = num_of_elements
         self._prompt_formatter = prompt_formatter
 
@@ -168,8 +172,15 @@ class OpenAIPropertyExtractor(PropertyExtractor):
 
         prompt = PropertiesZeroShotGuidancePrompt()
 
-        schema_name = document.properties["_schema_class"]
-        schema = document.properties["_schema"]
+        if self._schema_name is not None:
+            schema_name = self._schema_name
+        else:
+            schema_name = document.properties["_schema_class"]
+
+        if self._schema is not None:
+            schema = self._schema
+        else:
+            schema = document.properties["_schema"]
 
         entities = self._llm.generate(
             prompt_kwargs={"prompt": prompt, "entity": schema_name, "properties": schema, "query": text}


### PR DESCRIPTION
The ExtractProperties transform relies on a schema to guide the LLM on what to extract. This schema can be extracted using an LLM, or it can be added explicitly to each documetn in a "_schema" property.

I frequently want to be able to extract fields from an explicit schema that I pass in, without having to update the properties map on each document. This change just adds that ability in the form of arguments to the OpenAIPropertyExtractor class. Example usage of how to extract basic information about a scientific paper from a DocSet:

    schema = {
        "title": "string",
        "authors": "list[string]",
        "abstract": "string"
    }

    docs = context.read.binary(paths=[path], binary_format="pdf")\
                .partition(partitioner=SycamorePartitioner())\
                .extract_properties(OpenAIPropertyExtractor(llm, schema_name="PaperInfo", schema=schema))\
                .show(show_elements=False)