### PR TITLE
Fixed an error in file_writer_ray.py

### DIFF
--- a/lib/sycamore/sycamore/connectors/file/file_writer_ray.py
+++ b/lib/sycamore/sycamore/connectors/file/file_writer_ray.py
@@ -39,6 +39,8 @@ class _FileDataSink(Datasink):
         is_s3_uri = parsed_uri.scheme == "s3"
 
         if not is_s3_uri and self._filesystem.get_file_info(self._root).type is FileType.NotFound:
+            if self._root == "":
+                self._root = "./"
             self._filesystem.create_dir(self._root, recursive=True)
 
     def write(self, blocks: Iterable[Block], ctx: TaskContext) -> Any:

--- a/lib/sycamore/sycamore/connectors/file/file_writer_ray.py
+++ b/lib/sycamore/sycamore/connectors/file/file_writer_ray.py
@@ -25,6 +25,8 @@ class _FileDataSink(Datasink):
     ):
         (paths, self._filesystem) = _resolve_paths_and_filesystem(path, filesystem)
         self._root = paths[0]
+        if self._root == "":
+            self._root = "./"
         self._filename_fn = filename_fn
         self._doc_to_bytes_fn = doc_to_bytes_fn
         self._makedirs = makedirs
@@ -39,8 +41,6 @@ class _FileDataSink(Datasink):
         is_s3_uri = parsed_uri.scheme == "s3"
 
         if not is_s3_uri and self._filesystem.get_file_info(self._root).type is FileType.NotFound:
-            if self._root == "":
-                self._root = "./"
             self._filesystem.create_dir(self._root, recursive=True)
 
     def write(self, blocks: Iterable[Block], ctx: TaskContext) -> Any:


### PR DESCRIPTION
_FileDataSink would crash if you passed it an empty string as `_root` because PyArrow can't create a directory at ""

Now if `_root` is an empty string, it automatically switches to "./" before creating the directory.
