### PR TITLE
Add local (no-ray) execution mode to speed up lineage development

### DIFF
--- a/lib/sycamore/sycamore/__init__.py
+++ b/lib/sycamore/sycamore/__init__.py
@@ -1,6 +1,6 @@
-from sycamore.context import init, shutdown, Context
+from sycamore.context import init, shutdown, Context, ExecMode
 from sycamore.docset import DocSet
 from sycamore.executor import Execution
 
 
-__all__ = ["DocSet", "init", "shutdown", "Context", "Execution"]
+__all__ = ["DocSet", "init", "shutdown", "Context", "Execution", "ExecMode"]

--- a/lib/sycamore/sycamore/connectors/file/materialized_scan.py
+++ b/lib/sycamore/sycamore/connectors/file/materialized_scan.py
@@ -43,6 +43,9 @@ class DocScan(MaterializedScan):
     def execute(self, **kwargs) -> Dataset:
         return from_items(items=[{"doc": doc.serialize()} for doc in self._docs])
 
+    def local_source(self) -> list[Document]:
+        return self._docs
+
     def format(self):
         return "document"
 

--- a/lib/sycamore/sycamore/context.py
+++ b/lib/sycamore/sycamore/context.py
@@ -1,10 +1,12 @@
+from enum import Enum
 import logging
 import threading
-from typing import Any, Optional
-
-import ray
+from typing import Any, Optional, TYPE_CHECKING
 
 from sycamore.rules import Rule
+
+if TYPE_CHECKING:
+    import ray
 
 
 def _ray_logging_setup():
@@ -34,27 +36,41 @@ def _ray_logging_setup():
     # other_logger.info("RayLoggingSetup-After-3")
 
 
+class ExecMode(Enum):
+    UNKNOWN = 0
+    RAY = 1
+    LOCAL = 2
+
+
 class Context:
     """
     A class to implement a Sycamore Context, which initializes a Ray Worker and provides the ability
     to read data into a DocSet
     """
 
-    def __init__(self, ray_args: Optional[dict[str, Any]] = None):
-        if ray_args is None:
-            ray_args = {}
+    def __init__(self, exec_mode=ExecMode.RAY, ray_args: Optional[dict[str, Any]] = None):
+        self.exec_mode = exec_mode
+        if self.exec_mode == ExecMode.RAY:
+            import ray
 
-        if "logging_level" not in ray_args:
-            ray_args.update({"logging_level": logging.INFO})
+            if ray_args is None:
+                ray_args = {}
 
-        if "runtime_env" not in ray_args:
-            ray_args["runtime_env"] = {}
+            if "logging_level" not in ray_args:
+                ray_args.update({"logging_level": logging.INFO})
 
-        if "worker_process_setup_hook" not in ray_args["runtime_env"]:
-            # logging.error("Spurious log 0: If you do not see spurious log 1 & 2, log messages are being dropped")
-            ray_args["runtime_env"]["worker_process_setup_hook"] = _ray_logging_setup
+            if "runtime_env" not in ray_args:
+                ray_args["runtime_env"] = {}
 
-        ray.init(**ray_args)
+            if "worker_process_setup_hook" not in ray_args["runtime_env"]:
+                # logging.error("Spurious log 0: If you do not see spurious log 1 & 2, log messages are being dropped")
+                ray_args["runtime_env"]["worker_process_setup_hook"] = _ray_logging_setup
+
+            ray.init(**ray_args)
+        elif self.exec_mode == ExecMode.LOCAL:
+            pass
+        else:
+            assert False, f"unsupported mode {self.exec_mode}"
 
         self.extension_rules: list[Rule] = []
         self._internal_lock = threading.Lock()
@@ -93,7 +109,7 @@ _context_lock = threading.Lock()
 _global_context: Optional[Context] = None
 
 
-def init(ray_args: Optional[dict[str, Any]] = None) -> Context:
+def init(exec_mode=ExecMode.RAY, ray_args: Optional[dict[str, Any]] = None) -> Context:
     global _global_context
     with _context_lock:
         if _global_context is None:
@@ -106,7 +122,7 @@ def init(ray_args: Optional[dict[str, Any]] = None) -> Context:
 
             sycamore_logger.setup_logger()
 
-            _global_context = Context(ray_args)
+            _global_context = Context(exec_mode, ray_args)
 
         return _global_context
 

--- a/lib/sycamore/sycamore/data/document.py
+++ b/lib/sycamore/sycamore/data/document.py
@@ -221,8 +221,12 @@ class MetadataDocument(Document):
         if "metadata" not in self.data:
             self.data["metadata"] = {}
         self.data["metadata"].update(kwargs)
+        if "lineage_links" in self.metadata:
+            assert len(self.metadata["lineage_links"]["from_ids"]) > 0
+
         del self.data["lineage_id"]
         del self.data["elements"]
+        del self.data["properties"]
 
     # Override some of the common operations to make it hard to mis-use metadata. If any of these
     # are called it means that something tried to process a MetadataDocument as if it was a

--- a/lib/sycamore/sycamore/data/element.py
+++ b/lib/sycamore/sycamore/data/element.py
@@ -5,8 +5,8 @@ from typing import Any, Optional
 
 from PIL import Image
 
-from sycamore.data import BoundingBox
-from sycamore.data import Table
+from sycamore.data.bbox import BoundingBox
+from sycamore.data.table import Table
 
 
 class Element(UserDict):

--- a/lib/sycamore/sycamore/data/table.py
+++ b/lib/sycamore/sycamore/data/table.py
@@ -5,7 +5,7 @@ import xml.etree.ElementTree as ET
 
 import apted
 from bs4 import BeautifulSoup, Tag
-from sycamore.data import BoundingBox
+from sycamore.data.bbox import BoundingBox
 from PIL import Image, ImageDraw
 import numpy as np
 from pandas import DataFrame

--- a/lib/sycamore/sycamore/docset.py
+++ b/lib/sycamore/sycamore/docset.py
@@ -7,6 +7,7 @@ from typing import Callable, Optional, Any, Iterable, Type
 from sycamore.context import Context
 from sycamore.data import Document, Element, MetadataDocument
 from sycamore.functions.tokenizer import Tokenizer
+from sycamore.lineage import Materialize, MaterializeMode
 from sycamore.plan_nodes import Node, Transform
 from sycamore.transforms.augment_text import TextAugmentor
 from sycamore.transforms.embed import Embedder
@@ -166,10 +167,8 @@ class DocSet:
         from sycamore import Execution
 
         execution = Execution(self.context, self.plan)
-        dataset = execution.execute(self.plan, **kwargs)
         ret = []
-        for row in dataset.iter_rows():
-            doc = Document.from_row(row)
+        for doc in execution.execute_iter(self.plan, **kwargs):
             if not include_metadata and isinstance(doc, MetadataDocument):
                 continue
             ret.append(doc)
@@ -949,3 +948,15 @@ class DocSet:
                      index_settings=index_settings)
         """
         return DocSetWriter(self.context, self.plan)
+
+    def materialize(self, path=None, mode=MaterializeMode.INMEM_VERIFY_ONLY, max_retries=1, keep=0) -> "DocSet":
+        """
+        Guarantees reliable execution up to this point, allows for
+        follow on execution based on the checkpoint if the checkpoint is named.
+        """
+
+        assert path is None, "unimplemented"
+        assert mode == MaterializeMode.INMEM_VERIFY_ONLY, "unimplemented"
+        assert max_retries == 1, "unimplemented"
+        assert keep == 0, "unimplemented"
+        return DocSet(self.context, Materialize(self.plan))

--- a/lib/sycamore/sycamore/executor.py
+++ b/lib/sycamore/sycamore/executor.py
@@ -1,6 +1,10 @@
-from ray.data import Dataset
+from typing import Iterable, TYPE_CHECKING
 
-from sycamore import Context
+if TYPE_CHECKING:
+    from ray.data import Dataset
+
+from sycamore.context import Context, ExecMode
+from sycamore.data import Document
 from sycamore.plan_nodes import Node
 
 
@@ -8,6 +12,7 @@ class Execution:
     def __init__(self, context: Context, plan: Node):
         self._context = context
         self._plan = plan
+        self._exec_mode = context.exec_mode
         from sycamore.rewriter import Rewriter
 
         extension_rules = context.get_extension_rule()
@@ -15,4 +20,35 @@ class Execution:
 
     def execute(self, plan: Node, **kwargs) -> "Dataset":
         self.rewriter.rewrite(plan)
-        return plan.execute(**kwargs)
+        if self._exec_mode == ExecMode.RAY:
+            return plan.execute(**kwargs)
+        if self._exec_mode == ExecMode.LOCAL:
+            from ray.data import from_items
+
+            return from_items(items=[{"doc": doc.serialize()} for doc in self.recursive_execute(self._plan)])
+        assert False
+
+    def execute_iter(self, plan: Node, **kwargs) -> Iterable[Document]:
+        self.rewriter.rewrite(plan)
+        if self._exec_mode == ExecMode.RAY:
+            ds = plan.execute(**kwargs)
+            for row in ds.iter_rows():
+                yield Document.from_row(row)
+            return
+        if self._exec_mode == ExecMode.LOCAL:
+            for d in self.recursive_execute(self._plan):
+                yield d
+            return
+        assert False
+
+    def recursive_execute(self, n: Node) -> list[Document]:
+        if len(n.children) == 0:
+            assert hasattr(n, "local_source"), f"Source {n} needs a local_source method"
+            return n.local_source()
+        if len(n.children) == 1:
+            assert hasattr(n, "local_execute"), f"Transform {n.__class__.__name__} needs a local_execute method"
+            assert n.children[0] is not None
+            return n.local_execute(self.recursive_execute(n.children[0]))
+
+        assert f"Unable to handle node {n} with multiple children"
+        return []

--- a/lib/sycamore/sycamore/lineage.py
+++ b/lib/sycamore/sycamore/lineage.py
@@ -1,0 +1,38 @@
+from enum import Enum
+import logging
+import pprint
+from typing import TYPE_CHECKING
+
+from sycamore.plan_nodes import Node, UnaryNode
+from sycamore.data import Document, MetadataDocument
+
+if TYPE_CHECKING:
+    from ray import Dataset
+
+
+class MaterializeMode(Enum):
+    UNKNOWN = 0
+    INMEM_VERIFY_ONLY = 1
+    # todo: more modes
+
+
+class Materialize(UnaryNode):
+    def __init__(self, child: Node, **kwargs):
+        assert isinstance(child, Node)
+        super().__init__(child, **kwargs)
+
+    def execute(self, **kwargs) -> "Dataset":
+        input_dataset = self.child().execute(**kwargs)
+        md = []
+        for row in input_dataset.iter_rows():
+            doc = Document.from_row(row)
+            if not isinstance(doc, MetadataDocument):
+                continue
+            md.append(doc)
+        return input_dataset
+
+    def local_execute(self, docs: list[Document]) -> list[Document]:
+        md = [d for d in docs if isinstance(d, MetadataDocument)]
+        logging.info(f"Found {len(md)} md documents")
+        logging.info(f"\n{pprint.pformat(md)}")
+        return docs

--- a/lib/sycamore/sycamore/plan_nodes.py
+++ b/lib/sycamore/sycamore/plan_nodes.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
-from typing import Callable, Optional
+from typing import Callable, Optional, TYPE_CHECKING
 
-from ray.data import Dataset
+if TYPE_CHECKING:
+    from ray import Dataset
 
 
 class Node(ABC):
@@ -19,7 +20,7 @@ class Node(ABC):
         return "node"
 
     @abstractmethod
-    def execute(self, **kwargs) -> Dataset:
+    def execute(self, **kwargs) -> "Dataset":
         pass
 
     def traverse_down(self, f: Callable[["Node"], "Node"]) -> "Node":

--- a/lib/sycamore/sycamore/tests/integration/test_image_utils.py
+++ b/lib/sycamore/sycamore/tests/integration/test_image_utils.py
@@ -40,12 +40,12 @@ def check_image(image: Image.Image, expected_color=(0, 0, 255, 255)) -> None:
     assert expected_color in set((color_tup[1] for color_tup in raw_colors))
 
 
-def test_draw_boxes_bbox(source_image, image_boxes):
+def test_draw_boxes_bbox(source_image, image_boxes) -> None:
     output: Image.Image = try_draw_boxes(source_image, image_boxes)
     check_image(output)
 
 
-def test_draw_boxes_object_bbox(source_image, image_boxes):
+def test_draw_boxes_object_bbox(source_image, image_boxes) -> None:
     class BBoxHolder:
         def __init__(self, bbox):
             self._bbox = bbox
@@ -59,25 +59,25 @@ def test_draw_boxes_object_bbox(source_image, image_boxes):
     check_image(output)
 
 
-def test_draw_boxes_coord_list(source_image, image_boxes):
+def test_draw_boxes_coord_list(source_image, image_boxes) -> None:
     boxes = [b.coordinates for b in image_boxes]
     output: Image.Image = try_draw_boxes(source_image, boxes)
     check_image(output)
 
 
-def test_draw_boxes_point_list(source_image, image_boxes):
+def test_draw_boxes_point_list(source_image, image_boxes) -> None:
     boxes = [[(b.x1, b.y1), (b.x2, b.y1), (b.x2, b.y2), (b.x1, b.y2)] for b in image_boxes]
     output: Image.Image = try_draw_boxes(source_image, boxes)
     check_image(output)
 
 
-def test_draw_boxes_two_points(source_image, image_boxes):
+def test_draw_boxes_two_points(source_image, image_boxes) -> None:
     boxes = [((b.x1, b.y1), (b.x2, b.y2)) for b in image_boxes]
     output: Image.Image = try_draw_boxes(source_image, boxes)
     check_image(output)
 
 
-def test_draw_boxes_dict(source_image, image_boxes):
+def test_draw_boxes_dict(source_image, image_boxes) -> None:
     boxes = [{"bbox": b.coordinates} for b in image_boxes]
     output: Image.Image = try_draw_boxes(source_image, boxes)
     check_image(output)

--- a/lib/sycamore/sycamore/tests/unit/connectors/common/test_base_writer.py
+++ b/lib/sycamore/sycamore/tests/unit/connectors/common/test_base_writer.py
@@ -73,7 +73,7 @@ class Common:
 
 class TestBaseDBWriter(Common):
 
-    def test_fake_writer_e2e_happy(self, mocker, tmp_path):
+    def test_fake_writer_e2e_happy(self, mocker, tmp_path) -> None:
         input_node = mocker.Mock(spec=Node)
         client_params = FakeClientParams(fspath=tmp_path)
         target_params = FakeTargetParams(dirname="target", mode="fake")
@@ -94,7 +94,7 @@ class TestBaseDBWriter(Common):
         assert FakeWriter.Record == FakeRecord
         assert FakeWriter.TargetParams == FakeTargetParams
 
-    def test_fake_writer_filtered_happy(self, mocker, tmp_path):
+    def test_fake_writer_filtered_happy(self, mocker, tmp_path) -> None:
         input_node = mocker.Mock(spec=Node)
         client_params = FakeClientParams(fspath=tmp_path)
         target_params = FakeTargetParams(dirname="target", mode="fake")

--- a/lib/sycamore/sycamore/tests/unit/test_lineage.py
+++ b/lib/sycamore/sycamore/tests/unit/test_lineage.py
@@ -1,0 +1,29 @@
+import uuid
+
+import sycamore
+from sycamore.context import ExecMode
+from sycamore.data import Document, MetadataDocument
+
+
+class TestLineage:
+    def make_docs(self, num):
+        docs = []
+        for i in range(num):
+            doc = Document({"doc_id": f"doc_{i}"})
+            docs.append(doc)
+
+        docs.append(
+            MetadataDocument(
+                lineage_links={"from_ids": ["root:" + str(uuid.uuid4())], "to_ids": [d.lineage_id for d in docs]}
+            )
+        )
+
+        return docs
+
+    @staticmethod
+    def noop_fn(d):
+        return d
+
+    def test_simple(self):
+        ctx = sycamore.init(exec_mode=ExecMode.LOCAL)
+        ctx.read.document(self.make_docs(3)).map(self.noop_fn).materialize().show()

--- a/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
@@ -509,7 +509,7 @@ def nms(objects, match_criteria="object2_overlap", match_threshold=0.05, keep_hi
     return [obj for idx, obj in enumerate(objects) if not suppression[idx]]
 
 
-def align_headers(headers, rows):
+def align_headers(headers, rows) -> list[dict[str, list]]:
     """
     Adjust the header boundary to be the convex hull of the rows it intersects
     at least 50% of the height of.
@@ -518,7 +518,7 @@ def align_headers(headers, rows):
     eliminate anything besides the top-most header.
     """
 
-    aligned_headers = []
+    aligned_headers: list[dict[str, list]] = []
 
     for row in rows:
         row["header"] = False
@@ -557,6 +557,7 @@ def align_headers(headers, rows):
             # Having more than 1 header is not supported currently.
             break
 
+    assert header_rect is not None
     header = {"bbox": header_rect.to_list()}
     aligned_headers.append(header)
 


### PR DESCRIPTION
Speeds up the new test_lineage.py from ~20s -> ~4s.  Specified via the context. Currently only works for linear pipelines with a source of in-memory documents.  Implementation is the obvious recursive execution.

Attempted further improvements of making import sycamore faster, but it turned out to be very complex.  We have lots of dependencies; started making some of them optional and using conditional imports to keep typechecking working.

Fix a handful of additional type issues beyond the ones the change introduced.

Fix bug in auto-metadata where we calculate lineage without input/output documents.

Have to have the local mode return an Iterator[Document] keeping the Dataset api requires importing ray which takes >0.5s.

Added almost no-op materialize class and docset operator.