### PR TITLE
More dependencies at runtime. ~2x speedup on import sycamore test

### DIFF
--- a/lib/sycamore/sycamore/llms/guidance.py
+++ b/lib/sycamore/sycamore/llms/guidance.py
@@ -1,9 +1,14 @@
+from typing import TYPE_CHECKING
+
 from sycamore.llms.prompts.default_prompts import SimplePrompt
-from guidance.models import Chat, Instruct, Model as GuidanceModel
-from guidance import gen, user, system, assistant, instruction
+
+if TYPE_CHECKING:
+    from guidance.models import Model as GuidanceModel
 
 
-def _execute_chat(prompt: SimplePrompt, model: GuidanceModel, **kwargs) -> str:
+def _execute_chat(prompt: SimplePrompt, model: "GuidanceModel", **kwargs) -> str:
+    from guidance import gen, user, system, assistant
+
     with system():
         assert prompt.system is not None
         lm = model + prompt.system.format(**kwargs)
@@ -18,7 +23,9 @@ def _execute_chat(prompt: SimplePrompt, model: GuidanceModel, **kwargs) -> str:
     return lm[prompt.var_name]
 
 
-def _execute_instruct(prompt: SimplePrompt, model: GuidanceModel, **kwargs) -> str:
+def _execute_instruct(prompt: SimplePrompt, model: "GuidanceModel", **kwargs) -> str:
+    from guidance import gen, instruction
+
     with instruction():
         assert prompt.user is not None
         lm = model + prompt.user.format(**kwargs)
@@ -26,13 +33,17 @@ def _execute_instruct(prompt: SimplePrompt, model: GuidanceModel, **kwargs) -> s
     return lm[prompt.var_name]
 
 
-def _execute_completion(prompt: SimplePrompt, model: GuidanceModel, **kwargs) -> str:
+def _execute_completion(prompt: SimplePrompt, model: "GuidanceModel", **kwargs) -> str:
+    from guidance import gen
+
     assert prompt.user is not None
     lm = model + prompt.user.format(**kwargs) + gen(name=prompt.var_name)
     return lm[prompt.var_name]
 
 
-def execute_with_guidance(prompt: SimplePrompt, model: GuidanceModel, **kwargs) -> str:
+def execute_with_guidance(prompt: SimplePrompt, model: "GuidanceModel", **kwargs) -> str:
+    from guidance.models import Chat, Instruct
+
     if isinstance(model, Chat):
         return _execute_chat(prompt, model, **kwargs)
     elif isinstance(model, Instruct):

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -5,11 +5,8 @@ import os
 import pickle
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Awaitable, Optional, TypedDict, Union, cast
+from typing import Any, Awaitable, Optional, TypedDict, Union, cast, TYPE_CHECKING
 
-from guidance.models import AzureOpenAIChat, AzureOpenAICompletion
-from guidance.models import Model
-from guidance.models import OpenAI as GuidanceOpenAI
 from openai import AzureOpenAI as AzureOpenAIClient
 from openai import AsyncAzureOpenAI as AsyncAzureOpenAIClient
 from openai import OpenAI as OpenAIClient
@@ -24,6 +21,8 @@ from sycamore.llms.llms import LLM
 from sycamore.llms.prompts import SimplePrompt
 from sycamore.utils.cache import Cache
 
+if TYPE_CHECKING:
+    from guidance.models import Model
 
 logger = logging.getLogger(__name__)
 
@@ -213,8 +212,10 @@ class OpenAIClientWrapper:
         else:
             raise ValueError(f"Invalid client_type {self.client_type}")
 
-    def get_guidance_model(self, model) -> Model:
+    def get_guidance_model(self, model) -> "Model":
         if self.client_type == OpenAIClientType.OPENAI:
+            from guidance.models import OpenAI as GuidanceOpenAI
+
             return GuidanceOpenAI(
                 model=model.name,
                 api_key=self.api_key,
@@ -224,6 +225,8 @@ class OpenAIClientWrapper:
                 **self.extra_kwargs,
             )
         elif self.client_type == OpenAIClientType.AZURE:
+            from guidance.models import AzureOpenAIChat, AzureOpenAICompletion
+
             # Note: Theoretically the Guidance library automatically determines which
             # subclass to use, but this appears to be buggy and relies on a bunch of
             # specific assumptions about how deployed models are named that don't work

--- a/lib/sycamore/sycamore/tests/manual/test_fast_sycamore_import.py
+++ b/lib/sycamore/sycamore/tests/manual/test_fast_sycamore_import.py
@@ -5,21 +5,25 @@
 
 import inspect
 import sys
+from datetime import datetime
 
 
 def test_00_sycamore_not_yet_imported():
     assert "sycamore" not in sys.modules, "Test run with other tests that import ray"
 
 
-def test_no_direct_ray():
+def test_disallow_unconditional_dependencies():
     assert "ray" not in sys.modules, "Test run with other tests that import ray"
     import sycamore
 
     _ = sycamore  # make sure tools don't remove the import
+    assert "torch" not in sys.modules, "import sycamore should not unconditionally import torch"
     assert "ray" not in sys.modules, "import sycamore should not unconditionally import ray"
+    assert "guidance" not in sys.modules, "import sycamore should not unconditionally import guidance"
 
 
 if __name__ == "__main__":
+    all_start = datetime.now()
     tests = []
     for name, obj in inspect.getmembers(sys.modules[__name__]):
         if name.startswith("test") and inspect.isfunction(obj):
@@ -29,6 +33,8 @@ if __name__ == "__main__":
     for t in tests:
         (name, obj) = t
         print(f"Testing {name}")
+        start = datetime.now()
         obj()
+        print(f"Testing {name} took {datetime.now() - start}")
 
-    print("All tests ran")
+    print(f"All tests ran in {datetime.now() - all_start}")

--- a/lib/sycamore/sycamore/transforms/bbox_merge.py
+++ b/lib/sycamore/sycamore/transforms/bbox_merge.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from sycamore.data import Document, Element
 from sycamore.plan_nodes import Node, SingleThreadUser, NonGPUUser
-from sycamore.transforms import Map
+from sycamore.transforms.map import Map
 from sycamore.utils.time_trace import TimeTrace, timetrace
 
 

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -3,7 +3,6 @@ from typing import Any
 
 from PIL import Image
 import pdf2image
-import torch
 
 from sycamore.data import BoundingBox, Element, Document, TableElement
 from sycamore.plan_nodes import Node
@@ -150,6 +149,8 @@ class TableTransformerStructureExtractor(TableStructureExtractor):
 
         # Run inference using the model and convert the output to raw "objects" containing bounding boxes and types.
         pixel_values = structure_transform(cropped_image).unsqueeze(0).to(self._get_device())
+
+        import torch
 
         with torch.no_grad():
             outputs = self.structure_model(pixel_values)

--- a/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
@@ -12,8 +12,6 @@ import xml.etree.ElementTree as ET
 import numpy as np
 import pandas as pd
 
-import torch
-
 from sycamore.data.table import Table, TableCell
 from sycamore.data import BoundingBox
 
@@ -61,12 +59,16 @@ def iob(coords1, coords2) -> float:
 
 # for output bounding box post-processing
 def box_cxcywh_to_xyxy(x):
+    import torch
+
     x_c, y_c, w, h = x.unbind(-1)
     b = [(x_c - 0.5 * w), (y_c - 0.5 * h), (x_c + 0.5 * w), (y_c + 0.5 * h)]
     return torch.stack(b, dim=1)
 
 
 def rescale_bboxes(out_bbox, size):
+    import torch
+
     img_w, img_h = size
     b = box_cxcywh_to_xyxy(out_bbox)
     b = b * torch.tensor([img_w, img_h, img_w, img_h], dtype=torch.float32)

--- a/lib/sycamore/sycamore/writer.py
+++ b/lib/sycamore/sycamore/writer.py
@@ -5,7 +5,7 @@ from neo4j import Auth
 from neo4j.auth_management import AuthManager
 from pyarrow.fs import FileSystem
 
-from sycamore import Context
+from sycamore.context import Context
 from sycamore.connectors.common import HostAndPort
 from sycamore.connectors.file.file_writer import default_doc_to_bytes, default_filename, FileWriter, JsonWriter
 from sycamore.data import Document


### PR DESCRIPTION
2.6s to run test before, 1.35 after.

Also include timing of just the import statement, although time after exit seems proportional to the time to import.