### PR TITLE
Support user tracking for Helicone

### DIFF
--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -333,6 +333,9 @@ class OpenAI(LLM):
             **llm_kwargs,
         }
 
+        if "SYCAMORE_HELICONE_USER" in os.environ:
+            kwargs.update({"user": os.environ.get("SYCAMORE_HELICONE_USER")})
+
         if "prompt" in prompt_kwargs:
             prompt = prompt_kwargs.get("prompt")
             messages: list[ChatCompletionMessageParam] = [{"role": "user", "content": f"{prompt}"}]

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -333,8 +333,8 @@ class OpenAI(LLM):
             **llm_kwargs,
         }
 
-        if "SYCAMORE_HELICONE_USER" in os.environ:
-            kwargs.update({"user": os.environ.get("SYCAMORE_HELICONE_USER")})
+        if "SYCAMORE_OPENAI_USER" in os.environ:
+            kwargs.update({"user": os.environ.get("SYCAMORE_OPENAI_USER")})
 
         if "prompt" in prompt_kwargs:
             prompt = prompt_kwargs.get("prompt")


### PR DESCRIPTION
Send `user` parameter in OpenAI call based on environment variable `SYCAMORE_HELICONE_USER`