### PR TITLE
Allow custom names for Map/FlatMap nodes

### DIFF
--- a/lib/sycamore/sycamore/tests/unit/test_docset.py
+++ b/lib/sycamore/sycamore/tests/unit/test_docset.py
@@ -64,7 +64,10 @@ class TestDocSet:
     def test_map_default_name(self, mocker):
         context = mocker.Mock(spec=Context)
         docset = DocSet(context, None)
-        f = lambda doc: doc
+
+        def f(doc):
+            return doc
+
         docset = docset.map(f=f)
         assert isinstance(docset.lineage(), Map)
         assert docset.lineage()._name == get_name_from_callable(f)

--- a/lib/sycamore/sycamore/tests/unit/test_docset.py
+++ b/lib/sycamore/sycamore/tests/unit/test_docset.py
@@ -80,11 +80,24 @@ class TestDocSet:
         assert isinstance(docset.lineage(), Map)
         assert docset.lineage()._name == test_name
 
-    def test_flat_map(self, mocker):
+    def test_flat_map_default_name(self, mocker):
         context = mocker.Mock(spec=Context)
         docset = DocSet(context, None)
-        docset = docset.flat_map(f=lambda doc: [doc])
+
+        def f(doc):
+            return [doc]
+
+        docset = docset.flat_map(f=f)
         assert isinstance(docset.lineage(), FlatMap)
+        assert docset.lineage()._name == get_name_from_callable(f)
+
+    def test_flat_map_customt_name(self, mocker):
+        test_name = "test_flat_map_1"
+        context = mocker.Mock(spec=Context)
+        docset = DocSet(context, None)
+        docset = docset.flat_map(f=lambda doc: [doc], name=test_name)
+        assert isinstance(docset.lineage(), FlatMap)
+        assert docset.lineage()._name == test_name
 
     def test_map_batch(self, mocker):
         context = mocker.Mock(spec=Context)

--- a/lib/sycamore/sycamore/tests/unit/test_docset.py
+++ b/lib/sycamore/sycamore/tests/unit/test_docset.py
@@ -24,6 +24,7 @@ from sycamore.transforms import (
 )
 
 from sycamore.llms import LLM
+from sycamore.transforms.base import get_name_from_callable
 from sycamore.transforms.extract_entity import OpenAIEntityExtractor
 from sycamore.transforms.extract_schema import SchemaExtractor
 from sycamore.transforms import Filter
@@ -60,11 +61,21 @@ class TestDocSet:
         docset = docset.query(query_executor=query_executor)
         assert isinstance(docset.lineage(), Query)
 
-    def test_map(self, mocker):
+    def test_map_default_name(self, mocker):
         context = mocker.Mock(spec=Context)
         docset = DocSet(context, None)
-        docset = docset.map(f=lambda doc: doc)
+        f = lambda doc: doc
+        docset = docset.map(f=f)
         assert isinstance(docset.lineage(), Map)
+        assert docset.lineage()._name == get_name_from_callable(f)
+
+    def test_map_custom_name(self, mocker):
+        test_name = "test_map_1"
+        context = mocker.Mock(spec=Context)
+        docset = DocSet(context, None)
+        docset = docset.map(f=lambda doc: doc, name=test_name)
+        assert isinstance(docset.lineage(), Map)
+        assert docset.lineage()._name == test_name
 
     def test_flat_map(self, mocker):
         context = mocker.Mock(spec=Context)

--- a/lib/sycamore/sycamore/transforms/map.py
+++ b/lib/sycamore/sycamore/transforms/map.py
@@ -21,8 +21,8 @@ class Map(BaseMapTransform):
             transformed_dataset = map_transformer.execute()
     """
 
-    def __init__(self, child: Optional[Node], *, f: Any, **resource_args):
-        super().__init__(child, f=Map.wrap(f), **{"name": get_name_from_callable(f), **resource_args})
+    def __init__(self, child: Optional[Node], *, f: Any, **kwargs):
+        super().__init__(child, f=Map.wrap(f), **{"name": get_name_from_callable(f), **kwargs})
 
     @staticmethod
     def wrap(f: Any) -> Callable[[list[Document]], list[Document]]:
@@ -73,8 +73,8 @@ class FlatMap(BaseMapTransform):
 
     """
 
-    def __init__(self, child: Optional[Node], *, f: Callable[[Document], list[Document]], **resource_args):
-        super().__init__(child, f=FlatMap.wrap(f), name=get_name_from_callable(f), **resource_args)
+    def __init__(self, child: Optional[Node], *, f: Callable[[Document], list[Document]], **kwargs):
+        super().__init__(child, f=FlatMap.wrap(f), **{"name": get_name_from_callable(f), **kwargs})
 
     @staticmethod
     def wrap(f: Callable[[Document], list[Document]]) -> Callable[[list[Document]], list[Document]]:
@@ -136,7 +136,7 @@ class MapBatch(BaseMapTransform):
         f_kwargs: Optional[dict[str, Any]] = None,
         f_constructor_args: Optional[Iterable[Any]] = None,
         f_constructor_kwargs: Optional[dict[str, Any]] = None,
-        **resource_args
+        **kwargs
     ):
         super().__init__(
             child,
@@ -145,7 +145,7 @@ class MapBatch(BaseMapTransform):
             kwargs=f_kwargs,
             constructor_args=f_constructor_args,
             constructor_kwargs=f_constructor_kwargs,
-            **resource_args
+            **kwargs
         )
 
     def run(self, docs: list[Document]) -> list[Document]:

--- a/lib/sycamore/sycamore/transforms/map.py
+++ b/lib/sycamore/sycamore/transforms/map.py
@@ -22,7 +22,7 @@ class Map(BaseMapTransform):
     """
 
     def __init__(self, child: Optional[Node], *, f: Any, **resource_args):
-        super().__init__(child, f=Map.wrap(f), name=get_name_from_callable(f), **resource_args)
+        super().__init__(child, f=Map.wrap(f), **{"name": get_name_from_callable(f), **resource_args})
 
     @staticmethod
     def wrap(f: Any) -> Callable[[list[Document]], list[Document]]:


### PR DESCRIPTION
Based on the ordering of params, we're unable to inject a custom name into a Map node. This fixes the order