### PR TITLE
Bugfix intermediate data

### DIFF
--- a/lib/sycamore/sycamore/tests/unit/transforms/test_base.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_base.py
@@ -325,7 +325,7 @@ class TestBaseMapTransform(Common):
         for d in Common.dicts:
             truth_id_to_content[d["doc_id"]] = d
 
-        # assert
+        # assert there is a directory for each node
         directories = next(os.walk(tmp_path))[1]
         assert {"node_1", "node_2"} == set(directories)
 

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_base.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_base.py
@@ -298,10 +298,19 @@ class TestBaseMapTransform(Common):
             "makedirs": True,
             "doc_to_bytes_fn": lambda doc: pickle.dumps(doc),
         }
+        node_a = BaseMapTransform(
+            self.input_node(mocker),
+            f=self.fn_a,
+            name="node_1",
+            args=["simple"],
+            kwargs={"extra2": "kwarg"},
+            enable_auto_metadata=True,
+        )
         self.outputs(
             BaseMapTransform(
-                self.input_node(mocker),
+                node_a,
                 f=self.fn_a,
+                name="node_2",
                 args=["simple"],
                 kwargs={"extra2": "kwarg"},
                 enable_auto_metadata=True,
@@ -316,6 +325,10 @@ class TestBaseMapTransform(Common):
         for d in Common.dicts:
             truth_id_to_content[d["doc_id"]] = d
 
+        # assert
+        directories = next(os.walk(tmp_path))[1]
+        assert {"node_1", "node_2"} == set(directories)
+
         reals = []
         for dirpath, _, filenames in os.walk(tmp_path):
             for filename in filenames:
@@ -323,7 +336,8 @@ class TestBaseMapTransform(Common):
                 with open(file_path, "rb") as file:
                     reals += [pickle.load(file)]
 
-        assert self.ndocs == len(reals)
+        # 2 transforms == each doc processed and written twice
+        assert 2 * self.ndocs == len(reals)
 
         for real in reals:
             assert real.doc_id in truth_id_to_content

--- a/lib/sycamore/sycamore/transforms/base.py
+++ b/lib/sycamore/sycamore/transforms/base.py
@@ -138,8 +138,8 @@ class BaseMapTransform(UnaryNode):
             if isinstance(intermediate_datasink, type):
                 assert intermediate_datasink_kwargs is not None
                 # ensure each nodes data is written in a separate directory
-                intermediate_datasink_kwargs["path"] = intermediate_datasink_kwargs["path"] + "/" + self._name
-                intermediate_datasink = intermediate_datasink(**intermediate_datasink_kwargs)
+                path = intermediate_datasink_kwargs["path"] + "/" + self._name
+                intermediate_datasink = intermediate_datasink(**{**intermediate_datasink_kwargs, "path": path})
             else:
                 intermediate_datasink = intermediate_datasink
             result.write_datasink(intermediate_datasink)


### PR DESCRIPTION
Was modifying 'intermediate_datasink_kwargs' which was resulting in nested directories for each node.