### PR TITLE
Fixed a problem in detr_partitioner.py

### DIFF
--- a/lib/sycamore/sycamore/transforms/detr_partitioner.py
+++ b/lib/sycamore/sycamore/transforms/detr_partitioner.py
@@ -298,7 +298,7 @@ class ArynPDFPartitioner:
                 raise ArynPDFPartitionerException(
                     f"Error partway through processing: {response_json['error']}\nPartial Status:\n{status}"
                 )
-            response_json = response_json.get("elements")
+            response_json = response_json.get("elements", [])
 
         elements = []
         for element_json in response_json:


### PR DESCRIPTION
`response_json = response_json.get("elements")` returns None by default, so this would crash when `response_json` is subsequently iterated. Changing the default to an empty list prevents this error.