### PR TITLE
Get integration tests working again.

### DIFF
--- a/apps/integration/integration/containers/running.py
+++ b/apps/integration/integration/containers/running.py
@@ -2,6 +2,8 @@ import pytest
 import docker
 import requests
 import time
+import logging
+import subprocess
 from opensearchpy import OpenSearch
 
 
@@ -19,11 +21,13 @@ def container_urls(stack):
     Get a mapping from container/service to network address
     :return: map of container/service to network address
     """
-    return {
+    ret = {
         service_name: stack.get_service_host_and_port(service_name, port=IMPORTANT_PORTS[service_name])
         for service_name in [c.Service for c in stack.get_containers()]
         if service_name in IMPORTANT_PORTS
     }
+    logging.error(f"Container URLs {ret}")
+    return ret
 
 
 @pytest.fixture(scope="session")
@@ -32,13 +36,17 @@ def container_handles(stack):
     Get docker objects representing each container in the stack
     :return: mapping from container/service to docker objects
     """
+    logging.error("Getting clients...")
+    subprocess.run(["docker", "ps"])
     docker_client = docker.from_env()
     jupyter = docker_client.containers.get(stack.get_container("jupyter").ID)
     opensearch = docker_client.containers.get(stack.get_container("opensearch").ID)
     demo_ui = docker_client.containers.get(stack.get_container("demo-ui").ID)
     rps = docker_client.containers.get(stack.get_container("rps").ID)
     importer = docker_client.containers.get(stack.get_container("importer").ID)
-    return {"jupyter": jupyter, "opensearch": opensearch, "demo_ui": demo_ui, "rps": rps, "importer": importer}
+    ret = {"jupyter": jupyter, "opensearch": opensearch, "demo_ui": demo_ui, "rps": rps, "importer": importer}
+    logging.error(f"Got all clients: {ret}")
+    return ret
 
 
 @pytest.fixture(scope="session")
@@ -47,6 +55,7 @@ def opensearch_client(container_urls):
     Get an opensearch client that hits the stack opensearch
     :return: the opensearch client
     """
+    logging.error("Waiting for opensearch to start...")
     host, port = container_urls["opensearch"]
     urlstr = f"https://{host}:{port}"
     # Ten minute deadline for opensearch startup
@@ -55,12 +64,13 @@ def opensearch_client(container_urls):
         try:
             r = requests.get(f"{urlstr}/_cluster/settings", verify=False)
             if r.status_code == 200 and "aryn_deploy_complete" in r.text:
-                print("Ready")
+                logging.error("Ready")
                 break
         except requests.exceptions.ConnectionError:
             pass
 
-        time.sleep(1)
+        time.sleep(3)
+        logging.error("Still waiting for opensearch to start...")
 
     return OpenSearch(
         hosts=[{"host": host, "port": port}],

--- a/apps/integration/integration/containers/stack.py
+++ b/apps/integration/integration/containers/stack.py
@@ -2,6 +2,10 @@ from testcontainers.compose import DockerCompose
 import pytest
 from integration import SYCAMORE_ROOT
 from typing import List, Union
+import logging
+import subprocess
+import os
+import time
 
 
 def docker_compose(services: Union[List[str], None] = None):
@@ -35,6 +39,26 @@ def stack(tag):
     base_compose = docker_compose()
     base_compose.pull = True
     set_version_tag(tag)
+    logging.error(f"Setting up compose with tag {tag} .. this may take a long time")
     with base_compose:
+        logging.error("Done")
         yield base_compose
+
+        logs = open("docker-logs.txt", "w")
+        subprocess.call(["docker", "compose", "logs"], stdout=logs)
+        logging.error("Wrote logs to docker-logs.txt")
+        maybe_wait_to_abort()
+        logging.error("Shutting down docker, this can take a little bit")
     set_version_tag("stable")
+
+
+def maybe_wait_to_abort():
+    if os.environ.get("NOEXIT", "") == "":
+        logging.error("You can set the environment variable NOEXIT to force a pause at this point")
+        return
+
+    while True:
+        logging.error("Waiting for /tmp/abort to exist")
+        if os.path.isfile("/tmp/abort"):
+            break
+        time.sleep(1)

--- a/apps/integration/integration/ingests/crawler.py
+++ b/apps/integration/integration/ingests/crawler.py
@@ -3,7 +3,11 @@ from docker.models.containers import Container
 from opensearchpy import OpenSearch
 from integration.containers.stack import docker_compose
 from integration.ingests.index_info import IndexInfo
+from subprocess import CalledProcessError
 import time
+import logging
+import subprocess
+import opensearchpy.exceptions
 
 PROFILE_TO_NAME_MAP = {"sort-one": "sycamore_crawler_http_sort_one", "sort-all": "sycamore_crawler_http_sort_all"}
 DEFAULT_INDEX_NAME = "demoindex0"
@@ -30,13 +34,32 @@ class HttpCrawlerIndex:
         Start a crawler image, wait for it to finish and read what it loads from the logs.
         Then watch the importer logs to determine when it has ingested all of the docs it needs to
         """
+        logging.error("http_crawler:__enter__")
         docker_client = docker.from_env()
-        self._importer.exec_run(cmd="rm -rf /app/.scrapy/*")
+        logging.error("http_crawler:__enter__:rm")
+        (code, out) = self._importer.exec_run(cmd="rm -rf /app/.scrapy/imported /app/.scrapy/downloads")
+        logging.error(f"rm says {code} {out}")
+        (code, out) = self._importer.exec_run(cmd="find /app/.scrapy ! -name httpcache -print")
+        outstr = str(out)
+        if code != 0 or "imported" in outstr or "downloads" in outstr:
+            logging.error(f"Find says {code} {out}")
+            assert False
+
         service_name = self._get_service_name()
+        logging.error(f"cleanup container {service_name}")
+        proc = subprocess.run(["docker", "compose", "rm", "-f", service_name])
+        logging.error(f"{proc}")
+        assert proc.returncode == 0
+        logging.error("http_crawler:__enter__:pre-compose")
         compose = docker_compose(services=[service_name])
         files = set()
         start_crawler_time = time.time()
-        compose.start()
+        try:
+            compose.start()
+        except CalledProcessError as e:
+            logging.error(f"CPE {e}\n\n{e.output}\n\n{e.stderr}")
+            raise
+        logging.error("http_crawler:__enter__:started")
         crawler_container = compose.get_container(service_name=service_name, include_all=True)
         crawler_container = docker_client.containers.get(crawler_container.ID)
         assert crawler_container.wait().get("StatusCode") == 0, "Crawler container failed"
@@ -49,32 +72,68 @@ class HttpCrawlerIndex:
                 file = pieces[1].strip()
                 if "unknown" not in file:
                     files.add(file)
+                    logging.info(f"found {file} in logs")
+
+        if len(files) == 0:
+            logging.error(f"Crawler {service_name} did not download any files?!")
+            raise RuntimeError(f"Crawler {service_name} did not download any files")
+
         num_files = len(files)
         importer_logs = self._importer.logs(stream=True, since=start_crawler_time)
+        no_change_count = 0
         for log in importer_logs:
             log = log.decode()
-            if log.startswith("Successfully imported:"):
-                list_insides = log.rstrip()[len("Successfully imported: [") : -len("]")]
-                quoted_files = list_insides.split(",")
-                imported_files = [file.strip()[len("'/app/") : -len("'")] for file in quoted_files]
-                for file in imported_files:
-                    print(f"imported {file}")
-                    files.remove(file)
-                print(f"remaining files: {files}")
-            if len(files) == 0:
-                print("finished importing!")
-                break
-            if log.startswith("No changes") and len(files) != num_files:
-                raise RuntimeError(
-                    "Importer thinks there are no more files to ingest, but there are more files to ingest"
-                )
+            if "Successfully imported:" in log or log.startswith("No changes"):
+                # the log line and ray output can be intermingled. Inspect the filesystem to figure out what is imported
+                (code, out) = self._importer.exec_run(cmd="find /app/.scrapy/imported -type f")
+                if b"No such file or directory" in out:
+                    # no files from before scraper finishes
+                    continue
+                foundfiles = out.decode().split("\n")
+
+                logging.error(f"Expecting files: {files}")
+                remain = set(files)
+                for i in foundfiles:
+                    if i == "":
+                        continue
+                    i = i.replace("/app/", "").replace("/imported/", "/downloads/")
+                    if i not in remain:
+                        logging.error(f"{i} not found in {remain}")
+                        assert False
+                    remain.remove(i)
+
+                if len(remain) == 0:
+                    logging.error("Found all files")
+                    break
+
+                # There is a race between no changes being noticed and the start of the log reporting.
+                # Ignore a handful of them. If there is a bug where the importer stops early, this will
+                # fail soon enough.
+                logging.error(f"Remaining files: {remain}")
+                if log.startswith("No changes"):
+                    no_change_count = no_change_count + 1
+                    if no_change_count >= 5:
+                        raise RuntimeError("Importer stopped importing with remaining files")
+                    else:
+                        logging.error(f"No changes {no_change_count}/5 before aborting")
+                else:
+                    no_change_count = 0
+
+        while not self._opensearch.indices.exists(DEFAULT_INDEX_NAME):
+            logging.error(f"Waiting for index {DEFAULT_INDEX_NAME} to exist")
+            time.sleep(1)
+
         return IndexInfo(name=DEFAULT_INDEX_NAME, num_docs=num_files)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """
         Context manager exit. Drop the index.
         """
-        self._opensearch.indices.delete(index=DEFAULT_INDEX_NAME)
+        try:
+            logging.error(f"Deleteing index {DEFAULT_INDEX_NAME}")
+            self._opensearch.indices.delete(index=DEFAULT_INDEX_NAME)
+        except opensearchpy.exceptions.NotFoundError as e:
+            logging.error(f"Failed to delete not found index {e}")
 
     def _get_service_name(self):
         return PROFILE_TO_NAME_MAP[self._profile]

--- a/apps/opensearch/setup_models.py
+++ b/apps/opensearch/setup_models.py
@@ -217,11 +217,13 @@ def construct_deploy_try_again_fn(model_id):
         )
         if deploy_tasks["hits"]["total"]["value"] > 0:
             return deploy_tasks["hits"]["hits"][0]["_id"]
-        deploy_model_response = opensearch_request(
-            f"/_plugins/_ml/models/{model_id}/_deploy", log_name=f"deploy_{model_id}", method="POST"
-        )
+
+        req_path = f"/_plugins/_ml/models/{model_id}/_deploy"
+        deploy_model_response = opensearch_request(req_path, log_name=f"deploy_{model_id}", method="POST")
         if "task_id" not in deploy_model_response:
             die(f"deploy model failed somehow: {deploy_model_response}")
+
+        print(f"Called {req_path}, got back {deploy_model_response['task_id']}, logged to deploy_{model_id}")
         return deploy_model_response["task_id"]
 
     return inner_try_again


### PR DESCRIPTION
Important fixes:
  * Add a ludicrous amount of additional logging so it's rare that something isn't logged after a short wait.  Logs go to error because I was having some issues with info logging not showing up.  That may be fixed now, but unclear.
  * rm -rf /app/.scrapy/imported /app/.scrapy/downloads instead of *; * isn't being expanded
  * Fix imported files via find in the filesystem instead of parsing output. The ray output and importer output are sometimes interleaved on the same line
  * Verify that the scraper downloaded something before continuing
  * Tolerate missing indices on deletion
  * Enable optionally waiting before aborting the test so state is preserved for inspection
  * Add more debugging on the opensearch side, although bugs appeared to all be test-side.
  * Update automation to take advantage of debugging