### PR TITLE
Add flatten option to weaviate writer

### DIFF
--- a/lib/sycamore/sycamore/connectors/writers/common.py
+++ b/lib/sycamore/sycamore/connectors/writers/common.py
@@ -32,11 +32,11 @@ def compare_docs(doc1, doc2):
     return filtered_doc1 == filtered_doc2
 
 
-def _add_key_to_prefix(prefix, key):
+def _add_key_to_prefix(prefix, key, separator="."):
     if len(prefix) == 0:
         return str(key)
     else:
-        return f"{prefix}.{key}"
+        return f"{prefix}{separator}{key}"
 
 
 def flatten_data(
@@ -44,6 +44,7 @@ def flatten_data(
     prefix: str = "",
     allowed_list_types: list[type] = [],
     homogeneous_lists: bool = True,
+    separator: str = ".",
 ) -> Iterable[Tuple[Any, Any]]:
     iterator: Union[Iterator[tuple[str, Any]], enumerate[Any]] = iter([])
     if isinstance(data, dict):
@@ -58,12 +59,14 @@ def flatten_data(
                 or (homogeneous_lists and any(all(isinstance(innerv, t) for innerv in v) for t in allowed_list_types))
             ):
                 # Allow lists of the allowed_list_types
-                items.append((_add_key_to_prefix(prefix, k), v))
+                items.append((_add_key_to_prefix(prefix, k, separator), v))
             else:
-                inner_values = flatten_data(v, _add_key_to_prefix(prefix, k), allowed_list_types, homogeneous_lists)
+                inner_values = flatten_data(
+                    v, _add_key_to_prefix(prefix, k, separator), allowed_list_types, homogeneous_lists, separator
+                )
                 items.extend([(innerk, innerv) for innerk, innerv in inner_values])
         elif v is not None:
-            items.append((_add_key_to_prefix(prefix, k), v))
+            items.append((_add_key_to_prefix(prefix, k, separator), v))
     return items
 
 

--- a/lib/sycamore/sycamore/writer.py
+++ b/lib/sycamore/sycamore/writer.py
@@ -148,6 +148,7 @@ class DocSetWriter:
         wv_client_args: dict,
         collection_name: str,
         collection_config: Optional[dict[str, Any]] = None,
+        flatten_properties: bool = False,
         execute: bool = True,
         **kwargs,
     ) -> Optional["DocSet"]:
@@ -161,7 +162,11 @@ class DocSetWriter:
                 method.If not provided, Weaviate will Auto-Schematize the incoming records, which may lead to
                 inconsistencies or failures. See more information at
                 https://weaviate.io/developers/weaviate/manage-data/collections#create-a-collection-and-define-properties
-            resource_args: Arguments to pass to the underlying execution engine
+            flatten_properties: Whether to flatten documents into pure key-value pairs or to allow nested
+                structures. Default is False (allow nested structures)
+            execute: Execute the pipeline and write to weaviate on adding this operator. If False,
+                will return a DocSet with this write in the plan. Default is True
+            kwargs: Arguments to pass to the underlying execution engine
 
         Example:
             The following code shows how to read a pdf dataset into a ``DocSet`` and write it out to a
@@ -253,7 +258,9 @@ class DocSetWriter:
             collection_config_object = CollectionConfigCreate(**collection_config)
         else:
             collection_config_object = CollectionConfigCreate(name=collection_name, **collection_config)
-        target_params = WeaviateTargetParams(name=collection_name, collection_config=collection_config_object)
+        target_params = WeaviateTargetParams(
+            name=collection_name, collection_config=collection_config_object, flatten_properties=flatten_properties
+        )
 
         wv_docs = WeaviateDocumentWriter(
             self.plan, client_params, target_params, name="weaviate_write_documents", **kwargs


### PR DESCRIPTION
Weaviate nested fields don't do filters or aggregations so we add the option to flatten them to top-level 'properties'.
An 'unflatten' option should be added to the scan, prob when the pinecone scan is written.