### PR TITLE
Updated Entity Extractor + Infrastructure Changes

### DIFF
--- a/lib/sycamore/pyproject.toml
+++ b/lib/sycamore/pyproject.toml
@@ -47,6 +47,7 @@ cryptography = "^42.0.3"
 aiohttp = "^3.9.2"
 apted = "^1.0.3"
 fasteners = "^0.19"
+pydantic = "^2.8.2"
 
 # Dependencies for building docs. Defined as an extra
 # so they can be installed using pip on RTD.
@@ -65,7 +66,6 @@ pinecone-text = "^0.9.0"
 duckdb = "1.0.0"
 neo4j = "^5.21.0"
 elasticsearch = "8.14.0"
-pydantic = "^2.8.2"
 
 [tool.poetry.group.test.dependencies]
 flake8 = "4.0.1"

--- a/lib/sycamore/sycamore/docset.py
+++ b/lib/sycamore/sycamore/docset.py
@@ -549,13 +549,15 @@ class DocSet:
                     .explode()
                 )
         """
-        from sycamore.transforms.extract_graph import ExtractDocumentStructure
+        from sycamore.transforms.extract_graph import ResolveEntities, ExtractDocumentStructure
 
-        self.plan = ExtractDocumentStructure(self.plan)
         docset = self
+
+        docset.plan = ExtractDocumentStructure(docset.plan)
         for extractor in extractors:
             docset = extractor.extract(docset)
-
+        if len(extractors) > 0:
+            docset = ResolveEntities.resolve(docset=docset)
         return docset
 
     def extract_properties(self, property_extractor: PropertyExtractor, **kwargs) -> "DocSet":

--- a/lib/sycamore/sycamore/docset.py
+++ b/lib/sycamore/sycamore/docset.py
@@ -554,10 +554,11 @@ class DocSet:
         docset = self
 
         docset.plan = ExtractDocumentStructure(docset.plan)
-        for extractor in extractors:
-            docset = extractor.extract(docset)
         if len(extractors) > 0:
+            for extractor in extractors:
+                docset = extractor.extract(docset)
             docset = ResolveEntities.resolve(docset=docset)
+
         return docset
 
     def extract_properties(self, property_extractor: PropertyExtractor, **kwargs) -> "DocSet":

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -440,11 +440,15 @@ class OpenAI(LLM):
             completion = await self.client_wrapper.get_async_client().beta.chat.completions.parse(
                 model=self._model_name, **kwargs
             )
+            if completion.choices[0].message.content is None:
+                raise ValueError("OpenAI declined to respond to query")
+            return completion.choices[0].message.content
         else:
             completion = await self.client_wrapper.get_async_client().chat.completions.create(
                 model=self._model_name, **kwargs
             )
-        return completion.choices[0].message.content
+            return completion.choices[0].message.content
+        
 
     def _generate_using_guidance(self, prompt_kwargs) -> str:
         guidance_model = self.client_wrapper.get_guidance_model(self.model)

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -440,17 +440,17 @@ class OpenAI(LLM):
 
     async def _generate_awaitable_using_openai(self, prompt_kwargs, llm_kwargs) -> Awaitable[str]:
         kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
-        if self._determine_using_beta(llm_kwargs.get("response_format", None)):
-            completion = await self.client_wrapper.get_async_client().beta.chat.completions.parse(
-                model=self._model_name, **kwargs
-            )
-            assert completion.choices[0].message.content is not None
-            return completion.choices[0].message.content
-        else:
-            completion = await self.client_wrapper.get_async_client().chat.completions.create(
-                model=self._model_name, **kwargs
-            )
-            return completion.choices[0].message.content
+        # if self._determine_using_beta(llm_kwargs.get("response_format", None)):
+        #     completion = await self.client_wrapper.get_async_client().beta.chat.completions.parse(
+        #         model=self._model_name, **kwargs
+        #     )
+        #     assert completion.choices[0].message.content is not None
+        #     return completion.choices[0].message.content
+        # else:
+        completion = await self.client_wrapper.get_async_client().chat.completions.create(
+            model=self._model_name, **kwargs
+        )
+        return completion.choices[0].message.content
 
     def _generate_using_guidance(self, prompt_kwargs) -> str:
         guidance_model = self.client_wrapper.get_guidance_model(self.model)

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -4,7 +4,7 @@ import os
 import pickle
 from dataclasses import dataclass
 from enum import Enum
-from typing import Awaitable, Optional, TypedDict, Union, cast
+from typing import Any, Awaitable, Optional, TypedDict, Union, cast
 
 from guidance.models import AzureOpenAIChat, AzureOpenAICompletion
 from guidance.models import Model
@@ -16,6 +16,7 @@ from openai import AsyncOpenAI as AsyncOpenAIClient
 from openai import max_retries as DEFAULT_MAX_RETRIES
 from openai.lib.azure import AzureADTokenProvider
 
+import pydantic
 from sycamore.llms.llms import LLM
 from sycamore.llms.prompts import GuidancePrompt
 from sycamore.utils.cache import Cache
@@ -380,6 +381,14 @@ class OpenAI(LLM):
             raise ValueError("Either prompt or messages must be present in prompt_kwargs.")
         return kwargs
 
+    def _determine_using_beta(self, response_format: Any) -> bool:
+        if isinstance(response_format, dict) and response_format.get("type") == "json_schema":
+            return True
+        elif issubclass(response_format, pydantic.BaseModel):
+            return True
+        else:
+            return False
+
     def generate(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> str:
         key, ret = self._cache_get(prompt_kwargs, llm_kwargs)
         if ret is not None:
@@ -401,8 +410,10 @@ class OpenAI(LLM):
 
     def _generate_using_openai(self, prompt_kwargs, llm_kwargs) -> str:
         kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
-
-        completion = self.client_wrapper.get_client().chat.completions.create(model=self._model_name, **kwargs)
+        if self._determine_using_beta(llm_kwargs.get("response_format", None)):
+            completion = self.client_wrapper.get_client().beta.chat.completions.parse(model=self._model_name, **kwargs)
+        else:
+            completion = self.client_wrapper.get_client().chat.completions.create(model=self._model_name, **kwargs)
         return completion.choices[0].message.content
 
     async def generate_async(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> Awaitable[str]:
@@ -425,10 +436,14 @@ class OpenAI(LLM):
 
     async def _generate_awaitable_using_openai(self, prompt_kwargs, llm_kwargs) -> Awaitable[str]:
         kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
-
-        completion = await self.client_wrapper.get_async_client().chat.completions.create(
-            model=self._model_name, **kwargs
-        )
+        if self._determine_using_beta(llm_kwargs.get("response_format", None)):
+            completion = await self.client_wrapper.get_async_client().beta.chat.completions.parse(
+                model=self._model_name, **kwargs
+            )
+        else:
+            completion = await self.client_wrapper.get_async_client().chat.completions.create(
+                model=self._model_name, **kwargs
+            )
         return completion.choices[0].message.content
 
     def _generate_using_guidance(self, prompt_kwargs) -> str:

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -427,10 +427,7 @@ class OpenAI(LLM):
 
         if llm_kwargs is None:
             raise ValueError("Must include llm_kwargs to generate future call")
-        if self._determine_using_beta(llm_kwargs.get("response_format", None)):
-            ret = await self._generate_awaitable_using_openai(prompt_kwargs, llm_kwargs)
-        else:
-            ret = await self._generate_awaitable_using_openai_structured(prompt_kwargs, llm_kwargs)
+        ret = await self._generate_awaitable_using_openai(prompt_kwargs, llm_kwargs)
 
         value = {
             "result": ret,
@@ -443,26 +440,17 @@ class OpenAI(LLM):
 
     async def _generate_awaitable_using_openai(self, prompt_kwargs, llm_kwargs) -> str:
         kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
-        # if self._determine_using_beta(llm_kwargs.get("response_format", None)):
-        #     completion = await self.client_wrapper.get_async_client().beta.chat.completions.parse(
-        #         model=self._model_name, **kwargs
-        #     )
-        #     assert completion.choices[0].message.content is not None
-        #     return completion.choices[0].message.content
-        # else:
-        completion = await self.client_wrapper.get_async_client().chat.completions.create(
-            model=self._model_name, **kwargs
-        )
-        return completion.choices[0].message.content
-    
-    async def _generate_awaitable_using_openai_structured(self, prompt_kwargs, llm_kwargs) -> str:
-        kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
-        completion = await self.client_wrapper.get_async_client().beta.chat.completions.parse(
-            model=self._model_name, **kwargs
-        )
-        assert completion.choices[0].message.content is not None
-        return completion.choices[0].message.content
-
+        if self._determine_using_beta(llm_kwargs.get("response_format", None)):
+            completion = await self.client_wrapper.get_async_client().beta.chat.completions.parse(
+                model=self._model_name, **kwargs
+            )
+            assert completion.choices[0].message.content is not None
+            return completion.choices[0].message.content
+        else:
+            completion = await self.client_wrapper.get_async_client().chat.completions.create(
+                model=self._model_name, **kwargs
+            )
+            return completion.choices[0].message.content
 
     def _generate_using_guidance(self, prompt_kwargs) -> str:
         guidance_model = self.client_wrapper.get_guidance_model(self.model)

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -1,4 +1,5 @@
 import functools
+import inspect
 import logging
 import os
 import pickle
@@ -384,7 +385,7 @@ class OpenAI(LLM):
     def _determine_using_beta(self, response_format: Any) -> bool:
         if isinstance(response_format, dict) and response_format.get("type") == "json_schema":
             return True
-        elif issubclass(response_format, pydantic.BaseModel):
+        elif inspect.isclass(response_format) and issubclass(response_format, pydantic.BaseModel):
             return True
         else:
             return False

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -427,7 +427,10 @@ class OpenAI(LLM):
 
         if llm_kwargs is None:
             raise ValueError("Must include llm_kwargs to generate future call")
-        ret = await self._generate_awaitable_using_openai(prompt_kwargs, llm_kwargs)
+        if self._determine_using_beta(llm_kwargs.get("response_format", None)):
+            ret = await self._generate_awaitable_using_openai(prompt_kwargs, llm_kwargs)
+        else:
+            ret = await self._generate_awaitable_using_openai_structured(prompt_kwargs, llm_kwargs)
 
         value = {
             "result": ret,
@@ -440,17 +443,19 @@ class OpenAI(LLM):
 
     async def _generate_awaitable_using_openai(self, prompt_kwargs, llm_kwargs) -> str:
         kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
-        if self._determine_using_beta(llm_kwargs.get("response_format", None)):
-            completion = await self.client_wrapper.get_async_client().beta.chat.completions.parse(
-                model=self._model_name, **kwargs
-            )
-            assert completion.choices[0].message.content is not None
-            return completion.choices[0].message.content
-        else:
-            completion = await self.client_wrapper.get_async_client().chat.completions.create(
-                model=self._model_name, **kwargs
-            )
-            return completion.choices[0].message.content
+        completion = await self.client_wrapper.get_async_client().chat.completions.create(
+            model=self._model_name, **kwargs
+        )
+        return completion.choices[0].message.content
+    
+    async def _generate_awaitable_using_openai_structured(self, prompt_kwargs, llm_kwargs) -> Awaitable[str]:
+        kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
+        completion = await self.client_wrapper.get_async_client().beta.chat.completions.parse(
+            model=self._model_name, **kwargs
+        )
+        assert completion.choices[0].message.content is not None
+        return completion.choices[0].message.content
+
 
     def _generate_using_guidance(self, prompt_kwargs) -> str:
         guidance_model = self.client_wrapper.get_guidance_model(self.model)

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -419,7 +419,7 @@ class OpenAI(LLM):
             completion = self.client_wrapper.get_client().chat.completions.create(model=self._model_name, **kwargs)
             return completion.choices[0].message.content
 
-    async def generate_async(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> Awaitable[Any]:
+    async def generate_async(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> Any:
         key, ret = self._cache_get(prompt_kwargs, llm_kwargs)
         if ret is not None:
             return ret
@@ -437,7 +437,7 @@ class OpenAI(LLM):
         self._cache_set(key, value)
         return ret
 
-    async def _generate_awaitable_using_openai(self, prompt_kwargs, llm_kwargs) -> Awaitable[Any]:
+    async def _generate_awaitable_using_openai(self, prompt_kwargs, llm_kwargs) -> Any:
         kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
         if self._determine_using_beta(llm_kwargs.get("response_format", None)):
             completion = await self.client_wrapper.get_async_client().beta.chat.completions.parse(

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -437,7 +437,7 @@ class OpenAI(LLM):
         self._cache_set(key, value)
         return ret
 
-    async def _generate_awaitable_using_openai(self, prompt_kwargs, llm_kwargs) -> Awaitable[str]:
+    async def _generate_awaitable_using_openai(self, prompt_kwargs, llm_kwargs) -> Union[Awaitable[str], str]:
         kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
         if self._determine_using_beta(llm_kwargs.get("response_format", None)):
             completion = await self.client_wrapper.get_async_client().beta.chat.completions.parse(

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -5,7 +5,7 @@ import os
 import pickle
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Awaitable, Optional, TypedDict, Union, cast
+from typing import Any, Optional, TypedDict, Union, cast
 
 from guidance.models import AzureOpenAIChat, AzureOpenAICompletion
 from guidance.models import Model

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -389,7 +389,7 @@ class OpenAI(LLM):
         else:
             return False
 
-    def generate(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> str:
+    def generate(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> Optional[str]:
         key, ret = self._cache_get(prompt_kwargs, llm_kwargs)
         if ret is not None:
             return ret
@@ -408,7 +408,7 @@ class OpenAI(LLM):
         self._cache_set(key, value)
         return ret
 
-    def _generate_using_openai(self, prompt_kwargs, llm_kwargs) -> str:
+    def _generate_using_openai(self, prompt_kwargs, llm_kwargs) -> Optional[str]:
         kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
         if self._determine_using_beta(llm_kwargs.get("response_format", None)):
             completion = self.client_wrapper.get_client().beta.chat.completions.parse(model=self._model_name, **kwargs)

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -416,15 +416,12 @@ class OpenAI(LLM):
         kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
         completion = self.client_wrapper.get_client().chat.completions.create(model=self._model_name, **kwargs)
         return completion.choices[0].message.content
-        
+
     def _generate_using_openai_structured(self, prompt_kwargs, llm_kwargs) -> str:
         kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
-        completion = self.client_wrapper.get_client().beta.chat.completions.parse(
-            model=self._model_name, **kwargs
-        )
-        assert completion.choices[0].message.content is not None
+        completion = self.client_wrapper.get_client().beta.chat.completions.parse(model=self._model_name, **kwargs)
+        assert completion.choices[0].message.content is not None, "OpenAI refused to respond to the query"
         return completion.choices[0].message.content
-
 
     async def generate_async(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> Awaitable[str]:
         key, ret = self._cache_get(prompt_kwargs, llm_kwargs)
@@ -453,15 +450,14 @@ class OpenAI(LLM):
             model=self._model_name, **kwargs
         )
         return completion.choices[0].message.content
-    
+
     async def _generate_awaitable_using_openai_structured(self, prompt_kwargs, llm_kwargs) -> str:
         kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
         completion = await self.client_wrapper.get_async_client().beta.chat.completions.parse(
             model=self._model_name, **kwargs
         )
-        assert completion.choices[0].message.content is not None
+        assert completion.choices[0].message.content is not None, "OpenAI refused to respond to the query"
         return completion.choices[0].message.content
-
 
     def _generate_using_guidance(self, prompt_kwargs) -> str:
         guidance_model = self.client_wrapper.get_guidance_model(self.model)

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -441,7 +441,7 @@ class OpenAI(LLM):
         self._cache_set(key, value)
         return ret
 
-    async def _generate_awaitable_using_openai(self, prompt_kwargs, llm_kwargs) -> Awaitable[str]:
+    async def _generate_awaitable_using_openai(self, prompt_kwargs, llm_kwargs) -> str:
         kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
         # if self._determine_using_beta(llm_kwargs.get("response_format", None)):
         #     completion = await self.client_wrapper.get_async_client().beta.chat.completions.parse(
@@ -455,11 +455,12 @@ class OpenAI(LLM):
         )
         return completion.choices[0].message.content
     
-    async def _generate_awaitable_using_openai_structured(self, prompt_kwargs, llm_kwargs) -> Awaitable[str]:
+    async def _generate_awaitable_using_openai_structured(self, prompt_kwargs, llm_kwargs) -> str:
         kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
         completion = await self.client_wrapper.get_async_client().beta.chat.completions.parse(
             model=self._model_name, **kwargs
         )
+        assert completion.choices[0].message.content is not None
         return completion.choices[0].message.content
 
 

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -412,6 +412,8 @@ class OpenAI(LLM):
         kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
         if self._determine_using_beta(llm_kwargs.get("response_format", None)):
             completion = self.client_wrapper.get_client().beta.chat.completions.parse(model=self._model_name, **kwargs)
+            if completion.choices[0].message.content is None:
+                raise ValueError("OpenAI declined to respond to query")
         else:
             completion = self.client_wrapper.get_client().chat.completions.create(model=self._model_name, **kwargs)
         return completion.choices[0].message.content
@@ -442,13 +444,11 @@ class OpenAI(LLM):
             )
             if completion.choices[0].message.content is None:
                 raise ValueError("OpenAI declined to respond to query")
-            return completion.choices[0].message.content
         else:
             completion = await self.client_wrapper.get_async_client().chat.completions.create(
                 model=self._model_name, **kwargs
             )
-            return completion.choices[0].message.content
-        
+        return completion.choices[0].message.content
 
     def _generate_using_guidance(self, prompt_kwargs) -> str:
         guidance_model = self.client_wrapper.get_guidance_model(self.model)

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -414,9 +414,10 @@ class OpenAI(LLM):
             completion = self.client_wrapper.get_client().beta.chat.completions.parse(model=self._model_name, **kwargs)
             if completion.choices[0].message.content is None:
                 raise ValueError("OpenAI declined to respond to query")
+            return completion.choices[0].message.content
         else:
             completion = self.client_wrapper.get_client().chat.completions.create(model=self._model_name, **kwargs)
-        return completion.choices[0].message.content
+            return completion.choices[0].message.content
 
     async def generate_async(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> Awaitable[str]:
         key, ret = self._cache_get(prompt_kwargs, llm_kwargs)
@@ -444,11 +445,12 @@ class OpenAI(LLM):
             )
             if completion.choices[0].message.content is None:
                 raise ValueError("OpenAI declined to respond to query")
+            return completion.choices[0].message.content
         else:
             completion = await self.client_wrapper.get_async_client().chat.completions.create(
                 model=self._model_name, **kwargs
             )
-        return completion.choices[0].message.content
+            return completion.choices[0].message.content
 
     def _generate_using_guidance(self, prompt_kwargs) -> str:
         guidance_model = self.client_wrapper.get_guidance_model(self.model)

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -389,7 +389,7 @@ class OpenAI(LLM):
         else:
             return False
 
-    def generate(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> str:
+    def generate(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> Any:
         key, ret = self._cache_get(prompt_kwargs, llm_kwargs)
         if ret is not None:
             return ret
@@ -408,7 +408,7 @@ class OpenAI(LLM):
         self._cache_set(key, value)
         return ret
 
-    def _generate_using_openai(self, prompt_kwargs, llm_kwargs) -> str:
+    def _generate_using_openai(self, prompt_kwargs, llm_kwargs) -> Any:
         kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
         if self._determine_using_beta(llm_kwargs.get("response_format", None)):
             completion = self.client_wrapper.get_client().beta.chat.completions.parse(model=self._model_name, **kwargs)
@@ -419,7 +419,7 @@ class OpenAI(LLM):
             completion = self.client_wrapper.get_client().chat.completions.create(model=self._model_name, **kwargs)
             return completion.choices[0].message.content
 
-    async def generate_async(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> Awaitable[str]:
+    async def generate_async(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> Awaitable[Any]:
         key, ret = self._cache_get(prompt_kwargs, llm_kwargs)
         if ret is not None:
             return ret
@@ -437,14 +437,12 @@ class OpenAI(LLM):
         self._cache_set(key, value)
         return ret
 
-    async def _generate_awaitable_using_openai(self, prompt_kwargs, llm_kwargs) -> Union[Awaitable[str], str]:
+    async def _generate_awaitable_using_openai(self, prompt_kwargs, llm_kwargs) -> Awaitable[Any]:
         kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
         if self._determine_using_beta(llm_kwargs.get("response_format", None)):
             completion = await self.client_wrapper.get_async_client().beta.chat.completions.parse(
                 model=self._model_name, **kwargs
             )
-            if completion.choices[0].message.content is None:
-                raise ValueError("OpenAI declined to respond to query")
             return completion.choices[0].message.content
         else:
             completion = await self.client_wrapper.get_async_client().chat.completions.create(

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -5,7 +5,7 @@ import os
 import pickle
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Optional, TypedDict, Union, cast
+from typing import Any, Awaitable, Optional, TypedDict, Union, cast
 
 from guidance.models import AzureOpenAIChat, AzureOpenAICompletion
 from guidance.models import Model
@@ -420,7 +420,7 @@ class OpenAI(LLM):
             completion = self.client_wrapper.get_client().chat.completions.create(model=self._model_name, **kwargs)
             return completion.choices[0].message.content
 
-    async def generate_async(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> Any:
+    async def generate_async(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> Awaitable[str]:
         key, ret = self._cache_get(prompt_kwargs, llm_kwargs)
         if ret is not None:
             return ret
@@ -438,12 +438,13 @@ class OpenAI(LLM):
         self._cache_set(key, value)
         return ret
 
-    async def _generate_awaitable_using_openai(self, prompt_kwargs, llm_kwargs) -> Any:
+    async def _generate_awaitable_using_openai(self, prompt_kwargs, llm_kwargs) -> Awaitable[str]:
         kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
         if self._determine_using_beta(llm_kwargs.get("response_format", None)):
             completion = await self.client_wrapper.get_async_client().beta.chat.completions.parse(
                 model=self._model_name, **kwargs
             )
+            assert completion.choices[0].message.content is not None
             return completion.choices[0].message.content
         else:
             completion = await self.client_wrapper.get_async_client().chat.completions.create(

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -389,7 +389,7 @@ class OpenAI(LLM):
         else:
             return False
 
-    def generate(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> Optional[str]:
+    def generate(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> str:
         key, ret = self._cache_get(prompt_kwargs, llm_kwargs)
         if ret is not None:
             return ret
@@ -408,7 +408,7 @@ class OpenAI(LLM):
         self._cache_set(key, value)
         return ret
 
-    def _generate_using_openai(self, prompt_kwargs, llm_kwargs) -> Optional[str]:
+    def _generate_using_openai(self, prompt_kwargs, llm_kwargs) -> str:
         kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
         if self._determine_using_beta(llm_kwargs.get("response_format", None)):
             completion = self.client_wrapper.get_client().beta.chat.completions.parse(model=self._model_name, **kwargs)

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -448,7 +448,7 @@ class OpenAI(LLM):
         )
         return completion.choices[0].message.content
     
-    async def _generate_awaitable_using_openai_structured(self, prompt_kwargs, llm_kwargs) -> Awaitable[str]:
+    async def _generate_awaitable_using_openai_structured(self, prompt_kwargs, llm_kwargs) -> str:
         kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
         completion = await self.client_wrapper.get_async_client().beta.chat.completions.parse(
             model=self._model_name, **kwargs

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -427,7 +427,10 @@ class OpenAI(LLM):
 
         if llm_kwargs is None:
             raise ValueError("Must include llm_kwargs to generate future call")
-        ret = await self._generate_awaitable_using_openai(prompt_kwargs, llm_kwargs)
+        if self._determine_using_beta(llm_kwargs.get("response_format", None)):
+            ret = await self._generate_awaitable_using_openai(prompt_kwargs, llm_kwargs)
+        else:
+            ret = await self._generate_awaitable_using_openai_structured(prompt_kwargs, llm_kwargs)
 
         value = {
             "result": ret,
@@ -451,6 +454,14 @@ class OpenAI(LLM):
             model=self._model_name, **kwargs
         )
         return completion.choices[0].message.content
+    
+    async def _generate_awaitable_using_openai_structured(self, prompt_kwargs, llm_kwargs) -> Awaitable[str]:
+        kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
+        completion = await self.client_wrapper.get_async_client().beta.chat.completions.parse(
+            model=self._model_name, **kwargs
+        )
+        return completion.choices[0].message.content
+
 
     def _generate_using_guidance(self, prompt_kwargs) -> str:
         guidance_model = self.client_wrapper.get_guidance_model(self.model)

--- a/lib/sycamore/sycamore/tests/unit/utils/test_pydantic_pickling.py
+++ b/lib/sycamore/sycamore/tests/unit/utils/test_pydantic_pickling.py
@@ -1,0 +1,28 @@
+import sys
+from typing import Optional
+from sycamore.utils.pickle_pydantic import safe_cloudpickle, safe_cloudunpickle
+import pydantic
+from pydantic import BaseModel, Field
+
+
+def test_pydantic_picklng():
+    class BoardMember(BaseModel):
+        name: str
+        votes_for: Optional[int]
+        votes_against: Optional[int]
+        votes_abstentions: Optional[int]
+
+    class Company(BaseModel):
+        name: str
+        founded: Optional[str] = Field(description="The date a company was founded")
+
+    company_pickled = safe_cloudpickle(Company)
+    board_member_pickled = safe_cloudpickle(BoardMember)
+
+    company_unpickled = safe_cloudunpickle(company_pickled)
+    board_member_unpickled = safe_cloudunpickle(board_member_pickled)
+
+
+    assert sys.getsizeof(company_unpickled) == sys.getsizeof(Company)
+    assert sys.getsizeof(board_member_unpickled) == sys.getsizeof(BoardMember)
+

--- a/lib/sycamore/sycamore/tests/unit/utils/test_pydantic_pickling.py
+++ b/lib/sycamore/sycamore/tests/unit/utils/test_pydantic_pickling.py
@@ -1,7 +1,6 @@
 import sys
 from typing import Optional
 from sycamore.utils.pickle_pydantic import safe_cloudpickle, safe_cloudunpickle
-import pydantic
 from pydantic import BaseModel, Field
 
 
@@ -22,7 +21,5 @@ def test_pydantic_picklng():
     company_unpickled = safe_cloudunpickle(company_pickled)
     board_member_unpickled = safe_cloudunpickle(board_member_pickled)
 
-
     assert sys.getsizeof(company_unpickled) == sys.getsizeof(Company)
     assert sys.getsizeof(board_member_unpickled) == sys.getsizeof(BoardMember)
-

--- a/lib/sycamore/sycamore/transforms/extract_graph.py
+++ b/lib/sycamore/sycamore/transforms/extract_graph.py
@@ -1,9 +1,13 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Awaitable, Dict, Any, Optional
+from collections import defaultdict
+import hashlib
+from typing import TYPE_CHECKING, Awaitable, Dict, Any, List, Optional
 from sycamore.plan_nodes import Node
 from sycamore.transforms.map import Map
 from sycamore.data import Document, MetadataDocument, HierarchicalDocument
 from sycamore.llms import LLM
+from pydantic import BaseModel, create_model
+
 import json
 import uuid
 import logging
@@ -35,20 +39,6 @@ class GraphMetadata(GraphData):
         self.relLabel = relLabel
 
 
-class GraphEntity(GraphData):
-    """
-    Object which contains the label and description of an entity type that is to be extracted from unstructured text
-
-    Args:
-        entityLabel: Label of entity(i.e. Person, Company, Country)
-        entityDescription: Description of what the entity is
-    """
-
-    def __init__(self, entityLabel: str, entityDescription: str):
-        self.label = entityLabel
-        self.description = entityDescription
-
-
 class GraphExtractor(ABC):
     def __init__(self):
         pass
@@ -61,7 +51,203 @@ class GraphExtractor(ABC):
     def _extract(self, doc: "HierarchicalDocument") -> "HierarchicalDocument":
         pass
 
-    def resolve(self, docset: "DocSet") -> "DocSet":
+
+class MetadataExtractor(GraphExtractor):
+    """
+    Extracts metadata from documents and represents them as nodes and relationship in neo4j
+
+    Args:
+        metadata: A list of GraphMetadata that is used to determine what metadata is extracted
+    """
+
+    def __init__(self, metadata: list[GraphMetadata]):
+        self.metadata = metadata
+
+    def extract(self, docset: "DocSet") -> "DocSet":
+        """
+        Extracts metadata from documents and creates an additional document in the docset that stores those nodes
+        """
+        docset.plan = ExtractFeatures(docset.plan, self)
+        return docset
+
+    def _extract(self, doc: HierarchicalDocument) -> HierarchicalDocument:
+        nodes: Dict[str, Dict[str, Any]] = {}
+        for m in self.metadata:
+            key = m.nodeKey
+            value = str(doc["properties"].get(key))
+            if value == "None":
+                continue
+
+            node: Dict[str, Any] = {
+                "type": "metadata",
+                "properties": {key: value},
+                "label": m.nodeLabel,
+                "relationships": {},
+            }
+            rel: Dict[str, Any] = {
+                "TYPE": m.relLabel,
+                "properties": {},
+                "START_ID": str(doc.doc_id),
+                "START_LABEL": doc.data["label"],
+            }
+
+            node["relationships"][str(uuid.uuid4())] = rel
+            nodes.setdefault(key, {})
+            nodes[key][value] = node
+            del doc["properties"][m.nodeKey]
+
+        doc["properties"]["nodes"] = nodes
+        return doc
+
+
+class EntityExtractor(GraphExtractor):
+    """
+    Extracts entity schemas
+
+    Args:
+        entities: A list of GraphEntity that determines what entities are extracted
+        llm: The LLM that is used to extract the entities
+    """
+
+    def __init__(
+        self, llm: LLM, entities: Optional[list[BaseModel]] = [], json_schema: Optional[dict[str, Any]] = None
+    ):
+        self.entities = self._serialize_entities(entities)
+        self.schema = json_schema
+        self.llm = llm
+        if json_schema is None and len(entities) == 0:
+            raise ValueError("Must input JSON schema or list of pydantic entities")
+
+    def extract(self, docset: "DocSet") -> "DocSet":
+        """
+        Extracts entities from documents then creates a document in the docset where they are stored as nodes
+        """
+        docset.plan = ExtractSummaries(docset.plan)
+        docset.plan = ExtractFeatures(docset.plan, self)
+        return docset
+
+    def _extract(self, doc: HierarchicalDocument) -> HierarchicalDocument:
+        import asyncio
+
+        if "EXTRACTED_NODES" in doc.data:
+            return doc
+
+        async def gather_api_calls():
+            tasks = [self._extract_from_section(child.data["summary"]) for child in doc.children]
+            res = await asyncio.gather(*tasks)
+            return res
+
+        res = asyncio.run(gather_api_calls())
+
+        for i, section in enumerate(doc.children):
+            nodes = defaultdict(dict)
+            try:
+                res[i] = json.loads(res[i])
+            except json.JSONDecodeError:
+                logger.warn("LLM Output failed to be decoded to JSON")
+                logger.warn("Input: " + section.data["summary"])
+                logger.warn("Output: " + res[i])
+                res[i] = {"entities": []}
+
+            for label, entities in res[i].items():
+                for entity in entities:
+                    hash = hashlib.sha256(json.dumps(entity).encode()).hexdigest()
+                    if hash not in nodes[label]:
+                        node = {
+                            "type": "extracted",
+                            "properties": {},
+                            "label": label,
+                            "relationships": {},
+                        }
+                        for key, value in entity.items():
+                            node["properties"][key] = value
+                        nodes[label][hash] = node
+                    rel: Dict[str, Any] = {
+                        "TYPE": "CONTAINS",
+                        "properties": {},
+                        "START_ID": str(section.doc_id),
+                        "START_LABEL": section.data["label"],
+                    }
+                    nodes[label][hash]["relationships"][str(uuid.uuid4())] = rel
+            section["properties"]["nodes"] = nodes
+        return doc
+
+    def _serialize_entities(self, entities):
+        from sycamore.utils.pickle_pydantic import safe_cloudpickle
+
+        serialized = []
+        for entity in entities:
+            serialized.append(safe_cloudpickle(entity))
+        return serialized
+
+    def _deserialize_entities(self):
+        from sycamore.utils.pickle_pydantic import safe_cloudunpickle
+
+        deserialized = []
+        for entity in self.entities:
+            deserialized.append(safe_cloudunpickle(entity))
+
+        fields = {entity.__name__: (List[entity], ...) for entity in deserialized}
+        return create_model("entities", __base__=BaseModel, **fields)
+
+    async def _extract_from_section(self, summary: str) -> Awaitable[str]:
+        llm_kwargs = None
+        if self.schema is not None:
+            llm_kwargs = {"response_format": {"type": "json_schema", "json_schema": self.schema}}
+        else:
+            llm_kwargs = {"response_format": self._deserialize_entities()}
+
+        return await self.llm.generate_async(
+            prompt_kwargs={"prompt": str(GraphEntityExtractorPrompt(summary))}, llm_kwargs=llm_kwargs
+        )
+
+
+def GraphEntityExtractorPrompt(query):
+    return f"""
+    -Goal-
+    You are a helpful information extraction system.
+
+    You will be given a sequence of data in different formats(text, table, Section-header) in order.
+    Your job is to extract entities that match the entity schemas provided.
+
+    -Real Data-
+    ######################
+    Text: {query}
+    ######################
+    Output:"""
+
+
+class ResolveEntities:
+    @staticmethod
+    def resolve(docset: "DocSet") -> "DocSet":
+        docset.plan = ResolveEntities.GroupEntities(docset.plan)
+        docset = ResolveEntities._resolve(docset)
+        return docset
+
+    class GroupEntities(Map):
+        def __init__(self, child: Node, **resource_args):
+            super().__init__(child, f=self.GroupDocumentNodes, **resource_args)
+
+        @staticmethod
+        def GroupDocumentNodes(doc: HierarchicalDocument) -> HierarchicalDocument:
+            if "EXTRACTED_NODES" in doc.data:
+                return doc
+            nodes = defaultdict(dict)
+            nodes |= doc["properties"]["nodes"]
+            for section in doc.children:
+                for label, hashes in section["properties"]["nodes"].items():
+                    for hash, node in hashes.items():
+                        if nodes[label].get(hash, None) is None:
+                            nodes[label][hash] = node
+                        else:
+                            for rel_uuid, rel in node["relationships"].items():
+                                nodes[label][hash]["relationships"][rel_uuid] = rel
+                del section["properties"]["nodes"]
+            doc["properties"]["nodes"] = nodes
+            return doc
+
+    @staticmethod
+    def _resolve(docset: "DocSet") -> "DocSet":
         """
         Aggregates 'nodes' from every document and resolves duplicate nodes
         """
@@ -90,29 +276,34 @@ class GraphExtractor(ABC):
 
         def accumulate_row(nodes, row):
             extracted = extract_nodes(row)
-            for key, value in extracted.items():
-                if nodes.get(key, {}) == {}:
-                    nodes[key] = value
-                else:
-                    for rel_uuid, rel in extracted[key]["relationships"].items():
-                        nodes[key]["relationships"][rel_uuid] = rel
+            for key, hashes in extracted.items():
+                for hash in hashes:
+                    if nodes.get(key, {}).get(hash, {}) == {}:
+                        nodes.setdefault(key, {})
+                        nodes[key][hash] = extracted[key][hash]
+                    else:
+                        for rel_uuid, rel in extracted[key][hash]["relationships"].items():
+                            nodes[key][hash]["relationships"][rel_uuid] = rel
             return nodes
 
         def merge(nodes1, nodes2):
-            for key, value in nodes2.items():
-                if nodes1.get(key, {}) == {}:
-                    nodes1[key] = value
-                else:
-                    for rel_uuid, rel in nodes2[key]["relationships"].items():
-                        nodes1[key]["relationships"][rel_uuid] = rel
+            for key, hashes in nodes2.items():
+                for hash in hashes:
+                    if nodes1.get(key, {}).get(hash, {}) == {}:
+                        nodes1.setdefault(key, {})
+                        nodes1[key][hash] = nodes2[key][hash]
+                    else:
+                        for rel_uuid, rel in nodes2[key][hash]["relationships"].items():
+                            nodes1[key][hash]["relationships"][rel_uuid] = rel
             return nodes1
 
         def finalize(nodes):
-            for value in nodes.values():
-                value["doc_id"] = str(uuid.uuid4())
-                for rel in value["relationships"].values():
-                    rel["END_ID"] = value["doc_id"]
-                    rel["END_LABEL"] = value["label"]
+            for key, hashes in nodes.items():
+                for hash, node in hashes.items():
+                    node["doc_id"] = str(uuid.uuid4())
+                    for rel in node["relationships"].values():
+                        rel["END_ID"] = node["doc_id"]
+                        rel["END_LABEL"] = node["label"]
             return nodes
 
         aggregation = AggregateFn(
@@ -127,178 +318,15 @@ class GraphExtractor(ABC):
                     del doc["properties"]["nodes"]
 
         doc = HierarchicalDocument()
-        for value in result["nodes"].values():
-            node = HierarchicalDocument(value)
-            doc.children.append(node)
+        for key, hashes in result["nodes"].items():
+            for hash, node in hashes.items():
+                node = HierarchicalDocument(node)
+                doc.children.append(node)
         doc.data["EXTRACTED_NODES"] = True
 
         docs.append(doc)
 
         return reader.document(docs)
-
-
-class MetadataExtractor(GraphExtractor):
-    """
-    Extracts metadata from documents and represents them as nodes and relationship in neo4j
-
-    Args:
-        metadata: A list of GraphMetadata that is used to determine what metadata is extracted
-    """
-
-    def __init__(self, metadata: list[GraphMetadata]):
-        self.metadata = metadata
-
-    def extract(self, docset: "DocSet") -> "DocSet":
-        """
-        Extracts metadata from documents and creates an additional document in the docset that stores those nodes
-        """
-        docset.plan = ExtractFeatures(docset.plan, self)
-        docset = self.resolve(docset)
-
-        return docset
-
-    def _extract(self, doc: HierarchicalDocument) -> HierarchicalDocument:
-        nodes: Dict[str, Dict[str, Any]] = {}
-        for m in self.metadata:
-            key = m.nodeKey
-            value = str(doc["properties"].get(key))
-            if value == "None":
-                continue
-
-            node: Dict[str, Any] = {
-                "type": "metadata",
-                "properties": {key: value},
-                "label": m.nodeLabel,
-                "relationships": {},
-            }
-            rel: Dict[str, Any] = {
-                "TYPE": m.relLabel,
-                "properties": {},
-                "START_ID": str(doc.doc_id),
-                "START_LABEL": doc.data["label"],
-            }
-
-            node["relationships"][str(uuid.uuid4())] = rel
-            nodes[key + "_" + value] = node
-            del doc["properties"][m.nodeKey]
-
-        doc["properties"]["nodes"] = nodes
-        return doc
-
-
-class EntityExtractor(GraphExtractor):
-    """
-    Extracts entities chosen by the user by using LLMs
-
-    Args:
-        entities: A list of GraphEntity that determines what entities are extracted
-        llm: The LLM that is used to extract the entities
-    """
-
-    def __init__(self, entities: list[GraphEntity], llm: LLM):
-        self.entities = entities
-        self.llm = llm
-
-    def extract(self, docset: "DocSet") -> "DocSet":
-        """
-        Extracts entities from documents then creates a document in the docset where they are stored as nodes
-        """
-        docset.plan = ExtractSummaries(docset.plan)
-        docset.plan = ExtractFeatures(docset.plan, self)
-        docset = self.resolve(docset)
-        return docset
-
-    def _extract(self, doc: HierarchicalDocument) -> HierarchicalDocument:
-        import asyncio
-
-        if "EXTRACTED_NODES" in doc.data or not isinstance(doc, HierarchicalDocument):
-            return doc
-
-        async def gather_api_calls():
-            labels = [e.label + ": " + e.description for e in self.entities]
-            tasks = [self._extract_from_section(labels, child.data["summary"]) for child in doc.children]
-            res = await asyncio.gather(*tasks)
-            return res
-
-        res = asyncio.run(gather_api_calls())
-
-        nodes = {}
-        for i, section in enumerate(doc.children):
-            try:
-                res[i] = json.loads(res[i])
-            except json.JSONDecodeError:
-                logger.warn("LLM Output failed to be decoded to JSON")
-                logger.warn("Input: " + section.data["summary"])
-                logger.warn("Output: " + res[i])
-                res[i] = {"entities": []}
-
-            for node in res[i]["entities"]:
-                node = {
-                    "type": "extracted",
-                    "properties": {"name": node["name"]},
-                    "label": node["type"],
-                    "relationships": {},
-                }
-                rel: Dict[str, Any] = {
-                    "TYPE": "CONTAINS",
-                    "properties": {},
-                    "START_ID": str(section.doc_id),
-                    "START_LABEL": section.data["label"],
-                }
-                node["relationships"][str(uuid.uuid4())] = rel
-
-                key = str(node["label"] + "_" + node["properties"]["name"])
-                if key not in nodes:
-                    nodes[key] = node
-                else:
-                    for rel_uuid, rel in node["relationships"].items():
-                        nodes[key]["relationships"][rel_uuid] = rel
-
-        doc["properties"]["nodes"] = nodes
-
-        return doc
-
-    async def _extract_from_section(self, labels, summary: str) -> Awaitable[str]:
-        return await self.llm.generate_async(
-            prompt_kwargs={"prompt": str(GraphEntityExtractorPrompt(labels, summary))},
-            llm_kwargs={"response_format": {"type": "json_object"}},
-        )
-
-
-def GraphEntityExtractorPrompt(entities, query):
-    return f"""
-    -Goal-
-    You are a helpful information extraction system.
-
-    You will be given a sequence of data in different formats(text, table, Section-header) in order.
-    Your job is to extract entities that match the following types and descriptions.
-
-
-    -Instructions-
-    Entity Types and Descriptions: [{entities}]
-
-    Identify all entities that fit one of the following types and their descriptions.
-    For each of these entities extract the following information.
-    - entity_name: Name of the entity, capitalized
-    - entity_type: One of the following types listed above.
-
-    Format each entity that fits one of the types and their description as a json object.
-    Then, collect all json objects into a single json array named entities.
-
-    **Format Example:**
-    {{
-    entities: [
-    {{"name": <entity_name_1>, "type": <entity_type_1>}},
-    {{"name": <entity_name_2>, "type": <entity_type_2>}},
-    ...]
-    }}
-
-    -Real Data-
-    ######################
-    Entity_types: {entities}
-    Text: {query}
-    ######################
-    Output:"""
 
 
 class ExtractDocumentStructure(Map):

--- a/lib/sycamore/sycamore/transforms/extract_graph.py
+++ b/lib/sycamore/sycamore/transforms/extract_graph.py
@@ -221,6 +221,12 @@ class ResolveEntities:
     """
     Aggregates entities across all documents and resolves duplicate nodes created
     during extraction.
+
+    This class currently implements basic entity resolution based of the json schema
+    of specific entities. Entities are stored in the 'nodes' key in properties where
+    each entity is stored in nodes[label][hash] where label is the type of entity, and
+    hash is its json representation hashes. If two nodes have the same label and
+    json representation, they will be merged with their result stored in nodes[label][hash].
     """
 
     @staticmethod

--- a/lib/sycamore/sycamore/transforms/extract_graph.py
+++ b/lib/sycamore/sycamore/transforms/extract_graph.py
@@ -140,7 +140,7 @@ class EntityExtractor(GraphExtractor):
         res = asyncio.run(gather_api_calls())
 
         for i, section in enumerate(doc.children):
-            nodes = defaultdict(dict)
+            nodes: defaultdict[dict, Any] = defaultdict(dict)
             try:
                 res[i] = json.loads(res[i])
             except json.JSONDecodeError:
@@ -232,7 +232,7 @@ class ResolveEntities:
         def GroupDocumentNodes(doc: HierarchicalDocument) -> HierarchicalDocument:
             if "EXTRACTED_NODES" in doc.data:
                 return doc
-            nodes = defaultdict(dict)
+            nodes: defaultdict[dict, Any] = defaultdict(dict)
             nodes |= doc["properties"].get("nodes", {})
             for section in doc.children:
                 if "nodes" not in section["properties"]:

--- a/lib/sycamore/sycamore/transforms/extract_graph.py
+++ b/lib/sycamore/sycamore/transforms/extract_graph.py
@@ -115,7 +115,7 @@ class EntityExtractor(GraphExtractor):
         self.entities = self._serialize_entities(entities)
         self.schema = json_schema
         self.llm = llm
-        if json_schema is None and len(entities) == 0:
+        if json_schema is None and entities is []:
             raise ValueError("Must input JSON schema or list of pydantic entities")
 
     def extract(self, docset: "DocSet") -> "DocSet":

--- a/lib/sycamore/sycamore/transforms/extract_graph.py
+++ b/lib/sycamore/sycamore/transforms/extract_graph.py
@@ -233,8 +233,10 @@ class ResolveEntities:
             if "EXTRACTED_NODES" in doc.data:
                 return doc
             nodes = defaultdict(dict)
-            nodes |= doc["properties"]["nodes"]
+            nodes |= doc["properties"].get("nodes", {})
             for section in doc.children:
+                if "nodes" not in section["properties"]:
+                    continue
                 for label, hashes in section["properties"]["nodes"].items():
                     for hash, node in hashes.items():
                         if nodes[label].get(hash, None) is None:

--- a/lib/sycamore/sycamore/utils/pickle_pydantic.py
+++ b/lib/sycamore/sycamore/utils/pickle_pydantic.py
@@ -1,0 +1,40 @@
+import io
+from typing import Any, Dict, Type
+from ray import cloudpickle
+from pydantic import BaseModel
+
+
+def safe_cloudpickle(obj: Any) -> bytes:
+    model_namespaces = {}
+
+    with io.BytesIO() as f:
+        pickler = cloudpickle.CloudPickler(f)
+
+        for ModelClass in BaseModel.__subclasses__():
+            model_namespaces[ModelClass] = ModelClass.__pydantic_parent_namespace__
+            ModelClass.__pydantic_parent_namespace__ = None
+
+        try:
+            pickler.dump(obj)
+            return f.getvalue()
+        finally:
+            for ModelClass, namespace in model_namespaces.items():
+                ModelClass.__pydantic_parent_namespace__ = namespace
+
+
+def safe_cloudunpickle(pickled_obj: bytes) -> Any:
+    model_namespaces: Dict[Type[BaseModel], str] = {}
+
+    # Collect the current parent namespaces before unpickling
+    for ModelClass in BaseModel.__subclasses__():
+        model_namespaces[ModelClass] = getattr(ModelClass, "__pydantic_parent_namespace__", None)
+        ModelClass.__pydantic_parent_namespace__ = None
+
+    try:
+        with io.BytesIO(pickled_obj) as f:
+            obj = cloudpickle.load(f)
+            return obj
+    finally:
+        # Restore the original __pydantic_parent_namespace__ attributes
+        for ModelClass, namespace in model_namespaces.items():
+            ModelClass.__pydantic_parent_namespace__ = namespace

--- a/lib/sycamore/sycamore/utils/pickle_pydantic.py
+++ b/lib/sycamore/sycamore/utils/pickle_pydantic.py
@@ -1,5 +1,5 @@
 import io
-from typing import Any, Dict, Type
+from typing import Any, Dict, Optional, Type
 from ray import cloudpickle
 from pydantic import BaseModel
 
@@ -23,7 +23,7 @@ def safe_cloudpickle(obj: Any) -> bytes:
 
 
 def safe_cloudunpickle(pickled_obj: bytes) -> Any:
-    model_namespaces: Dict[Type[BaseModel], str] = {}
+    model_namespaces: Dict[Type[BaseModel], Optional[Dict[str, Any]]] = {}
 
     # Collect the current parent namespaces before unpickling
     for ModelClass in BaseModel.__subclasses__():


### PR DESCRIPTION
This PR implements using pydantic models as entity schemas to be extracted from text.
**lib/sycamore/pyproject.toml**
- Added pydantic as a dependency

**lib/sycamore/sycamore/docset.py**
- Moved resolving duplicate entities to after all extractors run

**lib/sycamore/sycamore/llms/openai.py**
- Added functionality to use openai structured outputs
- Automatically select the beta client if the response format uses structured outputs

**lib/sycamore/sycamore/tests/unit/transforms/test_graph_extractor.py**
- Change tests to use normal docset inputs instead of hierarchical documents
- Changed entity extractor test to test using pydantic models

**lib/sycamore/sycamore/transforms/extract_graph.py**
- Removed resolve method and made it an importable function to be called after all graph extractors have been run
- Entity extractor now uses pydantic models to extract entity schemas
- Changes the way data schemas are modeled internally, instead of `nodes[label][value]` where value used to be the primary key, its now `nodes[label][hash]` where hash is the hash representation of the json object of a particular schema.

**lib/sycamore/sycamore/utils/pickle_pydantic.py**
- Implemented pickle workaround for pydantic objects created in ipynb notebooks to ensure they are ray serializable.
- https://github.com/pydantic/pydantic/issues/8232
