### PR TITLE
Change Aryn-SDK Error Message

### DIFF
--- a/lib/aryn-sdk/aryn_sdk/partition/partition.py
+++ b/lib/aryn-sdk/aryn_sdk/partition/partition.py
@@ -2,6 +2,7 @@ from typing import BinaryIO, Optional, Union
 from collections.abc import Mapping
 from aryn_sdk.config import ArynConfig
 import requests
+from requests.exceptions import HTTPError
 import sys
 import json
 import logging
@@ -130,8 +131,12 @@ def partition_file(
     assert isinstance(data, dict)
     status = data.get("status", [])
     if "error" in data:
-        raise ValueError(f"Error partway through processing: {data['error']}\nPartial Status:\n{status}")
-
+        error_msg = (
+            "Limit Exceeded:"
+            if "Please try again in a little while" in data["error"]
+            else "Error partway through processing:"
+        )
+        raise ValueError(f"{error_msg} {data['error']}\nPartial Status:\n{status}")
     return data
 
 

--- a/lib/aryn-sdk/aryn_sdk/partition/partition.py
+++ b/lib/aryn-sdk/aryn_sdk/partition/partition.py
@@ -2,7 +2,6 @@ from typing import BinaryIO, Optional, Union
 from collections.abc import Mapping
 from aryn_sdk.config import ArynConfig
 import requests
-from requests.exceptions import HTTPError
 import sys
 import json
 import logging


### PR DESCRIPTION
Allows `LimitExceededError` to have a message that makes more sense