### PR TITLE
Return an empty table when table transformers don't find a table.

### DIFF
--- a/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
@@ -103,6 +103,9 @@ DEFAULT_STRUCTURE_CLASS_THRESHOLDS = {
 def objects_to_table(objects, tokens, structure_class_thresholds=DEFAULT_STRUCTURE_CLASS_THRESHOLDS) -> Optional[Table]:
     structures = objects_to_structures(objects, tokens=tokens, class_thresholds=structure_class_thresholds)
 
+    if len(structures) == 0:
+        return None
+
     cells, _ = structure_to_cells(structures, tokens=tokens)
 
     table_cells = []
@@ -744,7 +747,9 @@ def objects_to_structures(objects, tokens, class_thresholds):
 
     tables = [obj for obj in objects if obj["label"] == "table"]
 
-    assert len(tables) == 1
+    assert len(tables) <= 1
+    if len(tables) == 0:
+        return {}
 
     table = tables[0]
     structure = {}


### PR DESCRIPTION
This was causing an assertion failure when the DETR model found a table but table transformers didn't.

We still leave the assertion in for the case where the table transformer model finds more than one table. It is not clear if this is happening in practice, and the fix is more involved, so we defer it.