### PR TITLE
set table text rep to csv rep of table

### DIFF
--- a/lib/sycamore/sycamore/data/element.py
+++ b/lib/sycamore/sycamore/data/element.py
@@ -169,6 +169,18 @@ class TableElement(Element):
     def tokens(self, tokens: list[dict[str, Any]]) -> None:
         self.data["tokens"] = tokens
 
+    @property
+    def text_representation(self) -> Optional[str]:
+        if "_override_text" in self.data:
+            return self.data["_override_text"]
+        if self.data["table"]:
+            return self.data["table"].to_csv()
+        return super().text_representation
+
+    @text_representation.setter
+    def text_representation(self, value: str) -> None:
+        self.data["_override_text"] = value
+
 
 def create_element(**kwargs) -> Element:
     if "type" in kwargs and kwargs["type"].lower() == "table":

--- a/lib/sycamore/sycamore/tests/unit/data/test_document.py
+++ b/lib/sycamore/sycamore/tests/unit/data/test_document.py
@@ -1,6 +1,8 @@
 import pytest
 
 from sycamore.data import BoundingBox, Document, Element, MetadataDocument
+from sycamore.data.element import TableElement
+from sycamore.data.table import Table, TableCell
 
 
 class TestElement:
@@ -26,6 +28,23 @@ class TestElement:
         del element.properties
         assert element.properties == {}
         assert element.data["bbox"] == (1, 2, 3, 4)
+
+    def test_table_element_text(self):
+        element = TableElement({"text_representation": "base text"})
+        assert element.type == "table"
+        assert element.text_representation == "base text"
+        table = Table(
+            [
+                TableCell(content="1", rows=[0], cols=[0]),
+                TableCell(content="2", rows=[0], cols=[1]),
+                TableCell(content="3", rows=[1], cols=[0]),
+                TableCell(content="4", rows=[1], cols=[1]),
+            ]
+        )
+        element.table = table
+        assert element.text_representation == table.to_csv()
+        element.text_representation = "new text"
+        assert element.text_representation == "new text"
 
 
 class TestDocument:


### PR DESCRIPTION
instead of whatever text representation it would ordinarily be. Can set it to something else if needed tho with just `table.text_representation = 'blah'`