### PR TITLE
Initial attempt at straightforward document processing script.

### DIFF
--- a/examples/direct.py
+++ b/examples/direct.py
@@ -1,0 +1,80 @@
+# fmt: off
+import sys
+from typing import BinaryIO
+from itertools import repeat
+from collections.abc import Iterator
+
+import boto3
+import pyarrow.fs
+
+import aryn_sdk.partition
+import sycamore
+from sycamore.transforms.embed import SentenceTransformerEmbedder
+from sycamore.transforms.sketcher import Sketcher
+from sycamore.connectors.duckdb.duckdb_writer import (
+    DuckDBWriterClientParams,
+    DuckDBWriterTargetParams,
+    DuckDBWriter,
+)
+
+###############################################################################
+
+def iterInputs(inputs: list[str], aws_sess = None) -> Iterator[BinaryIO]:
+    fs_s3 = None
+    for input in inputs:
+        if input.startswith("s3://"):
+            path = input[5:]
+            if not fs_s3:
+                cred = aws_sess.get_credentials()
+                fs_s3 = pyarrow.fs.S3FileSystem(
+                    access_key=cred.access_key,
+                    secret_key=cred.secret_key,
+                    region=aws_sess.region_name,
+                    session_token=cred.token,
+                )
+            fsys = fs_s3
+        else:
+            if input.startswith("file://"):
+                path = input[7:]
+            else:
+                path = input
+            fsys = pyarrow.fs.LocalFileSystem()
+
+        info = fsys.get_file_info(path)
+        if info.type == pyarrow.fs.FileType.File:
+            infos = [info]
+        else:
+            infos = fsys.get_file_info(
+                pyarrow.fs.FileSelector(path, recursive=True)
+            )
+        for info in infos:
+            strm = fsys.open_input_stream(info.path)
+            yield (input, strm)
+
+###############################################################################
+
+inputs = [
+    "s3://aryn-public/cccmad-tiny/2019/006965487_National Student Nurses Association.pdf.pdf",
+    "s3://aryn-public/cccmad-tiny/2011/",
+    "file:///home/alex/load/pdfs/ntsb0.pdf",
+    "/home/alex/load/pdfs/ca_san_luis_obispo_21_22_adopted.pdf",
+]
+
+aws_sess = boto3.session.Session()
+embedder = SentenceTransformerEmbedder("sentence-transformers/all-MiniLM-L6-v2")
+
+ddb_writer = DuckDBWriter(
+    None,  # FIXME default plan to None
+    DuckDBWriterClientParams(),
+    DuckDBWriterTargetParams(dimensions=384),  # FIXME get from embedder
+)
+
+for fn, strm in iterInputs(inputs, aws_sess):
+    res = aryn_sdk.partition.partition_file(strm)
+    bigdoc = sycamore.data.document.Document(res)
+    docs = sycamore.transforms.Explode.explode(bigdoc)
+    for idx in range(len(docs)):
+        docs[idx].doc_id = f"{fn}-{idx}"  # FIXME make explode do this
+    docs = list(map(Sketcher.sketcher, docs, repeat(17), repeat(16)))  # FIXME default numeric params
+    docs = embedder.generate_embeddings(docs)
+    ddb_writer.write_docs(docs)


### PR DESCRIPTION
This is a proposal/example, not meant to be checked in.

The basic idea here is not only to bypass Ray, but also avoid the lazy-evaluated pipeline abstraction.  Instead, it's coded the way a typical programmer would expect to write the code.  This approach is synchronous rather than functional and allows different documents to be treated differently on the fly.

Instead of DocSet, we deal with a list of Document.  DocSet confuses people because it's not a set of documents.

One finding is that most existing transforms would be easier to use a simple functions.  Then they could the the target of "map", either directly or via DocSet.

This code represents the exercise of simplifying without modifying Sycamore.  The function `iterInputs` would be intended as an addition to the Sycamore library.  There are FIXME comments for how Sycamore could become easier to use directly.

The remaining piece would be a way to encapsulate common processing sequences into higher-level single calls.  We could do this generally, or just provide some off-the-shelf.  This may turn into an exercise in naming.