### PR TITLE
Bugfixes for context_vars

### DIFF
--- a/lib/sycamore/sycamore/context.py
+++ b/lib/sycamore/sycamore/context.py
@@ -2,6 +2,7 @@ import functools
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Optional, Union, List
+import inspect
 
 from sycamore.plan_nodes import Node, NodeTraverse
 
@@ -83,6 +84,8 @@ def get_val_from_context(
 def context_params(*names):
     """
     Applies kwargs from the context to a function call. Requires 'context': Context, to be an argument to the method.
+
+    There is a fair bit of complexity regarding arg management but the comments should be clear.
     """
 
     def decorator(func: Callable) -> Callable:
@@ -91,26 +94,44 @@ def context_params(*names):
             self = args[0] if len(args) > 0 else {}
             ctx = kwargs.get("context", getattr(self, "context", getattr(self, "_context", None)))
             if ctx and ctx.params:
-                new_kwargs = {}
-                new_kwargs.update(ctx.params.get("default", {}))
-                qual_name = func.__qualname__  # e.g. 'DocSetWriter.opensearch'
-                function_name_wo_class = qual_name.split(".")[-1]
-                new_kwargs.update(ctx.params.get(function_name_wo_class, {}))
-                new_kwargs.update(ctx.params.get(qual_name, {}))
-
-                for i in names:
-                    new_kwargs.update(ctx.params.get(i, {}))
-                new_kwargs.update(kwargs)
 
                 """
-                If positional args are provided, we want to pop those keys from new_kwargs that have been deduced 
-                from context
+                Create argument candidates 'candidate_kwargs' from the Context
+                """
+                candidate_kwargs = {}
+                candidate_kwargs.update(ctx.params.get("default", {}))
+                qual_name = func.__qualname__  # e.g. 'DocSetWriter.opensearch'
+                function_name_wo_class = qual_name.split(".")[-1]  # e.g. 'opensearch'
+                candidate_kwargs.update(ctx.params.get(function_name_wo_class, {}))
+                candidate_kwargs.update(ctx.params.get(qual_name, {}))
+
+                """
+                If positional args are provided, we want to pop those keys from candidate_kwargs
                 """
                 signature = func.__code__.co_varnames[: func.__code__.co_argcount]
                 for param in signature[: len(args)]:
-                    if param == "self":
-                        continue
-                    new_kwargs.pop(param)
+                    candidate_kwargs.pop(param, None)
+
+                """
+                If the function doesn't accept arbitrary kwargs, we don't want to use candidate_kwargs that aren't in 
+                the function signature.
+                """
+                new_kwargs = {}
+                sig = inspect.signature(func)
+                accepts_kwargs = any(param.kind == param.VAR_KEYWORD for param in sig.parameters.values())
+
+                if accepts_kwargs:
+                    new_kwargs = candidate_kwargs
+                else:
+                    for param in signature[len(args) :]:  # arguments that haven't been passed as positional args
+                        new_kwargs[param] = candidate_kwargs.get(param)
+
+                """
+                Put in user provided kwargs (either through decorator param or function call)
+                """
+                for i in names:
+                    new_kwargs.update(ctx.params.get(i, {}))
+                new_kwargs.update(kwargs)
 
                 return func(*args, **new_kwargs)
             else:

--- a/lib/sycamore/sycamore/docset.py
+++ b/lib/sycamore/sycamore/docset.py
@@ -1137,7 +1137,7 @@ class DocSet:
     @context_params(OperationTypes.INFORMATION_EXTRACTOR)
     def top_k(
         self,
-        llm: LLM,
+        llm: Optional[LLM],
         field: str,
         k: Optional[int],
         descending: bool = True,
@@ -1181,7 +1181,7 @@ class DocSet:
         return docset
 
     @context_params(OperationTypes.INFORMATION_EXTRACTOR)
-    def llm_cluster_entity(self, llm: LLM, instruction: str, field: str) -> "DocSet":
+    def llm_cluster_entity(self, llm: LLM, instruction: str, field: str, **kwargs) -> "DocSet":
         """
         Normalizes a particular field of a DocSet. Identifies and assigns each document to a "group".
 

--- a/lib/sycamore/sycamore/tests/unit/test_context.py
+++ b/lib/sycamore/sycamore/tests/unit/test_context.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import sycamore
-from sycamore.context import context_params, Context, get_val_from_context
+from sycamore.context import context_params, Context, get_val_from_context, ExecMode
 
 
 def test_init():
@@ -71,3 +71,52 @@ def test_function_w_class_context():
 
     # ensure explicit arg overrides context
     assert "B" == obj.get_first_character_w_class_context("Baryn")
+
+
+@context_params
+def two_positional_args_method(some_function_arg: str, some_other_arg: str, context: Optional[Context] = None):
+    assert some_function_arg is not None
+    assert some_other_arg is not None
+    return some_function_arg + " " + some_other_arg
+
+
+@context_params
+def two_positional_args_method_with_kwargs(some_function_arg: str, context: Optional[Context] = None, **kwargs):
+    assert some_function_arg is not None
+    assert kwargs.get("some_other_arg") is not None
+    return some_function_arg + " " + str(kwargs.get("some_other_arg"))
+
+
+def test_positional_args_and_context_args():
+    context = Context(
+        params={"default": {"some_other_arg": "Aryn2", "some_unrelated_arg": "ArynZ"}}, exec_mode=ExecMode.LOCAL
+    )
+
+    # no context
+    assert "a b" == two_positional_args_method("a", "b")
+
+    # Should ignore context vars because of positional args
+    assert "a b" == two_positional_args_method("a", "b", context=context)
+
+    # Pickup 'some_other_arg' from context
+    assert "a Aryn2" == two_positional_args_method(some_function_arg="a", context=context)
+
+    # Should ignore context vars because of kwargs
+    assert "a b" == two_positional_args_method(some_function_arg="a", some_other_arg="b", context=context)
+
+    # Combine positional and kwarg
+    assert "a b" == two_positional_args_method_with_kwargs("a", some_other_arg="b", context=context)
+
+
+def test_positional_args_and_context_args_f_with_kwargs():
+    context = Context(
+        params={"default": {"some_other_arg": "Aryn2", "some_unrelated_arg": "ArynZ"}}, exec_mode=ExecMode.LOCAL
+    )
+    # Pickup 'some_other_arg' from context
+    assert "a Aryn2" == two_positional_args_method_with_kwargs(some_function_arg="a", context=context)
+
+    # Should ignore context vars because of kwargs
+    assert "a b" == two_positional_args_method_with_kwargs(some_function_arg="a", some_other_arg="b", context=context)
+
+    # Combine positional and kwarg
+    assert "a b" == two_positional_args_method_with_kwargs("a", some_other_arg="b", context=context)

--- a/lib/sycamore/sycamore/tests/unit/test_docset.py
+++ b/lib/sycamore/sycamore/tests/unit/test_docset.py
@@ -86,7 +86,7 @@ class TestDocSet:
             Document(text_representation="1", parent_id=13),
             Document(text_representation="3", parent_id=5),
         ]
-        context = sycamore.init()
+        context = sycamore.init(params={"default": {"llm": MockLLM()}})
         return context.read.document(doc_list)
 
     @pytest.fixture
@@ -448,7 +448,6 @@ class TestDocSet:
 
     def test_top_k_llm_cluster(self, number_docset):
         top_k_docset = number_docset.top_k(
-            llm=MockLLM(),
             field="text_representation",
             k=2,
             descending=True,
@@ -464,7 +463,7 @@ class TestDocSet:
         assert top_k_list[1].properties["count"] == 2
 
     def test_llm_cluster_entity(self, number_docset):
-        cluster_docset = number_docset.llm_cluster_entity(llm=MockLLM(), instruction="", field="text_representation")
+        cluster_docset = number_docset.llm_cluster_entity(instruction="", field="text_representation")
         for doc in cluster_docset.take():
             if doc.text_representation == "1" or doc.text_representation == "one":
                 assert doc.properties["_autogen_ClusterAssignment"] == "group1"


### PR DESCRIPTION
A few fixes and improvements in @contextvars. This fixes top_k with LLMs being broken currently

1. Bugfix to handle popping keys that don't exist in new kwargs
2. Handle cases where a function might not accept **kwargs and we try to send extra args. In this case we only want to send args that the signature allows
3. Updated top_k and llm_cluster tests to use LLMs from the context
4. Added a bunch of comments in the @contextvars implementation to explain what's going on