### PR TITLE
Fill in "gaps" in non-contiguous rows and columns from TATR .

### DIFF
--- a/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
@@ -107,11 +107,18 @@ def objects_to_table(objects, tokens, structure_class_thresholds=DEFAULT_STRUCTU
 
     table_cells = []
     for cell in cells:
+
+        rows = sorted(cell["row_nums"])
+        rows = list(range(rows[0], rows[-1] + 1))
+
+        cols = sorted(cell["column_nums"])
+        cols = list(range(cols[0], cols[-1] + 1))
+
         table_cells.append(
             TableCell(
                 content=cell["cell text"],
-                rows=cell["row_nums"],
-                cols=cell["column_nums"],
+                rows=rows,
+                cols=cols,
                 is_header=cell["column header"],
                 bbox=BoundingBox(*cell["bbox"]),
             )


### PR DESCRIPTION
We have seen at least one case where table transformers will produce a cell that spans a non-contiguous span of rows (e.g. [8,9,11,12]). This is clearly wrong, and we were asserting on it, but it is quite difficult to update the table transformer heuristics in a way that prevents this without having other potentially deleterious effects on quality. This change simply replaces the row and column spans with list(range(min, max)), which always produces a continuous run of rows/cols.