### PR TITLE
parse html tables better

### DIFF
--- a/lib/sycamore/sycamore/data/table.py
+++ b/lib/sycamore/sycamore/data/table.py
@@ -166,7 +166,7 @@ class Table:
 
         if html_str is not None:
             html_str = html_str.strip()
-            if not html_str.startswith("<table>") or not html_str.endswith("</table>"):
+            if not html_str.startswith("<table") or not html_str.endswith("</table>"):
                 raise ValueError("html_str must be a valid html table enclosed in <table></table> tags.")
 
             root = BeautifulSoup(html_str, "html.parser")

--- a/lib/sycamore/sycamore/tests/unit/data/test_table.py
+++ b/lib/sycamore/sycamore/tests/unit/data/test_table.py
@@ -56,7 +56,19 @@ class SimpleTable(TableFormatTestCase):
                 </tr>
               </tbody>
             </table>
+            """,
             """
+            <table frame="hsides">
+              <tr>
+                <td>1</td>
+                <td>2</td>
+              </tr>
+              <tr>
+                <td>3</td>
+                <td>4</td>
+              </tr>
+            </table>
+            """,
         ]
 
     def csv(self) -> str:
@@ -482,3 +494,8 @@ def test_from_html(test_case):
     actual = Table.from_html(html_str=test_case.canonical_html())
     expected = test_case.table()
     assert actual == expected
+
+    if hasattr(test_case, "other_html"):
+        for other_html in test_case.other_html():
+            actual = Table.from_html(html_str=other_html)
+            assert actual == expected


### PR DESCRIPTION
when you get a table with extra stuff in the tag, e.g. from pubtabnet
```
<html> <head> <meta charset="utf-8"/> <style> table, th, td { border: 1px solid black; font-size: 10px; } </style> </head> <body> <table frame="hsides" rules="groups" width="100%"> <thead> <tr> <td> <b> Kinetic parameter </b> </td> <td> <b> ND </b> </td> <td>...
```
and you try to parse the table string part don't vomit because the string doesn't start with `<table>`