### PR TITLE
fix table html parsing edge case

### DIFF
--- a/lib/sycamore/sycamore/tests/unit/data/test_table.py
+++ b/lib/sycamore/sycamore/tests/unit/data/test_table.py
@@ -199,6 +199,49 @@ class SimpleTableMultiColHeader(TableFormatTestCase):
         )
 
 
+class TableWithRowspanShenanigans(TableFormatTestCase):
+    def canonical_html(self) -> str:
+        return """
+        <table>
+          <tr>
+            <td>A</td>
+            <td rowspan="3">B</td>
+            <td>C</td>
+          </tr>
+          <tr>
+            <td rowspan="2">D</td>
+            <td>E</td>
+          </tr>
+          <tr>
+            <td>F</td>
+          </tr>
+          <tr>
+            <td>G</td>
+            <td>H</td>
+            <td>I</td>
+          </tr>
+        </table>
+        """
+
+    def csv(self) -> str:
+        return "A,B,C\nD,,E\n,,F\nG,H,I"
+
+    def table(self) -> Table:
+        return Table(
+            [
+                TableCell(content="A", rows=[0], cols=[0], is_header=False),
+                TableCell(content="B", rows=[0, 1, 2], cols=[1], is_header=False),
+                TableCell(content="C", rows=[0], cols=[2], is_header=False),
+                TableCell(content="D", rows=[1, 2], cols=[0], is_header=False),
+                TableCell(content="E", rows=[1], cols=[2], is_header=False),
+                TableCell(content="F", rows=[2], cols=[2], is_header=False),
+                TableCell(content="G", rows=[3], cols=[0], is_header=False),
+                TableCell(content="H", rows=[3], cols=[1], is_header=False),
+                TableCell(content="I", rows=[3], cols=[2], is_header=False),
+            ]
+        )
+
+
 class SimpleTableMultiRowHeader(TableFormatTestCase):
     def canonical_html(self) -> str:
         return """
@@ -373,6 +416,7 @@ test_cases = [
     SimpleTableMultiRowHeader(),
     SimpleTableMultiRowColHeader(),
     SmithsonianSampleTable(),
+    TableWithRowspanShenanigans(),
 ]
 
 
@@ -493,6 +537,8 @@ def test_table_from_dict_missing():
 def test_from_html(test_case):
     actual = Table.from_html(html_str=test_case.canonical_html())
     expected = test_case.table()
+    print(actual.cells)
+    print(expected.cells)
     assert actual == expected
 
     if hasattr(test_case, "other_html"):

--- a/lib/sycamore/sycamore/tests/unit/data/test_table.py
+++ b/lib/sycamore/sycamore/tests/unit/data/test_table.py
@@ -537,8 +537,6 @@ def test_table_from_dict_missing():
 def test_from_html(test_case):
     actual = Table.from_html(html_str=test_case.canonical_html())
     expected = test_case.table()
-    print(actual.cells)
-    print(expected.cells)
     assert actual == expected
 
     if hasattr(test_case, "other_html"):


### PR DESCRIPTION
old algorithm:
for each cell, if I am a rowspan, check all the other cells and bump everything below and to the right of me.

new algorithm:
for each cell, if I need to be bumped, bump myself, and if I'm a rowspan tell the rows below me that there might need to be bumping.

old algorithm failed on a table like
```
__________
|__|  |__|
|  |  |__|
|__|__|__|
```
because the cell on the bottom right was initially in col=0, and the middle cell wouldn't bump it