### PR TITLE
Get logging working in ray

### DIFF
--- a/examples/simple_duckdb.py
+++ b/examples/simple_duckdb.py
@@ -8,7 +8,6 @@ from sycamore.transforms.merge_elements import MarkedMerger
 from sycamore.transforms.partition import SycamorePartitioner
 from sycamore.transforms.extract_entity import OpenAIEntityExtractor
 from sycamore.transforms.embed import SentenceTransformerEmbedder
-from sycamore.utils.time_trace import ray_logging_setup
 from sycamore.tests.config import TEST_DIR
 from simple_config import title_template
 
@@ -22,7 +21,7 @@ davinci_llm = OpenAI(OpenAIModels.GPT_3_5_TURBO_INSTRUCT.value)
 
 tokenizer = HuggingFaceTokenizer(model_name)
 
-ctx = sycamore.init(ray_args={"runtime_env": {"worker_process_setup_hook": ray_logging_setup}})
+ctx = sycamore.init()
 
 ds = (
     ctx.read.binary(paths, binary_format="pdf")

--- a/lib/sycamore/sycamore/__init__.py
+++ b/lib/sycamore/sycamore/__init__.py
@@ -1,6 +1,6 @@
-from sycamore.context import init, Context
+from sycamore.context import init, shutdown, Context
 from sycamore.docset import DocSet
 from sycamore.executor import Execution
 
 
-__all__ = ["DocSet", "init", "Context", "Execution"]
+__all__ = ["DocSet", "init", "shutdown", "Context", "Execution"]

--- a/lib/sycamore/sycamore/context.py
+++ b/lib/sycamore/sycamore/context.py
@@ -7,13 +7,47 @@ import ray
 from sycamore.rules import Rule
 
 
+def _ray_logging_setup():
+    # The commented out lines allow for easier testing that logging is working correctly since
+    # they will emit information at the start.
+
+    # logging.error("RayLoggingSetup-Before (expect -After; if missing there is a bug)")
+
+    ## WARNING: There can be weird interactions in jupyter/ray with auto-reload. Without the
+    ## Spurious log [0-2]: messages below to verify that log messages are being properly
+    ## propogated.  Spurious log 1 seems to somehow be required.  Without it, the remote map
+    ## worker messages are less likely to come back.
+
+    ## Some documentation for ray implies things should use the ray logger
+    ray_logger = logging.getLogger("ray")
+    ray_logger.setLevel(logging.INFO)
+    # ray_logger.info("Spurious log 2: Verifying that log messages are propogated")
+
+    ## Make the default logging show info messages
+    logging.getLogger().setLevel(logging.INFO)
+    logging.info("Spurious log 1: Verifying that log messages are propogated")
+    # logging.error("RayLoggingSetup-After-2Error")
+
+    ## Verify that another logger would also log properly
+    other_logger = logging.getLogger("other_logger")
+    other_logger.setLevel(logging.INFO)
+    # other_logger.info("RayLoggingSetup-After-3")
+
+
 class Context:
     def __init__(self, ray_args: Optional[dict[str, Any]] = None):
         if ray_args is None:
             ray_args = {}
 
         if "logging_level" not in ray_args:
-            ray_args.update({"logging_level": logging.WARNING})
+            ray_args.update({"logging_level": logging.INFO})
+
+        if "runtime_env" not in ray_args:
+            ray_args["runtime_env"] = {}
+
+        if "worker_process_setup_hook" not in ray_args["runtime_env"]:
+            # logging.error("Spurious log 0: If you do not see spurious log 1 & 2, log messages are being dropped")
+            ray_args["runtime_env"]["worker_process_setup_hook"] = _ray_logging_setup
 
         ray.init(**ray_args)
 
@@ -60,3 +94,10 @@ def init(ray_args: Optional[dict[str, Any]] = None) -> Context:
             _global_context = Context(ray_args)
 
         return _global_context
+
+
+def shutdown() -> None:
+    global _global_context
+    with _context_lock:
+        ray.shutdown()
+        _global_context = None

--- a/lib/sycamore/sycamore/tests/integration/connectors/duckdb/test_pdf_to_duckdb.py
+++ b/lib/sycamore/sycamore/tests/integration/connectors/duckdb/test_pdf_to_duckdb.py
@@ -5,7 +5,6 @@ from sycamore.transforms.merge_elements import MarkedMerger
 from sycamore.transforms.partition import UnstructuredPdfPartitioner
 from sycamore.transforms.embed import SentenceTransformerEmbedder
 from sycamore.tests.config import TEST_DIR
-from sycamore.utils.time_trace import ray_logging_setup
 import duckdb
 import os
 
@@ -17,7 +16,7 @@ def test_to_duckdb():
     paths = str(TEST_DIR / "resources/data/pdfs/")
 
     tokenizer = HuggingFaceTokenizer(model_name)
-    ctx = sycamore.init(ray_args={"runtime_env": {"worker_process_setup_hook": ray_logging_setup}})
+    ctx = sycamore.init()
 
     ds = (
         ctx.read.binary(paths, binary_format="pdf")

--- a/lib/sycamore/sycamore/tests/integration/transforms/test_partition.py
+++ b/lib/sycamore/sycamore/tests/integration/transforms/test_partition.py
@@ -67,9 +67,7 @@ def check_table_extraction(**kwargs):
         ]
     )
 
-    from sycamore.utils.time_trace import ray_logging_setup
-
-    context = sycamore.init(ray_args={"runtime_env": {"worker_process_setup_hook": ray_logging_setup}})
+    context = sycamore.init()
 
     # TODO: The title on the paper is recognized as a section header rather than a page header at the moment.
     # The test will need to be updated if and when that changes.

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_aryn_partitioner.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_aryn_partitioner.py
@@ -10,24 +10,18 @@ class MockResponseNoTables:
     def __init__(self) -> None:
         self.status_code = 200
 
-    def json(self) -> dict:
+    def iter_lines(self):
         path = TEST_DIR / "resources/data/json/model_server_output_transformer.json"
-        return json.loads(open(str(path), "r").read())
-
-    def text(self) -> str:
-        return ""
+        yield open(str(path), "rb").read()
 
 
 class MockResponseTables:
     def __init__(self) -> None:
         self.status_code = 200
 
-    def json(self) -> dict:
+    def iter_lines(self):
         path = TEST_DIR / "resources/data/json/model_server_output_transformer_extract_tables.json"
-        return json.loads(open(str(path), "r").read())
-
-    def text(self) -> str:
-        return ""
+        yield open(str(path), "rb").read()
 
 
 class TestArynPDFPartitioner:
@@ -44,7 +38,7 @@ class TestArynPDFPartitioner:
                         element.binary_representation = base64.b64decode(element.binary_representation)
                     expected_elements.append(element)
 
-                assert_deep_eq(partitioner.partition_pdf(pdf, aryn_api_key=""), expected_elements, [])
+                assert_deep_eq(partitioner.partition_pdf(pdf, aryn_api_key="mocked"), expected_elements, [])
 
     def test_partition_extract_table_structure(self, mocker) -> None:
         mocker.patch("requests.post", return_value=MockResponseTables())
@@ -62,7 +56,7 @@ class TestArynPDFPartitioner:
                     expected_elements.append(element)
 
                 assert_deep_eq(
-                    partitioner.partition_pdf(pdf, extract_table_structure=True, aryn_api_key=""),
+                    partitioner.partition_pdf(pdf, extract_table_structure=True, aryn_api_key="mocked"),
                     expected_elements,
                     [],
                 )

--- a/lib/sycamore/sycamore/transforms/detr_partitioner.py
+++ b/lib/sycamore/sycamore/transforms/detr_partitioner.py
@@ -36,6 +36,9 @@ from sycamore.utils.pdf import convert_from_path_streamed_batched
 from sycamore.utils.time_trace import LogTime, timetrace
 
 
+logger = logging.getLogger(__name__)
+
+
 def _batchify(iterable, n=1):
     length = len(iterable)
     for i in range(0, length, n):
@@ -80,7 +83,10 @@ class ArynPDFPartitioner:
             device: The device on which to run the model.
         """
         self.device = device
-        self.model = DeformableDetr(model_name_or_path, device)
+        if model_name_or_path is None:
+            self.model = None
+        else:
+            self.model = DeformableDetr(model_name_or_path, device)
         self.ocr_table_reader = None
 
     @staticmethod
@@ -132,6 +138,7 @@ class ArynPDFPartitioner:
         pages_per_call: int = -1,
     ) -> List[Element]:
         if use_partitioning_service:
+            assert aryn_api_key != ""
             return self._partition_remote(
                 file=file,
                 aryn_api_key=aryn_api_key,
@@ -145,6 +152,7 @@ class ArynPDFPartitioner:
                 pages_per_call=pages_per_call,
             )
         else:
+            assert self.model is not None
             if batch_at_a_time:
                 temp = self._partition_pdf_batched(
                     file=file,
@@ -210,32 +218,55 @@ class ArynPDFPartitioner:
         files: Mapping = {"pdf": file, "options": json.dumps(options).encode("utf-8")}
         header = {"Authorization": f"Bearer {aryn_api_key}"}
 
-        logging.debug(f"ArynPartitioner POSTing to {aryn_partitioner_address} with files={files}")
-        response = requests.post(aryn_partitioner_address, files=files, headers=header)
-        logging.debug("ArynPartitioner Recieved data")
+        logger.debug(f"ArynPartitioner POSTing to {aryn_partitioner_address} with files={files}")
+        response = requests.post(aryn_partitioner_address, files=files, headers=header, stream=True)
+        lines = []
+        in_status = False
+        for line in response.iter_lines():
+            if line:
+                lines.append(line)
+                if line.startswith(b'  "status"'):
+                    in_status = True
+                if not in_status:
+                    continue
+                if line.startswith(b"  ],"):
+                    in_status = False
+                    continue
+                if line.startswith(b'    "T+'):
+                    t = json.loads(line.decode("utf-8").removesuffix(","))
+                    logger.info(f"ArynPartitioner: {t}")
+
+        body = b"".join(lines).decode("utf-8")
+        logger.debug("ArynPartitioner Recieved data")
 
         if response.status_code != 200:
             if response.status_code == 500 or response.status_code == 502:
-                logging.debug(
+                logger.debug(
                     "ArynPartitioner recieved a retry-able error {} x-aryn-call-id: {}".format(
                         response, response.headers.get("x-aryn-call-id")
                     )
                 )
                 raise ArynPDFPartitionerException(
                     "Error: status_code: {}, reason: {} (x-aryn-call-id: {})".format(
-                        response.status_code, response.text, response.headers.get("x-aryn-call-id")
+                        response.status_code, body, response.headers.get("x-aryn-call-id")
                     ),
                     can_retry=True,
                 )
             raise ArynPDFPartitionerException(
                 "Error: status_code: {}, reason: {} (x-aryn-call-id: {})".format(
-                    response.status_code, response.text, response.headers.get("x-aryn-call-id")
+                    response.status_code, body, response.headers.get("x-aryn-call-id")
                 )
             )
 
-        response_json = response.json()
+        response_json = json.loads(body)
         if isinstance(response_json, dict):
+            status = response_json.get("status", [])
+            if "error" in response_json:
+                raise ArynPDFPartitionerException(
+                    f"Error partway through processing: {response_json['error']}\nPartial Status:\n{status}"
+                )
             response_json = response_json.get("elements")
+
         elements = []
         for element_json in response_json:
             element = create_element(**element_json)
@@ -411,7 +442,7 @@ class ArynPDFPartitioner:
                 pdffile.write(data)
                 del data
                 pdffile.flush()
-                logging.info(f"Wrote {pdffile.name}")
+                logger.info(f"Wrote {pdffile.name}")
             stat = os.stat(pdffile.name)
             assert stat.st_size == data_len
             return self._partition_pdf_batched_named(
@@ -488,7 +519,7 @@ class ArynPDFPartitioner:
 
         if tracemalloc.is_tracing():
             (current, peak) = tracemalloc.get_traced_memory()
-            logging.info(f"Memory Usage current={current} peak={peak}")
+            logger.info(f"Memory Usage current={current} peak={peak}")
             top = tracemalloc.take_snapshot()
             display_top(top)
         return deformable_layout
@@ -673,7 +704,7 @@ class PDFMinerExtractor:
 
         cached_result = pdf_miner_cache.get(hash_key) if use_cache else None
         if cached_result:
-            logging.info("Cache Hit for PDFMiner. Getting the result from cache.")
+            logger.info("Cache Hit for PDFMiner. Getting the result from cache.")
             return cached_result
         else:
             with open_filename(filename, "rb") as fp:
@@ -696,7 +727,7 @@ class PDFMinerExtractor:
 
                     pages.append(texts)
                 if use_cache:
-                    logging.info("Cache Miss for PDFMiner. Storing the result to the cache.")
+                    logger.info("Cache Miss for PDFMiner. Storing the result to the cache.")
                     pdf_miner_cache.set(hash_key, pages)
                 return pages
 

--- a/lib/sycamore/sycamore/utils/aryn_config.py
+++ b/lib/sycamore/sycamore/utils/aryn_config.py
@@ -2,49 +2,39 @@ import os
 import pathlib
 import yaml
 import logging
-import threading
+
+from typing import Dict, Any
 
 _DEFAULT_PATH = os.path.join(pathlib.Path.home(), ".aryn", "config.yaml")
 
 
 class ArynConfig:
-    _global_aryn_config_lock = threading.Lock()
-    _global_aryn_config = None
-
     @classmethod
     def get_aryn_api_key(cls, config_path: str = "") -> str:
         api_key = os.environ.get("ARYN_API_KEY")
         if api_key:
             return api_key
 
-        with cls._global_aryn_config_lock:
-            if cls._global_aryn_config:
-                return cls._global_aryn_config.get("aryn_token", "")
-
-        cls._get_aryn_config(config_path)
-
-        with cls._global_aryn_config_lock:
-            if cls._global_aryn_config:
-                return cls._global_aryn_config.get("aryn_token", "")
-            else:
-                return ""
+        return cls._get_aryn_config(config_path).get("aryn_token", "")
 
     @classmethod
-    def _get_aryn_config(cls, config_path: str = "") -> None:
-        with cls._global_aryn_config_lock:
-            if cls._global_aryn_config:
-                return
-            config_path = config_path or os.environ.get("ARYN_CONFIG") or _DEFAULT_PATH
+    def _get_aryn_config(cls, config_path: str = "") -> Dict[Any, Any]:
+        config_path = config_path or os.environ.get("ARYN_CONFIG") or _DEFAULT_PATH
 
-            try:
-                with open(config_path, "r") as yaml_file:
-                    aryn_config = yaml.safe_load(yaml_file)
-                    cls._global_aryn_config = aryn_config
-                    if not isinstance(aryn_config, dict):
-                        logging.warning("Aryn YAML config appears to be empty.")
-                        return
-                    logging.debug(f"Aryn configuration: {aryn_config}")
-            except FileNotFoundError as err:
+        try:
+            with open(config_path, "r") as yaml_file:
+                aryn_config = yaml.safe_load(yaml_file)
+                if not isinstance(aryn_config, dict):
+                    logging.warning("Aryn YAML config appears to be empty.")
+                    return {}
+                logging.debug(f"Aryn configuration: {aryn_config}")
+                return aryn_config
+        except FileNotFoundError as err:
+            if config_path == _DEFAULT_PATH:
                 logging.debug(f"Unable to load Aryn config {config_path}: {err}")
-            except yaml.scanner.ScannerError as err:
-                logging.error(f"Unable to parse {config_path}: {err}. Ignoring the config file.")
+            else:
+                logging.error(f"Unable to load Aryn config {config_path}: {err}")
+        except yaml.scanner.ScannerError as err:
+            logging.error(f"Unable to parse {config_path}: {err}. Ignoring the config file.")
+
+        return {}

--- a/lib/sycamore/sycamore/utils/time_trace.py
+++ b/lib/sycamore/sycamore/utils/time_trace.py
@@ -146,24 +146,6 @@ class _ZeroRU:
         self.ru_stime = 0
 
 
-def ray_logging_setup():
-    """Use this like:
-
-    ctx = sycamore.init(ray_args={"runtime_env": {"worker_process_setup_hook": ray_logging_setup}})
-
-    When ray starts up you should see:
-    (pid=###) ERROR:root:RayLoggingSetup-Before (expect -After; if missing there is a bug)
-    (pid=###) RayLoggingSetup-After
-
-    If either of those are missing there is a bug.
-    """
-    logging.error("RayLoggingSetup-Before (expect -After; if missing there is a bug)")
-    global logger
-    logger = logging.getLogger("ray")
-    logger.setLevel(logging.INFO)
-    logger.info("RayLoggingSetup-After")
-
-
 class LogTime:
     def __init__(self, name: str, *, point: bool = False, log_start: bool = False):
         if point:

--- a/lib/sycamore/sycamore/writer.py
+++ b/lib/sycamore/sycamore/writer.py
@@ -408,7 +408,7 @@ class DocSetWriter:
                 OpenAI(OpenAIModels.GPT_3_5_TURBO_INSTRUCT.value)
                 tokenizer = HuggingFaceTokenizer(model_name)
 
-                ctx = sycamore.init(ray_args={"runtime_env": {"worker_process_setup_hook": ray_logging_setup}})
+                ctx = sycamore.init()
 
                 ds = (
                     ctx.read.binary(paths, binary_format="pdf")

--- a/notebooks/SycamorePartitionerExample.ipynb
+++ b/notebooks/SycamorePartitionerExample.ipynb
@@ -3,34 +3,91 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d38dec71-a96f-4100-b30c-61f5ad3006e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02fc2d19-75bb-4262-bbc0-e718ce52d1fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sycamore.utils.aryn_config import ArynConfig\n",
+    "\n",
+    "doc_path = \"../lib/sycamore/sycamore/tests/resources/data/pdfs/Transformer.pdf\"\n",
+    "\n",
+    "# For debug checking; be careful this will put your key in the jupyter notebook\n",
+    "#print(ArynConfig.get_aryn_api_key())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e4116c0-49bd-47ec-876c-565e55a5172c",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# This example calls the parititoner directly and prints the output\n",
+    "import logging\n",
+    "import os\n",
+    "\n",
+    "from sycamore.utils.aryn_config import ArynConfig\n",
+    "from sycamore.transforms.detr_partitioner import ArynPDFPartitioner\n",
+    "\n",
+    "logging.getLogger().setLevel(logging.INFO)\n",
+    "\n",
+    "a = ArynPDFPartitioner(model_name_or_path=None)\n",
+    "with open(doc_path, \"rb\") as file:\n",
+    "    b = a.partition_pdf(file, aryn_api_key=ArynConfig.get_aryn_api_key())\n",
+    "    print(b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "0",
    "metadata": {},
    "outputs": [],
    "source": [
     "# This example draws bounding boxes and labels document elements, and it then displays the image as output and writes them to S3. \n",
     "\n",
+    "import ray\n",
     "import sycamore\n",
     "from sycamore.data import Document\n",
     "from sycamore.functions.document import split_and_convert_to_image, DrawBoxes\n",
-    "from sycamore.transforms.partition import SycamorePartitioner\n",
+    "from sycamore.transforms.partition import ArynPartitioner\n",
     "from sycamore.utils.image_utils import image_page_filename_fn\n",
     "from sycamore.utils.pdf_utils import show_pages\n",
+    "from sycamore.utils.aryn_config import ArynConfig\n",
     "from pathlib import Path\n",
+    "import os\n",
+    "import logging\n",
     "\n",
+    "sycamore.shutdown() # auto-reload can make this necessary\n",
     "context = sycamore.init()\n",
     "\n",
     "# This creates a DocSet and runs the Sycamore Partitioner. You can change the threshold (default is 0.4) or enable OCR.\n",
     "# You can use this example document: s3://aryn-public/sycamore-partitioner-examples/document-example-1.pdf\n",
-    "ds = context.read.binary(paths=[\"s3://my-bucket/my-input-folder\"], binary_format=\"pdf\")\\\n",
-    "            .partition(partitioner=SycamorePartitioner(extract_table_structure=True, use_ocr=False, threshold=0.4))\n",
+    "ds = context.read.binary(paths=[doc_path], binary_format=\"pdf\")\\\n",
+    "            .partition(partitioner=ArynPartitioner(model_name_or_path=None,\n",
+    "                                                   extract_table_structure=True, use_ocr=False, threshold=0.4))\n",
     "\n",
     "# This visualizes partitions inline in the notebook. \n",
     "show_pages(ds)\n",
     "\n",
+    "os.makedirs(\"/tmp/example\", exist_ok=True)\n",
     "# To save the visualized partitions for every page, you can use the following transforms.\n",
     "ds.flat_map(split_and_convert_to_image)\\\n",
     "  .map_batch(DrawBoxes, f_constructor_kwargs={\"draw_table_cells\": True})\\\n",
-    "  .write.files(\"s3://my-bucket/my-output-folder\", filename_fn=image_page_filename_fn)\n",
+    "  .write.files(\"/tmp/example\", filename_fn=image_page_filename_fn)\n",
     "\n",
     "# You can read from a S3 or local location. You can choose to read multiple PDFs from a folder, or specify just one PDF."
    ]
@@ -43,6 +100,7 @@
    "outputs": [],
    "source": [
     "# This example partitions the document, extracts images, and summarizes them using gpt-4-turbo. \n",
+    "import ray\n",
     "import sycamore\n",
     "from sycamore.data import BoundingBox, Document, Element, TableElement\n",
     "from sycamore.functions.document import split_and_convert_to_image, DrawBoxes\n",
@@ -79,7 +137,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.1"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
* Log the incremental output from the server
* Handle errors that happen partway through processing
* Move ray logging setup into default sycamore init
* for testing, add a sycamore.shutdown() to clean up sycamore.init()
* Add support for not loading the model when we're only going to call the server
* Add assertions to code to check for user error
* Switch partitioner to using logger. instead of logging. It's better style, it turned out to
  not be necessary.
* Remove caching from aryn_config. It caused problems when called with different parameters
  If we're going to re-introduce this we can use @cache which will respect parameters.
* Make SycamorePartitionerExample notebook runnable. The example failed because of missing
  files/directories.