### PR TITLE
Update Github integ test runner.

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -103,7 +103,7 @@ jobs:
         working-directory: lib/remote-processors
 
   integ-tests:
-    runs-on: integ-test-runner
+    runs-on: integ-test-runner2
     strategy:
       matrix:
         python-version: ["3.9"]


### PR DESCRIPTION
This moves the integ tests to a larger instance.