### PR TITLE
Added OpenAI Async client

### DIFF
--- a/lib/sycamore/sycamore/llms/llms.py
+++ b/lib/sycamore/sycamore/llms/llms.py
@@ -17,7 +17,7 @@ class LLM(ABC):
     def is_chat_mode(self) -> bool:
         pass
 
-    async def generate_future(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> Awaitable[str]:
+    async def generate_async(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> Awaitable[str]:
         raise ValueError("No implementation for llm futures exists")
 
 

--- a/lib/sycamore/sycamore/llms/llms.py
+++ b/lib/sycamore/sycamore/llms/llms.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Awaitable, Optional
 
 from sycamore.utils.cache import Cache
 
@@ -16,6 +16,9 @@ class LLM(ABC):
     @abstractmethod
     def is_chat_mode(self) -> bool:
         pass
+
+    async def generate_future(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> Awaitable[str]:
+        raise ValueError("No implementation for llm futures exists")
 
 
 class FakeLLM(LLM):

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -125,7 +125,7 @@ class OpenAIClientWrapper:
 
             self.api_key = os.environ.get("AZURE_OPENAI_API_KEY")
 
-    def get_client(self, asynchronous: bool = False) -> OpenAIClient:
+    def get_client(self, asynchronous: bool = False) -> Union[OpenAIClient, AsyncOpenAIClient]:
         if self.client_type == OpenAIClientType.OPENAI:
             # We currently only support Helicone with OpenAI.
             base_url = self.base_url

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -412,7 +412,7 @@ class OpenAI(LLM):
 
         if llm_kwargs is None:
             raise ValueError("Must include llm_kwargs to generate future call")
-        ret = await self._generate_future_using_openai(prompt_kwargs, llm_kwargs)
+        ret = await self._generate_awaitable_using_openai(prompt_kwargs, llm_kwargs)
 
         value = {
             "result": ret,
@@ -423,7 +423,7 @@ class OpenAI(LLM):
         self._cache_set(key, value)
         return ret
 
-    async def _generate_future_using_openai(self, prompt_kwargs, llm_kwargs) -> Awaitable[str]:
+    async def _generate_awaitable_using_openai(self, prompt_kwargs, llm_kwargs) -> Awaitable[str]:
         kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
 
         completion = await self.client_wrapper.get_async_client().chat.completions.create(

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -339,7 +339,7 @@ class OpenAI(LLM):
         return self._cache.get_hash_context(data).hexdigest()
 
     def _cache_get(self, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None):
-        if llm_kwargs.get("temperature", 0) != 0 or not self._cache:
+        if (llm_kwargs or {}).get("temperature", 0) != 0 or not self._cache:
             return (None, None)
 
         key = self._get_cache_key(prompt_kwargs, llm_kwargs)
@@ -363,10 +363,10 @@ class OpenAI(LLM):
             return
         self._cache.set(key, result)
 
-    def _get_generate_kwargs(self, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None):
+    def _get_generate_kwargs(self, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> dict:
         kwargs = {
             "temperature": 0,
-            **llm_kwargs,
+            **(llm_kwargs or {}),
         }
         if "SYCAMORE_OPENAI_USER" in os.environ:
             kwargs.update({"user": os.environ.get("SYCAMORE_OPENAI_USER")})

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_graph_extractor.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_graph_extractor.py
@@ -5,7 +5,6 @@ from sycamore.reader import DocSetReader
 from sycamore.transforms.extract_graph import GraphMetadata, MetadataExtractor, GraphEntity, EntityExtractor
 from sycamore.data import HierarchicalDocument
 from collections import defaultdict
-import asyncio
 
 
 class TestGraphExtractor:

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_graph_extractor.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_graph_extractor.py
@@ -5,6 +5,7 @@ from sycamore.reader import DocSetReader
 from sycamore.transforms.extract_graph import GraphMetadata, MetadataExtractor, GraphEntity, EntityExtractor
 from sycamore.data import HierarchicalDocument
 from collections import defaultdict
+import asyncio
 
 
 class TestGraphExtractor:
@@ -82,6 +83,10 @@ class TestGraphExtractor:
             super().__init__(model_name="mock_model")
 
         def generate(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None):
+            pass
+
+        async def generate_future(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None):
+            await asyncio.sleep(1)
             return """{
                 "entities": [
                     {

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_graph_extractor.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_graph_extractor.py
@@ -86,7 +86,6 @@ class TestGraphExtractor:
             pass
 
         async def generate_future(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None):
-            await asyncio.sleep(1)
             return """{
                 "entities": [
                     {

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_graph_extractor.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_graph_extractor.py
@@ -84,7 +84,7 @@ class TestGraphExtractor:
         def generate(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None):
             pass
 
-        async def generate_future(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None):
+        async def generate_async(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None):
             return """{
                 "entities": [
                     {

--- a/lib/sycamore/sycamore/transforms/extract_graph.py
+++ b/lib/sycamore/sycamore/transforms/extract_graph.py
@@ -258,7 +258,7 @@ class EntityExtractor(GraphExtractor):
         return doc
 
     async def _extract_from_section(self, labels, summary: str) -> Awaitable[str]:
-        return await self.llm.generate_future(
+        return await self.llm.generate_async(
             prompt_kwargs={"prompt": str(GraphEntityExtractorPrompt(labels, summary))},
             llm_kwargs={"response_format": {"type": "json_object"}},
         )


### PR DESCRIPTION
Added ```generate_future()``` to the openai client that can be used to request a large amount of openai calls in parallel.

Example usage:
```python
async def gather_api_calls():
    tasks = [self.llm.generate_future(prompt_kwargs={"prompt": prompt}, llm_kwargs={...}) for prompt in prompts]
    res = await asyncio.gather(*tasks)
    return res

res = asyncio.run(gather_api_calls())
```