### PR TITLE
make sure writers finalize

### DIFF
--- a/lib/sycamore/sycamore/docset.py
+++ b/lib/sycamore/sycamore/docset.py
@@ -3,7 +3,7 @@ import logging
 from pathlib import Path
 import pprint
 import sys
-from typing import Callable, Optional, Any, Iterable, Type, Union
+from typing import Callable, Optional, Any, Iterable, Type, Union, TYPE_CHECKING
 
 from sycamore.context import Context
 from sycamore.data import Document, Element, MetadataDocument
@@ -27,9 +27,11 @@ from sycamore.transforms.llm_query import LLMTextQueryAgent
 from sycamore.transforms.extract_table import TableExtractor
 from sycamore.transforms.merge_elements import ElementMerger
 from sycamore.utils.extract_json import extract_json
-from sycamore.writer import DocSetWriter
 from sycamore.transforms.query import QueryExecutor, Query
 from sycamore.materialize_config import MaterializeSourceMode
+
+if TYPE_CHECKING:
+    from sycamore.writer import DocSetWriter
 
 logger = logging.getLogger(__name__)
 
@@ -1193,7 +1195,7 @@ class DocSet:
         return joined_docset
 
     @property
-    def write(self) -> DocSetWriter:
+    def write(self) -> "DocSetWriter":
         """
         Exposes an interface for writing a DocSet to OpenSearch or other external storage.
         See :class:`~writer.DocSetWriter` for more information about writers and their arguments.
@@ -1235,6 +1237,8 @@ class DocSet:
                      index_name="my_index",
                      index_settings=index_settings)
         """
+        from sycamore.writer import DocSetWriter
+
         return DocSetWriter(self.context, self.plan)
 
     def materialize(

--- a/lib/sycamore/sycamore/writer.py
+++ b/lib/sycamore/sycamore/writer.py
@@ -663,7 +663,7 @@ class DocSetWriter:
                 if not.
             resource_args: Arguments to pass to the underlying execution environment.
         """
-        file_writer = FileWriter(
+        file_writer: Node = FileWriter(
             self.plan,
             path,
             filesystem=filesystem,
@@ -692,7 +692,7 @@ class DocSetWriter:
             resource_args: Arguments to pass to the underlying execution environment.
         """
 
-        node = JsonWriter(self.plan, path, filesystem=filesystem, **resource_args)
+        node: Node = JsonWriter(self.plan, path, filesystem=filesystem, **resource_args)
         node = Execution(self.context)._apply_rules(node)
         node.execute()
         node.traverse(visit=lambda n: n.finalize())


### PR DESCRIPTION
before a bunch of the writers were forcing execution by going to the ray level, which would skip the finalize call that materialize needs in order to function. This moves as many of the writers as possible to use DocSet.execute() and for those where it's non-trivial just sticks a finalize in the method after the ray-based execution-forcer