### PR TITLE
Potential memory leak point

### DIFF
--- a/lib/sycamore/sycamore/utils/pdf.py
+++ b/lib/sycamore/sycamore/utils/pdf.py
@@ -68,7 +68,7 @@ def convert_from_path_streamed(pdf_path: str) -> Generator[Image.Image, None, No
         # Popen.communicate() reads the entire strings.
         args = ["pdftoppm", "-r", "200", pdf_path]
         proc = Popen(args, stdout=PIPE, stderr=PIPE)
-        q: Queue = Queue()
+        q: Queue = Queue(4)
         t_out = Thread(
             target=capture_exception, daemon=True, args=(q, lambda: read_stdout(proc.stdout, q), StdoutEOF())
         )


### PR DESCRIPTION
Previously, the queue is set infinity. The memory consumption positive correlates to pdf page numbers, e.g. parsing a 2k page pdf requires 8gb memory while  parsing 4k page pdf requires 16gb memory using Eri's Rss metric tool. By setting queue size to 64, the rss stays fixed at around 2gb beyond 200 pages.
This number may need sync with batch size, it seems good enough to mitigate memory pressure for now.