### PR TITLE
Run Sycamore integ tests only on Python 3.9.

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -81,7 +81,7 @@ jobs:
     runs-on: integ-test-runner
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9"]
     services:
       opensearch:
         image: opensearchproject/opensearch:2.10.0


### PR DESCRIPTION
This should provide roughly the same coverage, but be significantly cheaper and faster to execute. We run with Python 3.9, the minimum python version we support, to catch cases where we have inadvertently added dependencies on features added in later versions.