### PR TITLE
Don't start PyTorch thread just doing import.

### DIFF
--- a/lib/sycamore/sycamore/transforms/detr_partitioner.py
+++ b/lib/sycamore/sycamore/transforms/detr_partitioner.py
@@ -13,7 +13,6 @@ import requests
 import json
 from tenacity import retry, retry_if_exception, wait_exponential, stop_after_delay
 import base64
-import easyocr
 import pdf2image
 import pytesseract
 import torch
@@ -648,6 +647,8 @@ def extract_ocr(
 
 
 def extract_table_ocr(image: Image.Image, elem: TableElement):
+    import easyocr
+
     width, height = image.size
 
     assert elem.bbox is not None

--- a/lib/sycamore/sycamore/transforms/embed.py
+++ b/lib/sycamore/sycamore/transforms/embed.py
@@ -94,7 +94,7 @@ class SentenceTransformerEmbedder(Embedder):
         if not self._transformer:
             from sentence_transformers import SentenceTransformer
 
-            self._transformer = SentenceTransformer(self.model_name)
+            self._transformer = SentenceTransformer(self.model_name)  # type: ignore[assignment]
 
         assert self._transformer is not None
 

--- a/lib/sycamore/sycamore/transforms/embed.py
+++ b/lib/sycamore/sycamore/transforms/embed.py
@@ -7,7 +7,6 @@ from typing import Any, Optional, Callable, Union
 from openai import OpenAI as OpenAIClient
 from openai import AzureOpenAI as AzureOpenAIClient
 from ray.data import ActorPoolStrategy
-from sentence_transformers import SentenceTransformer
 
 from sycamore.data import Document
 from sycamore.llms import OpenAIClientParameters
@@ -88,11 +87,13 @@ class SentenceTransformerEmbedder(Embedder):
     ):
         super().__init__(model_name, batch_size, model_batch_size, pre_process_document, device)
         self.type = type
-        self._transformer: Optional[SentenceTransformer] = None
+        self._transformer = None
 
     @timetrace("StEmbedder")
     def generate_embeddings(self, doc_batch: list[Document]) -> list[Document]:
         if not self._transformer:
+            from sentence_transformers import SentenceTransformer
+
             self._transformer = SentenceTransformer(self.model_name)
 
         assert self._transformer is not None

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -3,8 +3,6 @@ from typing import Any
 
 from PIL import Image
 import pdf2image
-from transformers import TableTransformerForObjectDetection
-from torchvision import transforms
 import torch
 
 from sycamore.data import BoundingBox, Element, Document, TableElement
@@ -118,9 +116,13 @@ class TableTransformerStructureExtractor(TableStructureExtractor):
         if element.bbox is None:
             return element
 
+        from torchvision import transforms
+
         width, height = doc_image.size
 
         if self.structure_model is None:
+            from transformers import TableTransformerForObjectDetection
+
             self.structure_model = TableTransformerForObjectDetection.from_pretrained(self.model).to(self._get_device())
         assert self.structure_model is not None  # For typechecking
 


### PR DESCRIPTION
The following modules:
- `easyocr`
- `sentence_transformers`
- `transformers`
- `torchvision`

all pull some shennanigans with `__init__.py` whereby the mere act of importing them starts a PyTorch thread.  Aside from being rude, this has the side effect of attaching to the GPU and holding a reference count on the GPU devices in `/dev/`.  In a Ray context, we don't want the driver to use the GPU, just the workers.  Also, just generally, importing something should not be so heavy-handed.