### PR TITLE
Change the file writer to create the output directory.

### DIFF
--- a/lib/sycamore/sycamore/tests/unit/test_writer.py
+++ b/lib/sycamore/sycamore/tests/unit/test_writer.py
@@ -186,3 +186,11 @@ class TestDocSetWriter:
         doc_set = context.read.document(docs).map(noop_map)
         doc_set.write.json(str(tmp_path))
         _check_doc_blocks(docs, tmp_path)
+
+    def test_file_writer_create_path(self, tmp_path: Path):
+        docs = generate_docs(5)
+        context = sycamore.init()
+        doc_set = context.read.document(docs).map(noop_map)
+        out_path = tmp_path / "new_subdir"
+        doc_set.write.files(str(out_path))
+        _check_doc_path(docs, out_path)


### PR DESCRIPTION
Based on customer feedback. This changes the default and fixes the implementation of the makedirs parameter so that the writer will create the directory to write to by default.