### PR TITLE
Default llm in transforms

### DIFF
--- a/lib/sycamore/sycamore/context.py
+++ b/lib/sycamore/sycamore/context.py
@@ -56,7 +56,7 @@ def get_val_from_context(
     context: "Context", val_key: str, param_names: List[str], ignore_default: bool = False
 ) -> Optional[Any]:
     """
-    GIven a Context object, return the possible value for a given val.
+    Helper function: Given a Context object, return the possible value for a given val.
     This assumes context.params is not a nested dict.
     @param context: Context to use
     @param val_key: Key for the value to be returned

--- a/lib/sycamore/sycamore/context.py
+++ b/lib/sycamore/sycamore/context.py
@@ -53,7 +53,7 @@ class Context:
 
 
 def get_val_from_context(
-    context: "Context", val_key: str, param_names: List[str], ignore_default: bool = False
+    context: "Context", val_key: str, param_names: Optional[List[str]] = None, ignore_default: bool = False
 ) -> Optional[Any]:
     """
     Helper function: Given a Context object, return the possible value for a given val.
@@ -68,10 +68,11 @@ def get_val_from_context(
     if not context.params:
         return None
 
-    for param_name in param_names:
-        cand = context.params.get(param_name, {}).get(val_key)
-        if cand is not None:
-            return cand
+    if param_names:
+        for param_name in param_names:
+            cand = context.params.get(param_name, {}).get(val_key)
+            if cand is not None:
+                return cand
 
     if not ignore_default:
         return context.params.get(OperationTypes.DEFAULT.value, {}).get(val_key)

--- a/lib/sycamore/sycamore/query/client.py
+++ b/lib/sycamore/sycamore/query/client.py
@@ -162,11 +162,18 @@ class SycamoreQueryClient:
         result = executor.execute(plan, query_id)
         return (query_id, result)
 
-    def query(self, query: str, index: str, dry_run: bool = False, codegen_mode: bool = False) -> str:
+    def query(
+        self,
+        query: str,
+        index: str,
+        context: Optional[Context] = None,
+        dry_run: bool = False,
+        codegen_mode: bool = False,
+    ) -> str:
         """Run a query against the given index."""
         schema = self.get_opensearch_schema(index)
         plan = self.generate_plan(query, index, schema)
-        _, result = self.run_plan(plan, dry_run=dry_run, codegen_mode=codegen_mode)
+        _, result = self.run_plan(plan, context=context, dry_run=dry_run, codegen_mode=codegen_mode)
         return result
 
     def dump_traces(self, logfile: str, query_id: Optional[str] = None):

--- a/lib/sycamore/sycamore/query/client.py
+++ b/lib/sycamore/sycamore/query/client.py
@@ -94,6 +94,7 @@ class SycamoreQueryClient:
     """A client for the Sycamore Query engine.
 
     Args:
+        context (optional): a configured Sycamore Context. A fresh one is created if not provided.
         s3_cache_path (optional): S3 path to use for LLM result caching.
         os_config (optional): OpenSearch configuration. Defaults to DEFAULT_OS_CONFIG.
         os_client_args (optional): OpenSearch client arguments. Defaults to DEFAULT_OS_CLIENT_ARGS.
@@ -115,6 +116,11 @@ class SycamoreQueryClient:
         self.os_config = os_config
         self.os_client_args = os_client_args
         self.trace_dir = trace_dir
+
+        if context and os_client_args:
+            raise AssertionError("If using a configured Context object, set os_client_args in context.params")
+        if context and s3_cache_path:
+            raise AssertionError("If using a configured Context object, set a cached llm in context.params")
 
         self.context = context
         if context is None:

--- a/lib/sycamore/sycamore/query/client.py
+++ b/lib/sycamore/sycamore/query/client.py
@@ -121,10 +121,7 @@ class SycamoreQueryClient:
             raise AssertionError("If using a configured Context object, set os_client_args in context.params")
         if context and s3_cache_path:
             raise AssertionError("If using a configured Context object, set a cached llm in context.params")
-
-        self.context = context
-        if context is None:
-            self.context = self._get_default_context()
+        self.context = context or self._get_default_context()
 
         self._os_client = OpenSearch(**self.os_client_args)
         self._os_query_executor = OpenSearchQueryExecutor(self.os_client_args)

--- a/lib/sycamore/sycamore/query/client.py
+++ b/lib/sycamore/sycamore/query/client.py
@@ -158,6 +158,7 @@ class SycamoreQueryClient:
         return plan
 
     def run_plan(self, plan: LogicalPlan, dry_run=False, codegen_mode=False) -> Tuple[str, str]:
+        assert self.context is not None, "Running a plan requires a configured Context"
         """Run the given logical query plan and return a tuple of the query ID and result."""
         executor = SycamoreExecutor(
             context=self.context,

--- a/lib/sycamore/sycamore/query/client.py
+++ b/lib/sycamore/sycamore/query/client.py
@@ -150,7 +150,7 @@ class SycamoreQueryClient:
         self, plan: LogicalPlan, context: Optional[Context] = None, dry_run=False, codegen_mode=False
     ) -> Tuple[str, str]:
         """Run the given logical query plan and return a tuple of the query ID and result."""
-        if not context:
+        if context is None:
             context = self._get_default_context()
         executor = SycamoreExecutor(
             context=context,
@@ -187,7 +187,7 @@ class SycamoreQueryClient:
                 except json.JSONDecodeError:
                     console.print(line)
 
-    def _get_default_context(self):
+    def _get_default_context(self) -> Context:
         context_params = {
             "default": {
                 "llm": OpenAI(

--- a/lib/sycamore/sycamore/query/execution/operations.py
+++ b/lib/sycamore/sycamore/query/execution/operations.py
@@ -1,8 +1,9 @@
 import json
 import math
-from typing import Any, List, Union
+from typing import Any, List, Union, Optional
 
 from sycamore import DocSet
+from sycamore.context import context_params, Context
 from sycamore.data import MetadataDocument
 from sycamore.llms.llms import LLM
 from sycamore.llms.prompts.default_prompts import (
@@ -53,7 +54,15 @@ def math_operation(val1: int, val2: int, operator: str) -> Union[int, float]:
         raise ValueError("Invalid math operator " + operator)
 
 
-def summarize_data(llm: LLM, question: str, result_description: str, result_data: List[Any], **kwargs) -> str:
+@context_params
+def summarize_data(
+    llm: LLM,
+    question: str,
+    result_description: str,
+    result_data: List[Any],
+    context: Optional[Context] = None,
+    **kwargs,
+) -> str:
     """
     Provides an English response to a question given relevant information.
 

--- a/lib/sycamore/sycamore/query/execution/sycamore_executor.py
+++ b/lib/sycamore/sycamore/query/execution/sycamore_executor.py
@@ -46,9 +46,9 @@ class SycamoreExecutor:
 
     Args:
         context (Context): The Sycamore context to use.
-        s3_cache_path (str): The S3 path to use for caching queries and results.
-        os_client_args (dict): The OpenSearch client arguments. Defaults to None.
         trace_dir (str, optional): If set, query execution traces will be written to this directory.
+        codegen_mode (bool, optional): If set, query execution traces will be done by generating python code.
+        dry_run (bool, optional): If set, query will not be executed, only generated python code will be returned
     """
 
     def __init__(
@@ -79,7 +79,6 @@ class SycamoreExecutor:
     def process_node(self, logical_node: LogicalOperator, query_id: str) -> Any:
         bind_contextvars(logical_node=logical_node)
         # This is lifted up here to avoid serialization issues with Ray.
-        s3_cache_path = self.s3_cache_path
 
         if logical_node.node_id in self.processed:
             log.info("Already processed")
@@ -116,7 +115,6 @@ class SycamoreExecutor:
                 logical_node=logical_node,
                 query_id=query_id,
                 inputs=inputs,
-                s3_cache_path=s3_cache_path,
                 trace_dir=self.trace_dir,
             )
         elif isinstance(logical_node, BasicFilter):
@@ -133,7 +131,6 @@ class SycamoreExecutor:
                 logical_node=logical_node,
                 query_id=query_id,
                 inputs=inputs,
-                s3_cache_path=s3_cache_path,
                 trace_dir=self.trace_dir,
             )
         elif isinstance(logical_node, Count):
@@ -166,7 +163,6 @@ class SycamoreExecutor:
                 logical_node=logical_node,
                 query_id=query_id,
                 inputs=inputs,
-                s3_cache_path=s3_cache_path,
                 trace_dir=self.trace_dir,
             )
         elif isinstance(logical_node, FieldIn):
@@ -184,7 +180,6 @@ class SycamoreExecutor:
                 logical_node=logical_node,
                 query_id=query_id,
                 inputs=inputs,
-                s3_cache_path=s3_cache_path,
                 trace_dir=self.trace_dir,
             )
         elif isinstance(logical_node, Math):

--- a/lib/sycamore/sycamore/query/execution/sycamore_executor.py
+++ b/lib/sycamore/sycamore/query/execution/sycamore_executor.py
@@ -226,11 +226,6 @@ class SycamoreExecutor:
         result += "from sycamore.query.execution.metrics import SycamoreQueryLogger\n"
         result += "from sycamore.utils.cache import S3Cache\n"
         result += "import sycamore\n\n"
-        # if self.context.params is not None:
-        #     result += f"context_params = {get_str_for_dict(self.context.params)}\n"
-        #     result += f"context = sycamore.init(params=context_params)\n"
-        # else:
-        #     result += "context = sycamore.init()\n\n"
 
         for node_id in sorted(self.node_id_to_node):
             description = self.node_id_to_node[node_id].description.strip("n")
@@ -259,12 +254,12 @@ class SycamoreExecutor:
                 code = self.get_code_string()
                 global_context: dict[str, Any] = {"context": self.context}
                 try:
-                    # Execute the generated code with the global context
                     exec(code, global_context)
-                except Exception:
-                    # Print the full stack trace if an exception occurs
+                except Exception as e:
+                    # exec(..) doesn't seem to print error messages completely, need to traceback
                     print("Exception occurred:")
                     traceback.print_exc()
+                    raise e
                 return global_context.get(self.OUTPUT_VAR_NAME)
 
             return result

--- a/lib/sycamore/sycamore/query/execution/sycamore_executor.py
+++ b/lib/sycamore/sycamore/query/execution/sycamore_executor.py
@@ -54,7 +54,6 @@ class SycamoreExecutor:
     def __init__(
         self,
         context: Context,
-        s3_cache_path: Optional[str] = None,
         trace_dir: Optional[str] = None,
         codegen_mode: bool = False,
         dry_run: bool = False,
@@ -62,14 +61,11 @@ class SycamoreExecutor:
         super().__init__()
 
         self.context = context
-        self.s3_cache_path = s3_cache_path
         self.trace_dir = trace_dir
         self.processed: Dict[int, Any] = dict()
         self.dry_run = dry_run
         self.codegen_mode = codegen_mode
 
-        if self.s3_cache_path:
-            log.info("Using S3 cache path: %s", s3_cache_path)
         if self.trace_dir:
             log.info("Using trace directory: %s", trace_dir)
         self.node_id_to_node: Dict[int, LogicalOperator] = {}

--- a/lib/sycamore/sycamore/query/execution/sycamore_operator.py
+++ b/lib/sycamore/sycamore/query/execution/sycamore_operator.py
@@ -149,8 +149,6 @@ class SycamoreSummarizeData(SycamoreOperator):
         description = self.logical_node.description
         assert self.logical_node.dependencies is not None and len(self.logical_node.dependencies) >= 1
 
-        if self.s3_cache_path:
-            pass
         logical_deps_str = ""
         for i, inp in enumerate(self.logical_node.dependencies):
             logical_deps_str += input_var or get_var_name(inp)
@@ -430,8 +428,6 @@ class SycamoreLlmExtractEntity(SycamoreOperator):
         input_str = input_var or get_var_name(logical_node.dependencies[0])
         output_str = output_var or get_var_name(logical_node)
 
-        if self.s3_cache_path:
-            pass
         result = f"""
 prompt = EntityExtractorMessagesPrompt(
     question='{question}', field='{field}', format='{fmt}', discrete={discrete}
@@ -552,8 +548,6 @@ class SycamoreTopK(SycamoreOperator):
         assert isinstance(logical_node, TopK)
         assert logical_node.dependencies is not None and len(logical_node.dependencies) == 1
 
-        if self.s3_cache_path:
-            pass
         result = f"""
 {output_var or get_var_name(self.logical_node)} = {input_var or get_var_name(logical_node.dependencies[0])}.top_k(
     field='{logical_node.field}',

--- a/lib/sycamore/sycamore/query/execution/sycamore_operator.py
+++ b/lib/sycamore/sycamore/query/execution/sycamore_operator.py
@@ -110,8 +110,6 @@ class SycamoreQueryDatabase(SycamoreOperator):
 class SycamoreSummarizeData(SycamoreOperator):
     """
     Use an LLM to generate a response based on the user input question and provided result set.
-    Args:
-        s3_cache_path (str): Optional S3 path to use for caching
     """
 
     def __init__(
@@ -121,10 +119,8 @@ class SycamoreSummarizeData(SycamoreOperator):
         query_id: str,
         inputs: Optional[List[Any]] = None,
         trace_dir: Optional[str] = None,
-        s3_cache_path: Optional[str] = None,
     ) -> None:
         super().__init__(context, logical_node, query_id, inputs, trace_dir=trace_dir)
-        self.s3_cache_path = s3_cache_path
         assert isinstance(self.logical_node, SummarizeData)
 
     def execute(self) -> Any:
@@ -173,7 +169,6 @@ class SycamoreLlmFilter(SycamoreOperator):
     """
     Use an LLM to filter records on a Docset.
     Args:
-        s3_cache_path (str): Optional S3 path to use for caching
     """
 
     def __init__(
@@ -183,10 +178,8 @@ class SycamoreLlmFilter(SycamoreOperator):
         query_id: str,
         inputs: Optional[List[Any]] = None,
         trace_dir: Optional[str] = None,
-        s3_cache_path: Optional[str] = None,
     ) -> None:
         super().__init__(context, logical_node, query_id, inputs, trace_dir=trace_dir)
-        self.s3_cache_path = s3_cache_path
 
     def execute(self) -> Any:
         assert self.inputs and len(self.inputs) == 1, "LlmFilter requires 1 input node"
@@ -366,8 +359,6 @@ class SycamoreCount(SycamoreOperator):
 class SycamoreLlmExtractEntity(SycamoreOperator):
     """
     Use an LLM to extract information from your data. The data is available for downstream tasks to consume.
-    Args:
-        s3_cache_path (str): Optional S3 path to use for caching
     """
 
     def __init__(
@@ -377,10 +368,8 @@ class SycamoreLlmExtractEntity(SycamoreOperator):
         query_id: str,
         inputs: Optional[List[Any]] = None,
         trace_dir: Optional[str] = None,
-        s3_cache_path: Optional[str] = None,
     ) -> None:
         super().__init__(context, logical_node, query_id, inputs, trace_dir=trace_dir)
-        self.s3_cache_path = s3_cache_path
 
     def execute(self) -> Any:
         assert self.inputs and len(self.inputs) == 1, "LlmExtractEntity requires 1 input node"
@@ -501,8 +490,6 @@ class SycamoreSort(SycamoreOperator):
 class SycamoreTopK(SycamoreOperator):
     """
     Return the Top-K values from a DocSet
-    Args:
-        s3_cache_path (str): Optional S3 path to use for caching when using an LLM
     """
 
     def __init__(
@@ -512,10 +499,8 @@ class SycamoreTopK(SycamoreOperator):
         query_id: str,
         inputs: Optional[List[Any]] = None,
         trace_dir: Optional[str] = None,
-        s3_cache_path: Optional[str] = None,
     ) -> None:
         super().__init__(context, logical_node, query_id, inputs, trace_dir=trace_dir)
-        self.s3_cache_path = s3_cache_path
 
     def execute(self) -> Any:
         assert self.inputs and len(self.inputs) == 1, "TopK requires 1 input node"

--- a/lib/sycamore/sycamore/reader.py
+++ b/lib/sycamore/sycamore/reader.py
@@ -5,6 +5,7 @@ from pandas import DataFrame
 from pyarrow import Table
 from pyarrow.filesystem import FileSystem
 
+from sycamore.context import context_params
 from sycamore.plan_nodes import Node
 from sycamore import Context, DocSet
 from sycamore.data import Document
@@ -209,7 +210,8 @@ class DocSetReader:
         return DocSet(self._context, scan)
 
     @requires_modules("opensearchpy", extra="opensearch")
-    def opensearch(self, os_client_args: dict, index_name: str, query: Optional[Dict] = None) -> DocSet:
+    @context_params
+    def opensearch(self, os_client_args: dict, index_name: str, query: Optional[Dict] = None, **kwargs) -> DocSet:
         """
         Reads the content of an OpenSearch index into a DocSet.
 

--- a/lib/sycamore/sycamore/tests/unit/query/execution/test_sycamore_executor.py
+++ b/lib/sycamore/sycamore/tests/unit/query/execution/test_sycamore_executor.py
@@ -49,6 +49,6 @@ def test_count_docs(test_count_docs_query_plan, mock_sycamore_docsetreader, mock
             }
         )
 
-        executor = SycamoreExecutor(context, s3_cache_path="s3://sycamore-cache")
+        executor = SycamoreExecutor(context)
         result = executor.execute(test_count_docs_query_plan)
         assert result == mock_opensearch_num_docs

--- a/lib/sycamore/sycamore/tests/unit/query/execution/test_sycamore_executor.py
+++ b/lib/sycamore/sycamore/tests/unit/query/execution/test_sycamore_executor.py
@@ -32,19 +32,23 @@ def test_count_docs_query_plan() -> LogicalPlan:
 
 def test_count_docs(test_count_docs_query_plan, mock_sycamore_docsetreader, mock_opensearch_num_docs):
     with patch("sycamore.reader.DocSetReader", new=mock_sycamore_docsetreader):
-        context = sycamore.init()
+        context = sycamore.init(
+            params={
+                "opensearch": {
+                    "os_client_args": {
+                        "hosts": [{"host": "localhost", "port": 9200}],
+                        "http_compress": True,
+                        "http_auth": ("admin", "admin"),
+                        "use_ssl": True,
+                        "verify_certs": False,
+                        "ssl_assert_hostname": False,
+                        "ssl_show_warn": False,
+                        "timeout": 120,
+                    }
+                }
+            }
+        )
 
-        os_client_args = {
-            "hosts": [{"host": "localhost", "port": 9200}],
-            "http_compress": True,
-            "http_auth": ("admin", "admin"),
-            "use_ssl": True,
-            "verify_certs": False,
-            "ssl_assert_hostname": False,
-            "ssl_show_warn": False,
-            "timeout": 120,
-        }
-
-        executor = SycamoreExecutor(context, os_client_args=os_client_args, s3_cache_path="s3://sycamore-cache")
+        executor = SycamoreExecutor(context, s3_cache_path="s3://sycamore-cache")
         result = executor.execute(test_count_docs_query_plan)
         assert result == mock_opensearch_num_docs

--- a/lib/sycamore/sycamore/tests/unit/query/execution/test_sycamore_operator.py
+++ b/lib/sycamore/sycamore/tests/unit/query/execution/test_sycamore_operator.py
@@ -97,7 +97,6 @@ def test_llm_filter():
             new_field="_autogen_LLMFilterOutput",
             prompt=ANY,
             field=logical_node.field,
-            threshold=3,
             name=str(logical_node.node_id),
         )
 

--- a/lib/sycamore/sycamore/tests/unit/query/execution/test_sycamore_operator.py
+++ b/lib/sycamore/sycamore/tests/unit/query/execution/test_sycamore_operator.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch, ANY, Mock
 
 import sycamore
+from sycamore.llms import LLM
 from sycamore.query.operators.field_in import FieldIn
 from sycamore.query.operators.llm_extract_entity import LlmExtractEntity
 from sycamore import DocSet
@@ -30,22 +31,24 @@ from sycamore.query.operators.top_k import TopK
 
 def test_query_database(mock_sycamore_docsetreader, mock_opensearch_num_docs):
     with patch("sycamore.reader.DocSetReader", new=mock_sycamore_docsetreader):
-        context = sycamore.init()
-
-        os_client_args = {
-            "hosts": [{"host": "localhost", "port": 9200}],
-            "http_compress": True,
-            "http_auth": ("admin", "admin"),
-            "use_ssl": True,
-            "verify_certs": False,
-            "ssl_assert_hostname": False,
-            "ssl_show_warn": False,
-            "timeout": 120,
-        }
-        logical_node = QueryDatabase(node_id=0, description="Load data", index="test_index")
-        sycamore_operator = SycamoreQueryDatabase(
-            context=context, logical_node=logical_node, query_id="test", os_client_args=os_client_args
+        context = sycamore.init(
+            params={
+                "opensearch": {
+                    "os_client_args": {
+                        "hosts": [{"host": "localhost", "port": 9200}],
+                        "http_compress": True,
+                        "http_auth": ("admin", "admin"),
+                        "use_ssl": True,
+                        "verify_certs": False,
+                        "ssl_assert_hostname": False,
+                        "ssl_show_warn": False,
+                        "timeout": 120,
+                    }
+                }
+            }
         )
+        logical_node = QueryDatabase(node_id=0, description="Load data", index="test_index")
+        sycamore_operator = SycamoreQueryDatabase(context=context, logical_node=logical_node, query_id="test")
         result = sycamore_operator.execute()
         # Validate result type
         assert isinstance(result, DocSet)
@@ -55,10 +58,7 @@ def test_query_database(mock_sycamore_docsetreader, mock_opensearch_num_docs):
 
 
 def test_summarize_data():
-    with (
-        patch("sycamore.query.execution.sycamore_operator.summarize_data") as mock_impl,
-        patch("sycamore.query.execution.sycamore_operator.OpenAI"),  # disable OpenAI client initialization
-    ):
+    with (patch("sycamore.query.execution.sycamore_operator.summarize_data") as mock_impl,):
         # Define the mock return value
         mock_impl.return_value = "success"
         context = sycamore.init()
@@ -69,7 +69,7 @@ def test_summarize_data():
 
         assert result == "success"
         mock_impl.assert_called_once_with(
-            llm=ANY,
+            context=context,
             question=logical_node.question,
             result_description=logical_node.description,
             result_data=[load_node],
@@ -78,11 +78,8 @@ def test_summarize_data():
 
 
 def test_llm_filter():
-    with (
-        patch("sycamore.query.execution.sycamore_operator.OpenAI"),  # disable OpenAI client initialization
-        patch("sycamore.query.execution.sycamore_operator.LlmFilterMessagesPrompt") as MockLlmFilterMessagesPrompt,
-    ):
-        context = sycamore.init()
+    with (patch("sycamore.query.execution.sycamore_operator.LlmFilterMessagesPrompt") as MockLlmFilterMessagesPrompt,):
+        context = sycamore.init(params={"default": {"llm": Mock(spec=LLM)}})
         doc_set = Mock(spec=DocSet)
         return_doc_set = Mock(spec=DocSet)
         doc_set.llm_filter.return_value = return_doc_set
@@ -97,7 +94,6 @@ def test_llm_filter():
         )
 
         doc_set.llm_filter.assert_called_once_with(
-            llm=ANY,
             new_field="_autogen_LLMFilterOutput",
             prompt=ANY,
             field=logical_node.field,
@@ -202,14 +198,12 @@ def test_join():
 
 def test_llm_extract_entity():
     with (
-        patch("sycamore.query.execution.sycamore_operator.OpenAI"),
         patch(
             "sycamore.query.execution.sycamore_operator.EntityExtractorMessagesPrompt"
         ) as MockEntityExtractorMessagesPrompt,
         patch("sycamore.query.execution.sycamore_operator.OpenAIEntityExtractor") as MockOpenAIEntityExtractor,
     ):
-
-        context = sycamore.init()
+        context = sycamore.init(params={"default": {"llm": Mock(spec=LLM)}})
         doc_set = Mock(spec=DocSet)
         return_doc_set = Mock(spec=DocSet)
         doc_set.extract_entity.return_value = return_doc_set
@@ -231,7 +225,6 @@ def test_llm_extract_entity():
         # assert OpenAIEntityExtractor called with expected arguments
         MockOpenAIEntityExtractor.assert_called_once_with(
             entity_name=logical_node.new_field,
-            llm=ANY,
             use_elements=False,
             prompt=ANY,
             field=logical_node.field,
@@ -263,34 +256,32 @@ def test_sort():
 
 
 def test_top_k():
-    with (patch("sycamore.query.execution.sycamore_operator.OpenAI"),):  # disable OpenAI client initialization
-        context = sycamore.init()
-        doc_set = Mock(spec=DocSet)
-        return_doc_set = Mock(spec=DocSet)
-        doc_set.top_k.return_value = return_doc_set
-        logical_node = TopK(
-            node_id=0,
-            descending=True,
-            K=10,
-            field="name",
-            llm_cluster=True,
-            primary_field="id",
-            llm_cluster_instruction="some description",
-        )
-        sycamore_operator = SycamoreTopK(context, logical_node, query_id="test", inputs=[doc_set])
-        result = sycamore_operator.execute()
+    context = sycamore.init(params={"default": {"llm": Mock(spec=LLM)}})
+    doc_set = Mock(spec=DocSet)
+    return_doc_set = Mock(spec=DocSet)
+    doc_set.top_k.return_value = return_doc_set
+    logical_node = TopK(
+        node_id=0,
+        descending=True,
+        K=10,
+        field="name",
+        llm_cluster=True,
+        primary_field="id",
+        llm_cluster_instruction="some description",
+    )
+    sycamore_operator = SycamoreTopK(context, logical_node, query_id="test", inputs=[doc_set])
+    result = sycamore_operator.execute()
 
-        doc_set.top_k.assert_called_once_with(
-            llm=ANY,
-            field=logical_node.field,
-            k=logical_node.K,
-            descending=logical_node.descending,
-            llm_cluster=logical_node.llm_cluster,
-            unique_field=logical_node.primary_field,
-            llm_cluster_instruction=logical_node.llm_cluster_instruction,
-            **sycamore_operator.get_execute_args(),
-        )
-        assert result == return_doc_set
+    doc_set.top_k.assert_called_once_with(
+        field=logical_node.field,
+        k=logical_node.K,
+        descending=logical_node.descending,
+        llm_cluster=logical_node.llm_cluster,
+        unique_field=logical_node.primary_field,
+        llm_cluster_instruction=logical_node.llm_cluster_instruction,
+        **sycamore_operator.get_execute_args(),
+    )
+    assert result == return_doc_set
 
 
 def test_limit(mock_docs):
@@ -308,11 +299,9 @@ def test_limit(mock_docs):
 
 class ValidationTests(unittest.TestCase):
     def test_query_database_validation(self):
-        context = sycamore.init()
+        context = sycamore.init(params={"opensearch": {"os_client_args": {"test_key": "test_value"}}})
         logical_node = QueryDatabase(node_id=0, description="Load data", index="test_index")
-        sycamore_operator = SycamoreQueryDatabase(
-            context=context, logical_node=logical_node, query_id="test", os_client_args={}
-        )
+        sycamore_operator = SycamoreQueryDatabase(context=context, logical_node=logical_node, query_id="test")
         _ = sycamore_operator.execute()
 
     def test_summarize_data_validation(self):

--- a/lib/sycamore/sycamore/tests/unit/test_context.py
+++ b/lib/sycamore/sycamore/tests/unit/test_context.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import sycamore
-from sycamore.context import context_params, Context
+from sycamore.context import context_params, Context, get_val_from_context
 
 
 def test_init():
@@ -16,6 +16,21 @@ def test_init():
 
     another_context = sycamore.init()
     assert another_context is not context
+
+
+def test_get_val_from_context():
+    params = {"paramKeyA": {"llm": 1}, "paramKeyB": {"llm": ["llm1", "llm2"]}, "default": {"llm": "openai"}}
+    context = Context(params=params)
+
+    assert "openai" == get_val_from_context(context, "llm")
+    assert 1 == get_val_from_context(context, "llm", param_names=["paramKeyA"])
+    assert ["llm1", "llm2"] == get_val_from_context(context, "llm", param_names=["paramKeyB"])
+    assert 1 == get_val_from_context(
+        context, "llm", param_names=["paramKeyA", "paramKeyB"]
+    ), "Unable to assert ordered parameter name retrieval"
+    assert get_val_from_context(context, "missing") is None
+    assert get_val_from_context(Context(), "missing") is None
+    assert get_val_from_context(Context(params={}), "missing") is None
 
 
 @context_params


### PR DESCRIPTION
Allow custom context object in query_client.run_plan/query(..). This allows you to pass in your own objects for query execution (e.g. custom llm).

```python
context = sycamore.init(params={OperationTypes.BINARY_CLASSIFIER: {"llm": MyFancyLLM()}})
query_client.query("How many dogs are cats?", index="catdog", context=context)
...
# llm_filter will use MyFancyLLM
```

Also includes a few more fixes/updates in the lib.