### PR TITLE
Fixed neo4j relationship property loading + added support for loading lists and dictionaries as properties

### DIFF
--- a/lib/sycamore/sycamore/connectors/neo4j/neo4j_writer.py
+++ b/lib/sycamore/sycamore/connectors/neo4j/neo4j_writer.py
@@ -274,7 +274,10 @@ class Neo4jWriteCSV(MapBatch, Write):
                 }
                 for property_key, property_value in value["properties"].items():
                     if property_key not in include_relationships:
-                        rel[property_key] = property_value
+                        if isinstance(property_value, list) or isinstance(property_value, dict):
+                            node[property_key] = json.dumps(property_value)
+                        else:
+                            node[property_key] = property_value
                 relationships[value["START_LABEL"]][value["END_LABEL"]].append(rel)
         return nodes, relationships
 

--- a/lib/sycamore/sycamore/connectors/neo4j/neo4j_writer.py
+++ b/lib/sycamore/sycamore/connectors/neo4j/neo4j_writer.py
@@ -88,8 +88,7 @@ class Neo4jWriterClient:
             CALL apoc.create.relationship(
               s,
               row[":TYPE"],
-              apoc.map.merge(properties,
-              {{uuid: row["uuid:ID"]}}),
+              apoc.map.merge(properties, {{uuid: row["uuid:ID"]}}),
               e
             ) YIELD rel
             RETURN rel

--- a/lib/sycamore/sycamore/data/document.py
+++ b/lib/sycamore/sycamore/data/document.py
@@ -337,8 +337,11 @@ class HierarchicalDocument(Document):
 
         self.doc_id = self.data.get("doc_id", str(uuid.uuid4()))
         self.children = self.data.get("children", [])
-        if self.data.get("type", "") == "table" and self.data.get("table", None) is not None:
-            self.text_representation = self.data["table"].to_csv()
+        if self.data.get("type", None) == "table":
+            table_csv = ""
+            if self.data.get("table", None):
+                table_csv = self.data["table"].to_csv()
+            self.text_representation = self.data.get("override_text", table_csv)
 
         for element in self.data.get("elements", []):
             self.children.append(HierarchicalDocument(Document(element.data)))

--- a/lib/sycamore/sycamore/data/document.py
+++ b/lib/sycamore/sycamore/data/document.py
@@ -338,10 +338,8 @@ class HierarchicalDocument(Document):
         self.doc_id = self.data.get("doc_id", str(uuid.uuid4()))
         self.children = self.data.get("children", [])
         if self.data.get("type", None) == "table":
-            table_csv = ""
-            if self.data.get("table", None):
-                table_csv = self.data["table"].to_csv()
-            self.text_representation = self.data.get("override_text", table_csv)
+            table_csv = self.data.get("table").to_csv() if self.data.get("table") else ""
+            self.text_representation = self.data.get("text_representation", table_csv)
 
         for element in self.data.get("elements", []):
             self.children.append(HierarchicalDocument(Document(element.data)))


### PR DESCRIPTION
**neo4j_writer.py**
- Fixed bug where relationship properties were not being added into neo4j(issue with prompt + logic in `_parse_docs`)
- Added support for lists + dictionaries are neo4j properties. Previously, they were flattened but this turns out to not be useful to the end user whilst just doing a `json.dumps()` on them allows them to be used by the user in neo4j with some commands.

**document.py**
- Now checks for text_representation in `self.data.get('text_representation')` before setting it to `self.data.get('table').to_csv()`