### PR TITLE
Fix function signature reading in contextvars

### DIFF
--- a/lib/sycamore/sycamore/context.py
+++ b/lib/sycamore/sycamore/context.py
@@ -108,7 +108,8 @@ def context_params(*names):
                 """
                 If positional args are provided, we want to pop those keys from candidate_kwargs
                 """
-                signature = func.__code__.co_varnames[: func.__code__.co_argcount]
+                sig = inspect.signature(func)
+                signature = list(sig.parameters.keys())
                 for param in signature[: len(args)]:
                     candidate_kwargs.pop(param, None)
 
@@ -117,7 +118,6 @@ def context_params(*names):
                 the function signature.
                 """
                 new_kwargs = {}
-                sig = inspect.signature(func)
                 accepts_kwargs = any(param.kind == param.VAR_KEYWORD for param in sig.parameters.values())
 
                 if accepts_kwargs:

--- a/lib/sycamore/sycamore/tests/integration/connectors/opensearch/test_pdf_to_opensearch.py
+++ b/lib/sycamore/sycamore/tests/integration/connectors/opensearch/test_pdf_to_opensearch.py
@@ -123,7 +123,7 @@ def test_pdf_to_opensearch_with_llm_caching():
                     "index_settings": index_settings,
                 },
             },
-            exec_mode=ExecMode.LOCAL
+            exec_mode=ExecMode.LOCAL,
         )
         ds = (
             context.read.binary(paths, binary_format="pdf")

--- a/lib/sycamore/sycamore/tests/integration/connectors/opensearch/test_pdf_to_opensearch.py
+++ b/lib/sycamore/sycamore/tests/integration/connectors/opensearch/test_pdf_to_opensearch.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 from opensearchpy import OpenSearch
 
 import sycamore
-from sycamore.context import OperationTypes
+from sycamore.context import OperationTypes, ExecMode
 from sycamore.functions import HuggingFaceTokenizer
 from sycamore.llms import OpenAIModels, OpenAI
 from sycamore.tests.config import TEST_DIR
@@ -123,6 +123,7 @@ def test_pdf_to_opensearch_with_llm_caching():
                     "index_settings": index_settings,
                 },
             },
+            exec_mode=ExecMode.LOCAL
         )
         ds = (
             context.read.binary(paths, binary_format="pdf")

--- a/lib/sycamore/sycamore/tests/unit/test_context.py
+++ b/lib/sycamore/sycamore/tests/unit/test_context.py
@@ -104,7 +104,6 @@ def test_positional_args_and_context_args():
     # Should ignore context vars because of kwargs
     assert "a b" == two_positional_args_method(some_function_arg="a", some_other_arg="b", context=context)
 
-
     # Combine positional and kwarg
     assert "a b" == two_positional_args_method_with_kwargs("a", some_other_arg="b", context=context)
 

--- a/lib/sycamore/sycamore/tests/unit/test_context.py
+++ b/lib/sycamore/sycamore/tests/unit/test_context.py
@@ -104,6 +104,7 @@ def test_positional_args_and_context_args():
     # Should ignore context vars because of kwargs
     assert "a b" == two_positional_args_method(some_function_arg="a", some_other_arg="b", context=context)
 
+
     # Combine positional and kwarg
     assert "a b" == two_positional_args_method_with_kwargs("a", some_other_arg="b", context=context)
 

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_entity_extraction.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_entity_extraction.py
@@ -62,9 +62,11 @@ class TestEntityExtraction:
     def test_extract_entity_w_context_llm(self, mocker):
         node = mocker.Mock(spec=Node)
         llm = MockLLM()
-        context = Context(params={
-            "default": {"llm": llm},
-        })
+        context = Context(
+            params={
+                "default": {"llm": llm},
+            }
+        )
         extract_entity = ExtractEntity(node, context=context, entity_extractor=OpenAIEntityExtractor("title"))
         input_dataset = ray.data.from_items([{"doc": self.doc.serialize()}])
         execute = mocker.patch.object(node, "execute")

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_entity_extraction.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_entity_extraction.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import ray.data
 
+from sycamore import Context
 from sycamore.data import Document
 from sycamore.plan_nodes import Node
 from sycamore.transforms import ExtractEntity
@@ -52,6 +53,19 @@ class TestEntityExtraction:
         node = mocker.Mock(spec=Node)
         llm = MockLLM()
         extract_entity = ExtractEntity(node, entity_extractor=OpenAIEntityExtractor("title", llm=llm))
+        input_dataset = ray.data.from_items([{"doc": self.doc.serialize()}])
+        execute = mocker.patch.object(node, "execute")
+        execute.return_value = input_dataset
+        output_dataset = extract_entity.execute()
+        assert Document.from_row(output_dataset.take(1)[0]).properties.get("title") == "title"
+
+    def test_extract_entity_w_context_llm(self, mocker):
+        node = mocker.Mock(spec=Node)
+        llm = MockLLM()
+        context = Context(params={
+            "default": {"llm": llm},
+        })
+        extract_entity = ExtractEntity(node, context=context, entity_extractor=OpenAIEntityExtractor("title"))
         input_dataset = ray.data.from_items([{"doc": self.doc.serialize()}])
         execute = mocker.patch.object(node, "execute")
         execute.return_value = input_dataset


### PR DESCRIPTION
`func.__code__.co_varnames[: func.__code__.co_argcount]` doesn't run reliably to inspect a function (as exposed by extract_entity because it's double decorated). Changed to use the inspect lib.