### PR TITLE
Add natural language result flag.

### DIFF
--- a/lib/sycamore/sycamore/query/planner.py
+++ b/lib/sycamore/sycamore/query/planner.py
@@ -107,7 +107,7 @@ class LlmPlanner:
         self._use_examples = use_examples
         self._natural_language_response = natural_language_response
 
-    def make_operator_prompt(self, operator: LogicalOperator) -> str:
+    def make_operator_prompt(self, operator: Type[LogicalOperator]) -> str:
         """Generate the prompt fragment for the given LogicalOperator."""
 
         prompt = operator.usage() + "\n\nInput schema:\n"

--- a/lib/sycamore/sycamore/query/planner.py
+++ b/lib/sycamore/sycamore/query/planner.py
@@ -60,8 +60,14 @@ guidelines when generating a plan:
         5. If an optional field does not have a value in the query plan, return null in its place.
         6. If you cannot generate a plan to answer a question, return an empty list.
         7. The first step of each plan MUST be a **QueryDatabase** operation that returns a database.
-        8. The last step of each plan should return the raw data associated with the response.
 """
+
+# Variants on the last step in the query plan, based on whether the user has requested raw data
+# or a natural language response.
+PLANNER_RAW_DATA_PROMPT = "8. The last step of each plan should return the raw data associated with the response."
+PLANNER_NATURAL_LANGUAGE_PROMPT = (
+    "8. The last step of each plan *MUST* be a **SummarizeData** operation that returns a natural language response."
+)
 
 
 class LlmPlanner:
@@ -76,6 +82,8 @@ class LlmPlanner:
         operators: A list of operators to use in the query plan.
         llm_client: The LLM client.
         use_examples: Whether to include examples in the prompt.
+        natural_language_response: Whether to generate a natural language response. If False,
+            the response will be raw data.
     """
 
     def __init__(
@@ -87,6 +95,7 @@ class LlmPlanner:
         operators: Optional[List[Type[LogicalOperator]]] = None,
         llm_client: Optional[LLM] = None,
         use_examples: bool = True,
+        natural_language_response: bool = False,
     ) -> None:
         super().__init__()
         self._index = index
@@ -96,6 +105,7 @@ class LlmPlanner:
         self._os_client = os_client
         self._llm_client = llm_client or OpenAI(OpenAIModels.GPT_4O.value)
         self._use_examples = use_examples
+        self._natural_language_response = natural_language_response
 
     def make_operator_prompt(self, operator: LogicalOperator) -> str:
         """Generate the prompt fragment for the given LogicalOperator."""
@@ -117,10 +127,15 @@ class LlmPlanner:
             indent=2,
         )
 
-    def generate_system_prompt(self, query):
+    def generate_system_prompt(self, query: str) -> str:
         """Generate the LLM system prompt for the given query."""
 
         prompt = PLANNER_SYSTEM_PROMPT
+
+        if self._natural_language_response:
+            prompt += PLANNER_NATURAL_LANGUAGE_PROMPT
+        else:
+            prompt += PLANNER_RAW_DATA_PROMPT
 
         # data schema
         prompt += f"""\n

--- a/lib/sycamore/sycamore/tests/unit/query/test_planner.py
+++ b/lib/sycamore/sycamore/tests/unit/query/test_planner.py
@@ -20,13 +20,42 @@ def mock_llm_client():
     return MagicMock()
 
 
-def test_llm_planner(mock_os_config, mock_os_client, mock_llm_client, monkeypatch):
-    index = "test_index"
+@pytest.fixture
+def mock_schema():
     schema = {
-        "description": "Database of airplane incidents",
-        "incidentId": "(string) e.g. A123G73",
-        "date": "(string: YYYY-MM-DD) e.g. 2022-01-01, 2024-02-10",
+        "incidentId": ("string", {"A1234, B1234, C1234"}),
+        "date": ("string", {"2022-01-01", "2024-02-10"}),
     }
+    return schema
+
+
+def test_generate_system_prompt(mock_schema):
+    index = "test_index"
+    planner = LlmPlanner(
+        index,
+        data_schema=mock_schema,
+        os_config=mock_os_config,
+        os_client=mock_os_client,
+        llm_client=mock_llm_client,
+        natural_language_response=True,
+    )
+    prompt = planner.generate_system_prompt("Test query")
+    assert "The last step of each plan *MUST* be a **SummarizeData** operation" in prompt
+
+    planner = LlmPlanner(
+        index,
+        data_schema=mock_schema,
+        os_config=mock_os_config,
+        os_client=mock_os_client,
+        llm_client=mock_llm_client,
+        natural_language_response=False,
+    )
+    prompt = planner.generate_system_prompt("Test query")
+    assert "The last step of each plan should return the raw data" in prompt
+
+
+def test_llm_planner(mock_os_config, mock_os_client, mock_llm_client, mock_schema, monkeypatch):
+    index = "test_index"
 
     # Mock the generate_from_llm method to return a static JSON object
     def mock_generate_from_llm(self, query):
@@ -69,10 +98,11 @@ def test_llm_planner(mock_os_config, mock_os_client, mock_llm_client, monkeypatc
 
     planner = LlmPlanner(
         index,
-        data_schema=schema,
+        data_schema=mock_schema,
         os_config=mock_os_config,
         os_client=mock_os_client,
         llm_client=mock_llm_client,
+        natural_language_response=True,
     )
 
     plan = planner.plan("Dummy query")


### PR DESCRIPTION
This PR adds a flag to the SycamoreQueryClient requesting a natural language response. This allows apps to request either natural language or raw data, based on what they need.
