### PR TITLE
Switch to using chunk_size=None when calling the APS.

### DIFF
--- a/lib/sycamore/sycamore/tests/unit/transforms/test_aryn_partitioner.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_aryn_partitioner.py
@@ -10,7 +10,7 @@ class MockResponseNoTables:
     def __init__(self) -> None:
         self.status_code = 200
 
-    def iter_lines(self):
+    def iter_lines(self, chunk_size):
         path = TEST_DIR / "resources/data/json/model_server_output_transformer.json"
         yield open(str(path), "rb").read()
 
@@ -19,7 +19,7 @@ class MockResponseTables:
     def __init__(self) -> None:
         self.status_code = 200
 
-    def iter_lines(self):
+    def iter_lines(self, chunk_size):
         path = TEST_DIR / "resources/data/json/model_server_output_transformer_extract_tables.json"
         yield open(str(path), "rb").read()
 

--- a/lib/sycamore/sycamore/transforms/detr_partitioner.py
+++ b/lib/sycamore/sycamore/transforms/detr_partitioner.py
@@ -223,7 +223,7 @@ class ArynPDFPartitioner:
         response = requests.post(aryn_partitioner_address, files=files, headers=header, stream=True)
         lines = []
         in_status = False
-        for line in response.iter_lines():
+        for line in response.iter_lines(chunk_size=None):
             if line:
                 lines.append(line)
                 if line.startswith(b'  "status"'):


### PR DESCRIPTION
Empirically this fixes issues with the client hanging for large responses.