### PR TITLE
Fixed a problem with passing an empty path to _FileDataSink

### DIFF
--- a/lib/sycamore/sycamore/connectors/file/file_writer_ray.py
+++ b/lib/sycamore/sycamore/connectors/file/file_writer_ray.py
@@ -39,6 +39,8 @@ class _FileDataSink(Datasink):
         is_s3_uri = parsed_uri.scheme == "s3"
 
         if not is_s3_uri and self._filesystem.get_file_info(self._root).type is FileType.NotFound:
+            if self._root == "":
+                self._root = "./"
             self._filesystem.create_dir(self._root, recursive=True)
 
     def write(self, blocks: Iterable[Block], ctx: TaskContext) -> Any:

--- a/lib/sycamore/sycamore/transforms/detr_partitioner.py
+++ b/lib/sycamore/sycamore/transforms/detr_partitioner.py
@@ -298,7 +298,7 @@ class ArynPDFPartitioner:
                 raise ArynPDFPartitionerException(
                     f"Error partway through processing: {response_json['error']}\nPartial Status:\n{status}"
                 )
-            response_json = response_json.get("elements")
+            response_json = response_json.get("elements", [])
 
         elements = []
         for element_json in response_json:


### PR DESCRIPTION
PyArrow will crash if you tell it to create a directory with "" as the path, so _FileDataSink does the same thing.

Now if you pass in an empty string, it will change it to "./" before getting PyArrow to create the directory.