### PR TITLE
Fix calls to structured outputs so that they can be cached

### DIFF
--- a/lib/sycamore/sycamore/transforms/extract_graph_entities.py
+++ b/lib/sycamore/sycamore/transforms/extract_graph_entities.py
@@ -6,6 +6,7 @@ from sycamore.plan_nodes import Node
 from sycamore.transforms.map import Map
 from sycamore.data import HierarchicalDocument
 from sycamore.llms import LLM
+from openai.lib._parsing import type_to_response_format_param
 from pydantic import BaseModel, create_model
 
 import json
@@ -103,7 +104,7 @@ class EntityExtractor(GraphEntityExtractor):
         return create_model("entities", __base__=BaseModel, **fields)
 
     async def _extract_from_section(self, summary: str) -> str:
-        llm_kwargs = {"response_format": self._deserialize_entities()}
+        llm_kwargs = {"response_format": type_to_response_format_param(self._deserialize_entities())}
 
         return await self.llm.generate_async(
             prompt_kwargs={"prompt": str(GraphEntityExtractorPrompt(summary))}, llm_kwargs=llm_kwargs

--- a/lib/sycamore/sycamore/transforms/extract_graph_relationships.py
+++ b/lib/sycamore/sycamore/transforms/extract_graph_relationships.py
@@ -7,6 +7,7 @@ from sycamore.plan_nodes import Node
 from sycamore.transforms.map import Map
 from sycamore.data import HierarchicalDocument
 from sycamore.llms import LLM
+from openai.lib._parsing import type_to_response_format_param
 from pydantic import BaseModel, create_model
 import asyncio
 
@@ -140,7 +141,7 @@ class RelationshipExtractor(GraphRelationshipExtractor):
                 entity_list.append(f"{node}\n")
         entities = "".join(entity_list)
 
-        llm_kwargs = {"response_format": relationships_model}
+        llm_kwargs = {"response_format": type_to_response_format_param(relationships_model)}
         res = await self.llm.generate_async(
             prompt_kwargs={"prompt": str(GraphRelationshipExtractorPrompt(section.data["summary"], entities))},
             llm_kwargs=llm_kwargs,


### PR DESCRIPTION
Uses openai's parser to parse the pydantic object into a json schema. This now allows for the response format to be serialized, meaning llm cache now works(previously, it was broken).