### PR TITLE
Fix long line issue in partitioner client

### DIFF
--- a/lib/sycamore/sycamore/tests/unit/transforms/test_aryn_partitioner.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_aryn_partitioner.py
@@ -10,7 +10,7 @@ class MockResponseNoTables:
     def __init__(self) -> None:
         self.status_code = 200
 
-    def iter_lines(self):
+    def iter_content(self, chunksize):
         path = TEST_DIR / "resources/data/json/model_server_output_transformer.json"
         yield open(str(path), "rb").read()
 
@@ -19,7 +19,7 @@ class MockResponseTables:
     def __init__(self) -> None:
         self.status_code = 200
 
-    def iter_lines(self):
+    def iter_content(self, chunksize):
         path = TEST_DIR / "resources/data/json/model_server_output_transformer_extract_tables.json"
         yield open(str(path), "rb").read()
 


### PR DESCRIPTION
The default requests code can be quadratic in the data size if it finds a single long line without a newline because it is doing the standard append to a string trick.  Switch over to chunking based on raw data and explicitly handle splitting by lines for the early status output.