### PR TITLE
Add user id variable to env (Helicone tracking for CI runs)

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,6 +17,7 @@ env:
   PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
   ARYN_API_KEY: ${{ secrets.MODEL_SERVER_KEY }}
   SYCAMORE_HELICONE_API_KEY: ${{ secrets.HELICONE_API_KEY }}
+  SYCAMORE_OPENAI_USER: 'sycamore-github-ci'
 
 # Permissions for AWS access
 permissions:


### PR DESCRIPTION
Forgot to update this in https://github.com/aryn-ai/sycamore/pull/599