### PR TITLE
Update default threshold values for ArynPartitioner.

### DIFF
--- a/lib/sycamore/sycamore/transforms/detr_partitioner.py
+++ b/lib/sycamore/sycamore/transforms/detr_partitioner.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from concurrent.futures import ProcessPoolExecutor
 from io import BytesIO, IOBase
-from typing import cast, Any, BinaryIO, List, Tuple, Union, Optional
+from typing import cast, Any, BinaryIO, List, Literal, Tuple, Union, Optional
 from pathlib import Path
 import pwd
 
@@ -45,6 +45,7 @@ def _batchify(iterable, n=1):
 ARYN_DETR_MODEL = "Aryn/deformable-detr-DocLayNet"
 DEFAULT_ARYN_PARTITIONER_ADDRESS = "https://api.aryn.cloud/v1/document/partition"
 _TEN_MINUTES = 600
+DEFAULT_LOCAL_THRESHOLD = 0.35
 
 
 class ArynPDFPartitionerException(Exception):
@@ -132,7 +133,7 @@ class ArynPDFPartitioner:
     def partition_pdf(
         self,
         file: BinaryIO,
-        threshold: float = 0.4,
+        threshold: Union[float, Literal["auto"]] = DEFAULT_LOCAL_THRESHOLD,
         use_ocr=False,
         ocr_images=False,
         ocr_tables=False,
@@ -149,6 +150,7 @@ class ArynPDFPartitioner:
     ) -> List[Element]:
         if use_partitioning_service:
             assert aryn_api_key != ""
+
             return self._partition_remote(
                 file=file,
                 aryn_api_key=aryn_api_key,
@@ -162,6 +164,9 @@ class ArynPDFPartitioner:
                 pages_per_call=pages_per_call,
             )
         else:
+            if isinstance(threshold, str):
+                raise ValueError("Auto threshold is only supported with the Aryn Partitioning Service.")
+
             if batch_at_a_time:
                 temp = self._partition_pdf_batched(
                     file=file,
@@ -205,7 +210,7 @@ class ArynPDFPartitioner:
         file: BinaryIO,
         aryn_api_key: str,
         aryn_partitioner_address=DEFAULT_ARYN_PARTITIONER_ADDRESS,
-        threshold: float = 0.4,
+        threshold: Union[float, Literal["auto"]] = "auto",
         use_ocr: bool = False,
         ocr_images: bool = False,
         ocr_tables: bool = False,
@@ -314,7 +319,7 @@ class ArynPDFPartitioner:
         file: BinaryIO,
         aryn_api_key: str,
         aryn_partitioner_address=DEFAULT_ARYN_PARTITIONER_ADDRESS,
-        threshold: float = 0.4,
+        threshold: Union[float, Literal["auto"]] = "auto",
         use_ocr: bool = False,
         ocr_images: bool = False,
         ocr_tables: bool = False,
@@ -353,7 +358,7 @@ class ArynPDFPartitioner:
     def _partition_pdf_sequenced(
         self,
         file: BinaryIO,
-        threshold: float = 0.4,
+        threshold: float = DEFAULT_LOCAL_THRESHOLD,
         use_ocr=False,
         ocr_images=False,
         ocr_tables=False,
@@ -456,7 +461,7 @@ class ArynPDFPartitioner:
     def _partition_pdf_batched(
         self,
         file: BinaryIO,
-        threshold: float = 0.4,
+        threshold: float = DEFAULT_LOCAL_THRESHOLD,
         use_ocr=False,
         ocr_images=False,
         ocr_tables=False,
@@ -498,7 +503,7 @@ class ArynPDFPartitioner:
         self,
         filename: str,
         hash_key: str,
-        threshold: float = 0.4,
+        threshold: float = DEFAULT_LOCAL_THRESHOLD,
         use_ocr=False,
         ocr_images=False,
         ocr_tables=False,

--- a/lib/sycamore/sycamore/transforms/partition.py
+++ b/lib/sycamore/sycamore/transforms/partition.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod, ABC
 import io
-from typing import Any, Optional
+from typing import Any, Literal, Optional, Union
 
 from bs4 import BeautifulSoup
 
@@ -18,7 +18,11 @@ from sycamore.utils.time_trace import timetrace
 from sycamore.utils import choose_device
 from sycamore.utils.aryn_config import ArynConfig
 
-from sycamore.transforms.detr_partitioner import ARYN_DETR_MODEL, DEFAULT_ARYN_PARTITIONER_ADDRESS
+from sycamore.transforms.detr_partitioner import (
+    ARYN_DETR_MODEL,
+    DEFAULT_ARYN_PARTITIONER_ADDRESS,
+    DEFAULT_LOCAL_THRESHOLD,
+)
 
 
 def _pageless_reorder_comparator(element1: Element, element2: Element) -> int:
@@ -387,9 +391,11 @@ class ArynPartitioner(Partitioner):
         model_name_or_path: The HuggingFace coordinates or model local path. Should be set to
              the default ARYN_DETR_MODEL unless you are testing a custom model.
              Ignored when local mode is false
-        threshold: The threshold to use for accepting the model's predicted bounding boxes. A lower
-             value will include more objects, but may have overlaps, a higher value will reduce the
-             number of overlaps, but may miss legitimate objects.
+        threshold: The threshold to use for accepting the model's predicted bounding boxes. When using
+             the Aryn Partitioning Service, this defaults to "auto", where the service will automatically
+             find the best predictions. You can override this or set it locally by specifying a numerical
+             threshold between 0 and 1. A lower value will include more objects, but may have overlaps,
+             while a higher value will reduce the number of overlaps, but may miss legitimate objects.
         use_ocr: Whether to use OCR to extract text from the PDF. If false, we will attempt to extract
              the text from the underlying PDF.
         ocr_images: If set with use_ocr, will attempt to OCR regions of the document identified as images.
@@ -431,7 +437,7 @@ class ArynPartitioner(Partitioner):
     def __init__(
         self,
         model_name_or_path=ARYN_DETR_MODEL,
-        threshold: float = 0.4,
+        threshold: Optional[Union[float, Literal["auto"]]] = None,
         use_ocr: bool = False,
         ocr_images: bool = False,
         ocr_tables: bool = False,
@@ -459,7 +465,17 @@ class ArynPartitioner(Partitioner):
             self._aryn_api_key = aryn_api_key
         self._model_name_or_path = model_name_or_path
         self._device = device
-        self._threshold = threshold
+
+        if threshold is None:
+            if use_partitioning_service:
+                self._threshold: Union[float, Literal["auto"]] = "auto"
+            else:
+                self._threshold = DEFAULT_LOCAL_THRESHOLD
+        else:
+            if not isinstance(threshold, float) and not use_partitioning_service:
+                raise ValueError("Auto threshold is only supported with the Aryn Partitioning Service.")
+            self._threshold = threshold
+
         self._use_ocr = use_ocr
         self._ocr_images = ocr_images
         self._ocr_tables = ocr_tables


### PR DESCRIPTION
Sets the default to "auto" when using the remote partitioner and 0.35 when running locally. Also updates all of the type signatures so that type checking passes.