### PR TITLE
Add __str__ methods to Document and Element.

### DIFF
--- a/lib/sycamore/sycamore/data/document.py
+++ b/lib/sycamore/sycamore/data/document.py
@@ -200,10 +200,12 @@ class Document(UserDict):
             "lineage_id": self.lineage_id,
             "type": self.type,
             "text_representation": self.text_representation[0:40] + "..." if self.text_representation else None,
-            "binary_representation": f"<{len(self.binary_representation)} bytes>" if self.binary_representation else None,
+            "binary_representation": (
+                f"<{len(self.binary_representation)} bytes>" if self.binary_representation else None
+            ),
             "elements": [str(e) for e in self.elements],
-            "embedding": f"<{len(self.embedding)} floats>" if self.embedding else None,
-            "shingles": f"<{len(self.shingles)} ints>" if self.shingles else None,
+            "embedding": (str(self.embedding[0:4]) + f"... <{len(self.embedding)} total>") if self.embedding else None,
+            "shingles": (str(self.shingles[0:4]) + f"... <{len(self.shingles)} total>") if self.shingles else None,
             "parent_id": self.parent_id,
             "bbox": str(self.bbox),
             "properties": self.properties,

--- a/lib/sycamore/sycamore/data/document.py
+++ b/lib/sycamore/sycamore/data/document.py
@@ -1,4 +1,5 @@
 from collections import UserDict
+import json
 from typing import Any, Optional
 import uuid
 
@@ -191,6 +192,23 @@ class Document(UserDict):
     def to_row(self) -> dict[str, bytes]:
         """Serialize this document into a row for use with Ray."""
         return {"doc": self.serialize()}
+
+    def __str__(self) -> str:
+        """Return a pretty-printed string representing this document."""
+        d = {
+            "doc_id": self.doc_id,
+            "lineage_id": self.lineage_id,
+            "type": self.type,
+            "text_representation": self.text_representation[0:40] + "..." if self.text_representation else None,
+            "binary_representation": f"<{len(self.binary_representation)} bytes>" if self.binary_representation else None,
+            "elements": [str(e) for e in self.elements],
+            "embedding": f"<{len(self.embedding)} floats>" if self.embedding else None,
+            "shingles": f"<{len(self.shingles)} ints>" if self.shingles else None,
+            "parent_id": self.parent_id,
+            "bbox": str(self.bbox),
+            "properties": self.properties,
+        }
+        return json.dumps(d, indent=2)
 
 
 class MetadataDocument(Document):

--- a/lib/sycamore/sycamore/data/element.py
+++ b/lib/sycamore/sycamore/data/element.py
@@ -1,5 +1,6 @@
 from collections import UserDict
 from io import BytesIO
+import json
 from typing import Any, Optional
 
 from PIL import Image
@@ -64,6 +65,17 @@ class Element(UserDict):
     @properties.deleter
     def properties(self) -> None:
         self.data["properties"] = {}
+
+    def __str__(self) -> str:
+        """Return a pretty-printed string representing this Element."""
+        d = {
+            "type": self.type,
+            "text_representation": self.text_representation[0:40] + "..." if self.text_representation else None,
+            "binary_representation": f"<{len(self.binary_representation)} bytes>" if self.binary_representation else None,
+            "bbox": str(self.bbox),
+            "properties": self.properties,
+        }
+        return json.dumps(d, indent=2)
 
 
 class ImageElement(Element):

--- a/lib/sycamore/sycamore/data/element.py
+++ b/lib/sycamore/sycamore/data/element.py
@@ -71,7 +71,9 @@ class Element(UserDict):
         d = {
             "type": self.type,
             "text_representation": self.text_representation[0:40] + "..." if self.text_representation else None,
-            "binary_representation": f"<{len(self.binary_representation)} bytes>" if self.binary_representation else None,
+            "binary_representation": (
+                f"<{len(self.binary_representation)} bytes>" if self.binary_representation else None
+            ),
             "bbox": str(self.bbox),
             "properties": self.properties,
         }


### PR DESCRIPTION
This is helpful for debugging as it does not dump the entire contents of, e.g., embedding and shingles.
