### PR TITLE
Improve materialize

### DIFF
--- a/lib/sycamore/sycamore/__init__.py
+++ b/lib/sycamore/sycamore/__init__.py
@@ -3,5 +3,17 @@ from sycamore.docset import DocSet
 from sycamore.executor import Execution
 from sycamore.materialize_config import MaterializeSourceMode
 
+MATERIALIZE_RECOMPUTE = MaterializeSourceMode.RECOMPUTE
+MATERIALIZE_USE_STORED = MaterializeSourceMode.USE_STORED
 
-__all__ = ["DocSet", "init", "shutdown", "Context", "Execution", "ExecMode", "MaterializeSourceMode"]
+__all__ = [
+    "DocSet",
+    "init",
+    "shutdown",
+    "Context",
+    "Execution",
+    "ExecMode",
+    "MaterializeSourceMode",
+    "MATERIALIZE_RECOMPUTE",
+    "MATERIALIZE_USE_STORED",
+]

--- a/lib/sycamore/sycamore/materialize_config.py
+++ b/lib/sycamore/sycamore/materialize_config.py
@@ -2,5 +2,9 @@ from enum import Enum
 
 
 class MaterializeSourceMode(Enum):
+    RECOMPUTE = 0
+    USE_STORED = 1
+
+    # Deprecated constants
     OFF = 0
     IF_PRESENT = 1


### PR DESCRIPTION
During discussion of the blog post, two things came up:
1. changing the constants used to define the source mode
2. adding clear_materialize() so people don't have to delete the source directories to easily force recomputation.