### PR TITLE
add weaviate writer docs. Also add connectors to ToC

### DIFF
--- a/docs/source/data_ingestion_and_preparation/connector_support.md
+++ b/docs/source/data_ingestion_and_preparation/connector_support.md
@@ -1,7 +1,0 @@
-# Writing a DocSet to Target Data Stores
-
-A final step in a Sycamore processing job is to load the data into a target database for use in your application. This could be a combination of a vector index and term-based index, and includes the enriched metadata from the job. Currently, Pinecone, Weaviate, Elasticsearch, DuckDB, and Opensearch are supported as target databases. Users can access this from a unified write interface, from where they can specify their databases and the respective connection and write arguments.
-
-Further information for each supported database and its relevant documentation is given below:
-
-* [DuckDB](./connectors/duckdb.md)

--- a/docs/source/data_ingestion_and_preparation/connectors.rst
+++ b/docs/source/data_ingestion_and_preparation/connectors.rst
@@ -1,0 +1,10 @@
+Connectors
+=============
+
+Sycamore supports connectors for reading and writing data to and from several sources.
+
+.. toctree::
+    :maxdepth: 1
+
+    ./connectors/duckdb.md
+    ./connectors/weaviate.md

--- a/docs/source/data_ingestion_and_preparation/connectors.rst
+++ b/docs/source/data_ingestion_and_preparation/connectors.rst
@@ -1,7 +1,12 @@
 Connectors
 =============
 
-Sycamore supports connectors for reading and writing data to and from several sources.
+Writing a DocSet to Target Data Stores
+--------------------------------------
+
+A final step in a Sycamore processing job is to load the data into a target database for use in your application. This could be a combination of a vector index and term-based index, and includes the enriched metadata from the job. Currently, Pinecone, Weaviate, Elasticsearch, DuckDB, and Opensearch are supported as target databases. Users can access this from a unified write interface, from where they can specify their databases and the respective connection and write arguments.
+
+Further information for each supported database and its relevant documentation is given below:
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/data_ingestion_and_preparation/connectors/weaviate.md
+++ b/docs/source/data_ingestion_and_preparation/connectors/weaviate.md
@@ -58,7 +58,7 @@ To write a DocSet to a Weaviate Collection from Sycamore, use the `docset.write.
 - `collection_name`: The name of the collection to write to.
 - `collection_config`: (optional) A dictionary of keyword parameters passed to the Weaviate client's [`collection.create(...)`](https://weaviate.io/developers/weaviate/client-libraries/python#instantiate-a-collection) method. A name specified here must match the `collection_name` argument.
 - `flatten_properties`: (optional, default=`False`) Whether to flatten nested property objects during the write. Weaviate can store flattened and nested properties, but will only filter and aggregate top-level properties, meaning they need to be flattened.
-- `execute`: (optional, defaul=`True`) Whether to execute this sycamore pipeline now, or return a docset to add more transforms.
+- `execute`: (optional, default=`True`) Whether to execute this sycamore pipeline now, or return a docset to add more transforms.
 
 To write a docset to the weaviate instance run by the docker compose above, we can write the following:
 

--- a/docs/source/data_ingestion_and_preparation/connectors/weaviate.md
+++ b/docs/source/data_ingestion_and_preparation/connectors/weaviate.md
@@ -1,0 +1,94 @@
+# Weaviate
+
+[Weaviate](https://weaviate.io/) is a full-featured, open-source, AI-native vector database and search engine. Weaviate makes it easy to build semantic search and RAG applications through the use of modular, configurable connectors to many popular AI services.
+
+## Configuration for Weaviate
+
+*Please see the Weaviate's [installation](https://weaviate.io/developers/weaviate/installation) page for more in-depth information on installing, configuring, and running Weaviate. We specify the setup required to run a simple demo app.*
+
+We recommend running Weaviate through docker compose. The provided `compose.yml` file runs Weaviate along with a sidecar local embedding service to make querying easier.
+
+<details>
+  <summary><i>compose.yml</i></summary>
+
+  ```yaml
+version: "3.4"
+services:
+  weaviate:
+    command:
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8080"
+      - --scheme
+      - http
+    image: cr.weaviate.io/semitechnologies/weaviate:1.25.0
+    ports:
+      - 8080:8080
+      - 50051:50051
+    volumes:
+      - weaviate_data:/var/lib/weaviate
+    restart: on-failure:0
+    environment:
+      QUERY_DEFAULTS_LIMIT: 25
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: "true"
+      PERSISTENCE_DATA_PATH: "/var/lib/weaviate"
+      DEFAULT_VECTORIZER_MODULE: "text2vec-transformers"
+      ENABLE_MODULES: "text2vec-transformers"
+      TRANSFORMERS_INFERENCE_API: http://t2v-transformers:8080
+      CLUSTER_HOSTNAME: "node1"
+  t2v-transformers:
+    image: cr.weaviate.io/semitechnologies/transformers-inference:sentence-transformers-all-MiniLM-L6-v2
+    environment:
+      ENABLE_CUDA: 0
+volumes:
+  weaviate_data:
+  ```
+
+  Note the choice of embedding model specified in the compose file.
+</details>
+
+With this you can run Weaviate with a simple `docker compose up`.
+
+## Writing to Weaviate
+
+To write a DocSet to a Weaviate Collection from Sycamore, use the `docset.write.weaviate(...)` function. The Weaviate writer takes the following arguments:
+
+- `wv_client_args`: A dictionary of arguments to pass to the Weaviate client constructor, as in an [explicit conection](https://weaviate.io/developers/weaviate/client-libraries/python#python-client-v4-explicit-connection).
+- `collection_name`: The name of the collection to write to.
+- `collection_config`: (optional) A dictionary of keyword parameters passed to the Weaviate client's [`collection.create(...)`](https://weaviate.io/developers/weaviate/client-libraries/python#instantiate-a-collection) method. A name specified here must match the `collection_name` argument.
+- `flatten_properties`: (optional, default=`False`) Whether to flatten nested property objects during the write. Weaviate can store flattened and nested properties, but will only filter and aggregate top-level properties, meaning they need to be flattened.
+- `execute`: (optional, defaul=`True`) Whether to execute this sycamore pipeline now, or return a docset to add more transforms.
+
+To write a docset to the weaviate instance run by the docker compose above, we can write the following:
+
+```python
+from weaviate.client import ConnectionParams
+from weaviate.collections.classes.config import Configure
+
+collection_name = "MyCollection"
+client_args = {
+    "connection_params": ConnectionParams.from_params(
+        http_host="localhost",
+        http_port=8080,
+        http_secure=False,
+        grpc_host="localhost",
+        grpc_port=50051,
+        grpc_secure=False,
+    )
+}
+collection_config = {
+    "name": collection_name,
+    "description": "A collection to demo data-prep with Sycamore",
+    "vectorizer_config": [Configure.NamedVectors.text2vec_transformers(name="embedding", source_properties=['text_representation'])],
+}
+
+docset.write.weaviate(
+    wv_client_args=client_args,
+    collection_name=collection_name,
+    collection_config=collection_config,
+    flatten_properties=True
+)
+```
+
+More information can be found in the {doc}`API documentation </APIs/data_preparation/docsetwriter>`.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -107,6 +107,7 @@ More Resources
    /data_ingestion_and_preparation/running_a_data_preparation_job.md
    /data_ingestion_and_preparation/generative_ai_configuration.md
    /data_ingestion_and_preparation/transforms.rst
+   /data_ingestion_and_preparation/connectors.rst
 
 
 .. toctree::


### PR DESCRIPTION
The compose file looks big here, but it's in a collapsible and looks like this by default:
![Screenshot 2024-07-12 at 2 11 29 PM](https://github.com/user-attachments/assets/df5d13a5-360e-441b-93f6-12101a606f5d)

also adds to the ToC like so
```
Data Ingestion and Preparation
  ..
  ..
  Transforms     v
  Connectors     ^
    DuckDB
    Weaviate
```