### PR TITLE
Handle non-hashable data types in opensearch schema extractor

### DIFF
--- a/lib/sycamore/sycamore/query/schema.py
+++ b/lib/sycamore/sycamore/query/schema.py
@@ -41,13 +41,16 @@ class OpenSearchSchemaFetcher:
             if not key.startswith("properties.entity") or ".keyword" in key:
                 continue
             try:
-                samples = {
-                    random_sample[i]["_source"]["properties"]["entity"].get(key[18:], None)
-                    for i in range(len(random_sample))
-                }
-                samples -= {None}
-                sample_type = type(samples.copy().pop())
-                result[key] = (str(sample_type), {str(example) for example in samples})
+                samples = set()
+                sample_type = None
+                for sample in random_sample:
+                    sample_value = sample["_source"]["properties"]["entity"].get(key[18:], None)
+                    if sample_value is not None:
+                        if not sample_type:
+                            sample_type = type(sample_value)
+                        samples.add(str(sample_value))
+                if len(samples) > 0:
+                    result[key] = (str(sample_type), {str(example) for example in samples})
             except KeyError:
                 # This can happen if there are mappings that have no corresponding values.
                 # Skip them.

--- a/lib/sycamore/sycamore/tests/unit/query/test_schema.py
+++ b/lib/sycamore/sycamore/tests/unit/query/test_schema.py
@@ -27,6 +27,12 @@ def test_opensearch_schema():
                         "weather": {"type": "text", "fields": {"keyword": {"type": "keyword", "ignore_above": 256}}}
                     },
                 },
+                "properties.entity.colors": {
+                    "full_name": "properties.entity.colors",
+                    "mapping": {
+                        "colors": {"type": "array", "fields": {"keyword": {"type": "keyword", "ignore_above": 256}}}
+                    },
+                },
             }
         }
     }
@@ -40,17 +46,19 @@ def test_opensearch_schema():
                     {
                         "_source": {
                             "properties": {
-                                "entity": {
-                                    "day": "2021-01-01",
-                                    "aircraft": "Boeing 747",
-                                }
+                                "entity": {"day": "2021-01-01", "aircraft": "Boeing 747", "colors": ["red", "blue"]}
                             }
                         }
                     },
                     {
                         "_source": {
                             "properties": {
-                                "entity": {"day": "2021-01-02", "aircraft": "Airbus A380", "weather": "Sunny"}
+                                "entity": {
+                                    "day": "2021-01-02",
+                                    "aircraft": "Airbus A380",
+                                    "weather": "Sunny",
+                                    "colors": [],
+                                }
                             }
                         }
                     },
@@ -69,4 +77,7 @@ def test_opensearch_schema():
     assert got["properties.entity.aircraft"] == ("<class 'str'>", {"Boeing 747", "Airbus A380"})
     assert "properties.entity.weather" in got
     assert got["properties.entity.weather"] == ("<class 'str'>", {"Sunny"})
+    assert "properties.entity.colors" in got
+    assert got["properties.entity.colors"] == ("<class 'list'>", {str(["red", "blue"]), str([])})
+
     assert "properties.entity.location" not in got


### PR DESCRIPTION
Current schema extractor breaks with lists which are common