### PR TITLE
Code executor

### DIFF
--- a/lib/sycamore/sycamore/query/client.py
+++ b/lib/sycamore/sycamore/query/client.py
@@ -141,7 +141,7 @@ class SycamoreQueryClient:
         plan = planner.plan(query)
         return plan
 
-    def run_plan(self, plan: LogicalPlan, dry_run=False) -> Tuple[str, str]:
+    def run_plan(self, plan: LogicalPlan, dry_run=False, codegen_mode=False) -> Tuple[str, str]:
         """Run the given logical query plan and return a tuple of the query ID and result."""
         context = sycamore.init()
         executor = SycamoreExecutor(
@@ -150,16 +150,17 @@ class SycamoreQueryClient:
             s3_cache_path=self.s3_cache_path,
             trace_dir=self.trace_dir,
             dry_run=dry_run,
+            codegen_mode=codegen_mode,
         )
         query_id = str(uuid.uuid4())
         result = executor.execute(plan, query_id)
         return (query_id, result)
 
-    def query(self, query: str, index: str, dry_run: bool = False) -> str:
+    def query(self, query: str, index: str, dry_run: bool = False, codegen_mode: bool = False) -> str:
         """Run a query against the given index."""
         schema = self.get_opensearch_schema(index)
         plan = self.generate_plan(query, index, schema)
-        _, result = self.run_plan(plan, dry_run=dry_run)
+        _, result = self.run_plan(plan, dry_run=dry_run, codegen_mode=codegen_mode)
         return result
 
     def dump_traces(self, logfile: str, query_id: Optional[str] = None):
@@ -190,6 +191,7 @@ def main():
     parser.add_argument("--show-plan", action="store_true", help="Show generated query plan.")
     parser.add_argument("--plan-only", action="store_true", help="Only generate and show query plan.")
     parser.add_argument("--dry-run", action="store_true", help="Generate and show query plan and execution code")
+    parser.add_argument("--codegen-mode", action="store_true", help="Execute through codegen")
     parser.add_argument("--trace-dir", help="Directory to write query execution trace.")
     parser.add_argument("--dump-traces", action="store_true", help="Dump traces from the execution.")
     parser.add_argument("--log-level", type=str, help="Log level", default="WARN")
@@ -235,7 +237,7 @@ def main():
     if args.plan_only:
         return
 
-    query_id, result = client.run_plan(plan, args.dry_run)
+    query_id, result = client.run_plan(plan, args.dry_run, args.codegen_mode)
 
     console.rule(f"Query result [{query_id}]")
     console.print(result)

--- a/lib/sycamore/sycamore/query/execution/sycamore_executor.py
+++ b/lib/sycamore/sycamore/query/execution/sycamore_executor.py
@@ -37,6 +37,9 @@ log = structlog.get_logger(__name__)
 
 
 class SycamoreExecutor:
+
+    OUTPUT_VAR_NAME = "result"
+
     """The Sycamore Query executor that processes a logical plan and executes it using Sycamore.
 
     Args:
@@ -52,6 +55,7 @@ class SycamoreExecutor:
         os_client_args: Any,
         s3_cache_path: Optional[str] = None,
         trace_dir: Optional[str] = None,
+        codegen_mode: bool = False,
         dry_run: bool = False,
     ) -> None:
         super().__init__()
@@ -62,16 +66,15 @@ class SycamoreExecutor:
         self.trace_dir = trace_dir
         self.processed: Dict[int, Any] = dict()
         self.dry_run = dry_run
+        self.codegen_mode = codegen_mode
 
         if self.s3_cache_path:
             log.info("Using S3 cache path: %s", s3_cache_path)
         if self.trace_dir:
             log.info("Using tracer: %s", trace_dir)
-        if self.dry_run:
-            log.info("Executing in dry-mode")
-            self.node_id_to_node: Dict[int, LogicalOperator] = {}
-            self.node_id_to_code: Dict[int, str] = {}
-            self.imports: List[str] = []
+        self.node_id_to_node: Dict[int, LogicalOperator] = {}
+        self.node_id_to_code: Dict[int, str] = {}
+        self.imports: List[str] = []
 
     @staticmethod
     def get_node_args(query_id: str, logical_node: LogicalOperator) -> Dict:
@@ -190,12 +193,14 @@ class SycamoreExecutor:
             raise Exception(f"Unsupported node type: {str(logical_node)}")
 
         if result is None:
-            if self.dry_run:
-                code, imports = operation.script()
-                self.imports += imports
-                self.node_id_to_code[logical_node.node_id] = code
-                self.node_id_to_node[logical_node.node_id] = logical_node
-            else:
+            code, imports = operation.script(
+                output_var=(self.OUTPUT_VAR_NAME if not logical_node.downstream_nodes else None)
+            )
+            self.imports += imports
+            self.node_id_to_code[logical_node.node_id] = code
+            self.node_id_to_node[logical_node.node_id] = logical_node
+
+            if not self.codegen_mode:
                 result = operation.execute()
 
         self.processed[logical_node.node_id] = result
@@ -228,8 +233,17 @@ class SycamoreExecutor:
             log.info("Executing query")
             assert isinstance(plan.result_node, LogicalOperator)
             result = self.process_node(plan.result_node, query_id)
+
+            if self.dry_run:
+                code = self.get_code_string()
+                return code
+
+            if self.codegen_mode:
+                code = self.get_code_string()
+                global_context = {}
+                exec(code, global_context)
+                return global_context.get(self.OUTPUT_VAR_NAME)
+
+            return result
         finally:
             clear_contextvars()
-        if self.dry_run:
-            return self.get_code_string()
-        return result

--- a/lib/sycamore/sycamore/query/execution/sycamore_executor.py
+++ b/lib/sycamore/sycamore/query/execution/sycamore_executor.py
@@ -240,7 +240,7 @@ class SycamoreExecutor:
 
             if self.codegen_mode:
                 code = self.get_code_string()
-                global_context = {}
+                global_context: dict[str, Any] = {}
                 exec(code, global_context)
                 return global_context.get(self.OUTPUT_VAR_NAME)
 

--- a/lib/sycamore/sycamore/query/execution/sycamore_operator.py
+++ b/lib/sycamore/sycamore/query/execution/sycamore_operator.py
@@ -182,8 +182,6 @@ class SycamoreSummarizeData(SycamoreOperator):
     result_description='{description}',
     result_data=[{logical_deps_str}]
 )
-result = {output_var or get_var_name(self.logical_node)}
-print(result)
 """
         return result, [
             "from sycamore.query.execution.operations import summarize_data",
@@ -249,7 +247,7 @@ prompt = LlmFilterMessagesPrompt(filter_question='{self.logical_node.question}')
     field='{self.logical_node.field}',
     threshold=3,
     **{self.get_node_args()},
-) 
+)
 """
         return result, [
             "from sycamore.llms import OpenAI, OpenAIModels",

--- a/lib/sycamore/sycamore/tests/integration/query/execution/test_sycamore_query.py
+++ b/lib/sycamore/sycamore/tests/integration/query/execution/test_sycamore_query.py
@@ -1,6 +1,3 @@
-import contextlib
-import io
-
 import pytest
 
 from sycamore.query.client import SycamoreQueryClient
@@ -8,23 +5,20 @@ from sycamore.query.client import SycamoreQueryClient
 
 class TestSycamoreQuery:
 
-    @pytest.mark.parametrize("codegen", [True, False])
-    def test_simple(self, query_integration_test_index: str, codegen: bool):
+    @pytest.mark.parametrize("codegen_mode", [True, False])
+    def test_simple(self, query_integration_test_index: str, codegen_mode: bool):
         """
         Simple test that ensures we can run a query end to end and get a text response.
         """
         client = SycamoreQueryClient()
         schema = client.get_opensearch_schema(query_integration_test_index)
         plan = client.generate_plan("How many incidents happened in california?", query_integration_test_index, schema)
-        query_id, result = client.run_plan(plan, dry_run=codegen)
+        query_id, result = client.run_plan(plan, codegen_mode=codegen_mode)
         assert isinstance(result, str)
         assert len(result) > 0
-        if codegen:
-            print(result)
-            exec(result)
 
-    @pytest.mark.parametrize("codegen", [True, False])
-    def test_forked(self, query_integration_test_index: str, codegen: bool):
+    @pytest.mark.parametrize("codegen_mode", [True, False])
+    def test_forked(self, query_integration_test_index: str, codegen_mode: bool):
         """
         Test that has a fork in the DAG, ensures we can support multiple execution paths.
         """
@@ -33,13 +27,7 @@ class TestSycamoreQuery:
         plan = client.generate_plan(
             "What fraction of all incidents happened in california?", query_integration_test_index, schema
         )
-        query_id, result = client.run_plan(plan, dry_run=codegen)
+        query_id, result = client.run_plan(plan, codegen_mode=codegen_mode)
         assert isinstance(result, str)
         assert len(result) > 0
-        if codegen:
-            print(result)
-            output = io.StringIO()
-            with contextlib.redirect_stdout(output):
-                exec(result)
-            result = output.getvalue()
         assert "0" in result


### PR DESCRIPTION
Allows you to run sycamore queries through generated code. This will become the default once we've tested existing workloads. 

We might also want to have the codegen mode return the result + generated code in 1 call, can think about it as we migrate