### PR TITLE
Fix show_pages in Google Colab.

### DIFF
--- a/lib/sycamore/sycamore/utils/image_utils.py
+++ b/lib/sycamore/sycamore/utils/image_utils.py
@@ -240,8 +240,8 @@ def show_images(images: Union[Image.Image, list[Image.Image]], width: int = 600)
     in_jupyter = False
 
     try:
-        ipy_class = get_ipython().__class__.__name__  # type: ignore
-        if ipy_class == "ZMQInteractiveShell":
+        ipy_class = get_ipython().__class__
+        if ipy_class.__name__ == "ZMQInteractiveShell" or ipy_class.__module__ == "google.colab._shell":  # type: ignore
             in_jupyter = True
     except NameError:
         in_jupyter = False

--- a/lib/sycamore/sycamore/utils/image_utils.py
+++ b/lib/sycamore/sycamore/utils/image_utils.py
@@ -240,7 +240,7 @@ def show_images(images: Union[Image.Image, list[Image.Image]], width: int = 600)
     in_jupyter = False
 
     try:
-        ipy_class = get_ipython().__class__
+        ipy_class = get_ipython().__class__  # type: ignore
         if ipy_class.__name__ == "ZMQInteractiveShell" or ipy_class.__module__ == "google.colab._shell":  # type: ignore
             in_jupyter = True
     except NameError:


### PR DESCRIPTION
Colab reports a different IPython shell than Jupyter, and this was throwing off our image drawing code. I don't love checking for colab explicitly, but there doesn't seem to be an easy way to check that the display method is available otherwise.