### PR TITLE
Add QueryVectorDatabase to SycamoreQuery

### DIFF
--- a/lib/sycamore/sycamore/connectors/opensearch/utils.py
+++ b/lib/sycamore/sycamore/connectors/opensearch/utils.py
@@ -7,6 +7,10 @@ from sycamore.transforms import Embedder
 
 @context_params("opensearch")
 def get_knn_query(text_embedder: Embedder, query_phrase: str, k: int = 500, context: Optional[Context] = None):
+    """
+    Given a query string and an Embedder, create a simple OpenSearch Knn query. Uses a default k value of 500.
+    This is only the base query, if you need to add filters or other specifics you can extend the object.
+    """
     embedding = text_embedder.generate_text_embedding(query_phrase)
     query = {
         "query": {

--- a/lib/sycamore/sycamore/connectors/opensearch/utils.py
+++ b/lib/sycamore/sycamore/connectors/opensearch/utils.py
@@ -1,0 +1,21 @@
+from typing import Optional
+
+from sycamore import Context
+from sycamore.context import context_params
+from sycamore.transforms import Embedder
+
+
+@context_params("opensearch")
+def get_knn_query(text_embedder: Embedder, query_phrase: str, k: int = 500, context: Optional[Context] = None):
+    embedding = text_embedder.generate_text_embedding(query_phrase)
+    query = {
+        "query": {
+            "knn": {
+                "embedding": {
+                    "vector": embedding,
+                    "k": k,
+                }
+            }
+        }
+    }
+    return query

--- a/lib/sycamore/sycamore/context.py
+++ b/lib/sycamore/sycamore/context.py
@@ -104,6 +104,8 @@ def context_params(*names):
                 function_name_wo_class = qual_name.split(".")[-1]  # e.g. 'opensearch'
                 candidate_kwargs.update(ctx.params.get(function_name_wo_class, {}))
                 candidate_kwargs.update(ctx.params.get(qual_name, {}))
+                for i in names:
+                    candidate_kwargs.update(ctx.params.get(i, {}))
 
                 """
                 If positional args are provided, we want to pop those keys from candidate_kwargs
@@ -123,14 +125,14 @@ def context_params(*names):
                 if accepts_kwargs:
                     new_kwargs = candidate_kwargs
                 else:
-                    for param in signature[len(args) :]:  # arguments that haven't been passed as positional args
-                        new_kwargs[param] = candidate_kwargs.get(param)
+                    for param in signature[len(args):]:  # arguments that haven't been passed as positional args
+                        candidate_val = candidate_kwargs.get(param)
+                        if candidate_val:
+                            new_kwargs[param] = candidate_val
 
                 """
                 Put in user provided kwargs (either through decorator param or function call)
                 """
-                for i in names:
-                    new_kwargs.update(ctx.params.get(i, {}))
                 new_kwargs.update(kwargs)
 
                 return func(*args, **new_kwargs)

--- a/lib/sycamore/sycamore/context.py
+++ b/lib/sycamore/sycamore/context.py
@@ -125,7 +125,7 @@ def context_params(*names):
                 if accepts_kwargs:
                     new_kwargs = candidate_kwargs
                 else:
-                    for param in signature[len(args):]:  # arguments that haven't been passed as positional args
+                    for param in signature[len(args) :]:  # arguments that haven't been passed as positional args
                         candidate_val = candidate_kwargs.get(param)
                         if candidate_val:
                             new_kwargs[param] = candidate_val

--- a/lib/sycamore/sycamore/docset.py
+++ b/lib/sycamore/sycamore/docset.py
@@ -894,7 +894,7 @@ class DocSet:
         flat_map = FlatMap(self.plan, f=f, **resource_args)
         return DocSet(self.context, flat_map)
 
-    def filter(self, f: Callable[[Document], bool], **resource_args) -> "DocSet":
+    def filter(self, f: Callable[[Document], bool], **kwargs) -> "DocSet":
         """
         Applies the Filter transform on the Docset.
 
@@ -917,7 +917,7 @@ class DocSet:
         """
         from sycamore.transforms import Filter
 
-        filtered = Filter(self.plan, f=f, **resource_args)
+        filtered = Filter(self.plan, f=f, **kwargs)
         return DocSet(self.context, filtered)
 
     def filter_elements(self, f: Callable[[Element], bool], **resource_args) -> "DocSet":

--- a/lib/sycamore/sycamore/query/client.py
+++ b/lib/sycamore/sycamore/query/client.py
@@ -21,6 +21,7 @@ import structlog
 import sycamore
 from sycamore import Context
 from sycamore.llms.openai import OpenAI, OpenAIModels
+from sycamore.transforms.embed import SentenceTransformerEmbedder
 from sycamore.transforms.query import OpenSearchQueryExecutor
 from sycamore.utils.cache import cache_from_path
 from sycamore.utils.import_utils import requires_modules
@@ -210,10 +211,12 @@ class SycamoreQueryClient:
     def _get_default_context(s3_cache_path, os_client_args) -> Context:
         context_params = {
             "default": {
-                "llm": OpenAI(OpenAIModels.GPT_4O.value, cache=cache_from_path(s3_cache_path)),
+                "llm": OpenAI(OpenAIModels.GPT_4O.value, cache=cache_from_path(s3_cache_path))
             },
             "opensearch": {
                 "os_client_args": os_client_args,
+                "text_embedder": SentenceTransformerEmbedder(batch_size=100,
+                                                             model_name="sentence-transformers/all-MiniLM-L6-v2")
             },
         }
         return sycamore.init(params=context_params)

--- a/lib/sycamore/sycamore/query/client.py
+++ b/lib/sycamore/sycamore/query/client.py
@@ -210,13 +210,12 @@ class SycamoreQueryClient:
     @staticmethod
     def _get_default_context(s3_cache_path, os_client_args) -> Context:
         context_params = {
-            "default": {
-                "llm": OpenAI(OpenAIModels.GPT_4O.value, cache=cache_from_path(s3_cache_path))
-            },
+            "default": {"llm": OpenAI(OpenAIModels.GPT_4O.value, cache=cache_from_path(s3_cache_path))},
             "opensearch": {
                 "os_client_args": os_client_args,
-                "text_embedder": SentenceTransformerEmbedder(batch_size=100,
-                                                             model_name="sentence-transformers/all-MiniLM-L6-v2")
+                "text_embedder": SentenceTransformerEmbedder(
+                    batch_size=100, model_name="sentence-transformers/all-MiniLM-L6-v2"
+                ),
             },
         }
         return sycamore.init(params=context_params)

--- a/lib/sycamore/sycamore/query/execution/sycamore_executor.py
+++ b/lib/sycamore/sycamore/query/execution/sycamore_executor.py
@@ -10,7 +10,7 @@ from sycamore.query.operators.limit import Limit
 from sycamore.query.operators.llm_extract_entity import LlmExtractEntity
 from sycamore.query.operators.llm_filter import LlmFilter
 from sycamore.query.operators.summarize_data import SummarizeData
-from sycamore.query.operators.query_database import QueryDatabase
+from sycamore.query.operators.query_database import QueryDatabase, QueryVectorDatabase
 from sycamore.query.operators.logical_operator import LogicalOperator
 from sycamore.query.execution.physical_operator import PhysicalOperator
 from sycamore.query.operators.math import Math
@@ -31,7 +31,7 @@ from sycamore.query.execution.sycamore_operator import (
     SycamoreTopK,
     SycamoreSort,
     SycamoreLimit,
-    SycamoreFieldIn,
+    SycamoreFieldIn, SycamoreQueryVectorDatabase,
 )
 from sycamore.query.logical_plan import LogicalPlan
 
@@ -104,6 +104,13 @@ class SycamoreExecutor:
         operation: Optional[PhysicalOperator] = None
         if isinstance(logical_node, QueryDatabase):
             operation = SycamoreQueryDatabase(
+                context=self.context,
+                logical_node=logical_node,
+                query_id=query_id,
+                trace_dir=self.trace_dir,
+            )
+        elif isinstance(logical_node, QueryVectorDatabase):
+            operation = SycamoreQueryVectorDatabase(
                 context=self.context,
                 logical_node=logical_node,
                 query_id=query_id,

--- a/lib/sycamore/sycamore/query/execution/sycamore_executor.py
+++ b/lib/sycamore/sycamore/query/execution/sycamore_executor.py
@@ -31,7 +31,8 @@ from sycamore.query.execution.sycamore_operator import (
     SycamoreTopK,
     SycamoreSort,
     SycamoreLimit,
-    SycamoreFieldIn, SycamoreQueryVectorDatabase,
+    SycamoreFieldIn,
+    SycamoreQueryVectorDatabase,
 )
 from sycamore.query.logical_plan import LogicalPlan
 

--- a/lib/sycamore/sycamore/query/execution/sycamore_operator.py
+++ b/lib/sycamore/sycamore/query/execution/sycamore_operator.py
@@ -132,9 +132,7 @@ class SycamoreQueryVectorDatabase(SycamoreOperator):
     def execute(self) -> Any:
         assert isinstance(self.logical_node, QueryVectorDatabase)
         embedder = get_val_from_context(context=self.context, val_key="text_embedder", param_names=["opensearch"])
-        assert (
-            embedder and isinstance(embedder, Embedder)
-        ), "QueryVectorDatabase requires an Embedder in the context"
+        assert embedder and isinstance(embedder, Embedder), "QueryVectorDatabase requires an Embedder in the context"
 
         assert (
             get_val_from_context(context=self.context, val_key="os_client_args", param_names=["opensearch"]) is not None
@@ -158,7 +156,8 @@ os_query["query"]["knn"]["embedding"]["filter"] = {self.logical_node.filter}"""
     query=os_query
 )
 """
-        return (result,
+        return (
+            result,
             ["from sycamore.connectors.opensearch.utils import get_knn_query"],
         )
 

--- a/lib/sycamore/sycamore/query/execution/sycamore_operator.py
+++ b/lib/sycamore/sycamore/query/execution/sycamore_operator.py
@@ -138,18 +138,18 @@ class SycamoreQueryVectorDatabase(SycamoreOperator):
             get_val_from_context(context=self.context, val_key="os_client_args", param_names=["opensearch"]) is not None
         ), "QueryDatabase:OpenSearch requires os_client_args"
 
-        os_query = get_knn_query(query_phrase=self.logical_node.query_to_embed, context=self.context)
-        if self.logical_node.filter:
-            os_query["query"]["knn"]["embedding"]["filter"] = self.logical_node.filter
+        os_query = get_knn_query(query_phrase=self.logical_node.query_phrase, context=self.context)
+        if self.logical_node.opensearch_filter:
+            os_query["query"]["knn"]["embedding"]["filter"] = self.logical_node.opensearch_filter
         result = self.context.read.opensearch(index_name=self.logical_node.index, query=os_query)
         return result
 
     def script(self, input_var: Optional[str] = None, output_var: Optional[str] = None) -> Tuple[str, List[str]]:
         assert isinstance(self.logical_node, QueryVectorDatabase)
-        result = f"""os_query = get_knn_query(query_phrase='{self.logical_node.query_to_embed}', context=context)"""
-        if self.logical_node.filter:
+        result = f"""os_query = get_knn_query(query_phrase='{self.logical_node.query_phrase}', context=context)"""
+        if self.logical_node.opensearch_filter:
             result += f"""
-os_query["query"]["knn"]["embedding"]["filter"] = {self.logical_node.filter}"""
+os_query["query"]["knn"]["embedding"]["filter"] = {self.logical_node.opensearch_filter}"""
         result += f"""
 {output_var or get_var_name(self.logical_node)} = context.read.opensearch(
     index_name='{self.logical_node.index}', 

--- a/lib/sycamore/sycamore/query/execution/sycamore_operator.py
+++ b/lib/sycamore/sycamore/query/execution/sycamore_operator.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
 from typing import Any, Optional, List, Dict, Tuple
 
+from sycamore.connectors.opensearch.utils import get_knn_query
 from sycamore.context import get_val_from_context, OperationTypes
 from sycamore.functions.basic_filters import MatchFilter, RangeFilter
 from sycamore.llms import LLM
@@ -11,12 +12,13 @@ from sycamore.query.operators.limit import Limit
 from sycamore.query.operators.llm_extract_entity import LlmExtractEntity
 from sycamore.query.operators.llm_filter import LlmFilter
 from sycamore.query.operators.summarize_data import SummarizeData
-from sycamore.query.operators.query_database import QueryDatabase
+from sycamore.query.operators.query_database import QueryDatabase, QueryVectorDatabase
 from sycamore.query.operators.top_k import TopK
 from sycamore.query.operators.field_in import FieldIn
 from sycamore.query.operators.sort import Sort
 
 from sycamore.query.execution.operations import summarize_data
+from sycamore.transforms import Embedder
 from sycamore.transforms.extract_entity import OpenAIEntityExtractor
 
 from sycamore import DocSet, Context
@@ -110,6 +112,54 @@ class SycamoreQueryDatabase(SycamoreOperator):
 )
 """,
             [],
+        )
+
+
+class SycamoreQueryVectorDatabase(SycamoreOperator):
+    """
+    Note: Currently only supports an OpenSearch vector search implementation.
+    """
+
+    def __init__(
+        self,
+        context: Context,
+        logical_node: QueryVectorDatabase,
+        query_id: str,
+        trace_dir: Optional[str] = None,
+    ) -> None:
+        super().__init__(context=context, logical_node=logical_node, query_id=query_id, trace_dir=trace_dir)
+
+    def execute(self) -> Any:
+        assert isinstance(self.logical_node, QueryVectorDatabase)
+        embedder = get_val_from_context(context=self.context, val_key="text_embedder", param_names=["opensearch"])
+        assert (
+            embedder and isinstance(embedder, Embedder)
+        ), "QueryVectorDatabase requires an Embedder in the context"
+
+        assert (
+            get_val_from_context(context=self.context, val_key="os_client_args", param_names=["opensearch"]) is not None
+        ), "QueryDatabase:OpenSearch requires os_client_args"
+
+        os_query = get_knn_query(query_phrase=self.logical_node.query_to_embed, context=self.context)
+        if self.logical_node.filter:
+            os_query["query"]["knn"]["embedding"]["filter"] = self.logical_node.filter
+        result = self.context.read.opensearch(index_name=self.logical_node.index, query=os_query)
+        return result
+
+    def script(self, input_var: Optional[str] = None, output_var: Optional[str] = None) -> Tuple[str, List[str]]:
+        assert isinstance(self.logical_node, QueryVectorDatabase)
+        result = f"""os_query = get_knn_query(query_phrase='{self.logical_node.query_to_embed}', context=context)"""
+        if self.logical_node.filter:
+            result += f"""
+os_query["query"]["knn"]["embedding"]["filter"] = {self.logical_node.filter}"""
+        result += f"""
+{output_var or get_var_name(self.logical_node)} = context.read.opensearch(
+    index_name='{self.logical_node.index}', 
+    query=os_query
+)
+"""
+        return (result,
+            ["from sycamore.connectors.opensearch.utils import get_knn_query"],
         )
 
 

--- a/lib/sycamore/sycamore/query/operators/llm_filter.py
+++ b/lib/sycamore/sycamore/query/operators/llm_filter.py
@@ -12,7 +12,7 @@ class LlmFilter(LogicalOperator):
     is to only include events that are natural disasters, LlmFilter can be used to analyze
     the text of the field to determine if the event is a natural disaster.
 
-    Whenever possible, use the `query' parameter to the QueryDatabase operation or 'query_to_embed' parameter
+    Whenever possible, use the `query' parameter to the QueryDatabase operation or 'query_phrase' parameter
     to the QueryVectorDatabase operation to filter data at the source.
 
     The BasicFilter operation is preferred to LLMFilter when the filter is simple and does not

--- a/lib/sycamore/sycamore/query/operators/llm_filter.py
+++ b/lib/sycamore/sycamore/query/operators/llm_filter.py
@@ -4,16 +4,16 @@ from sycamore.query.operators.logical_operator import LogicalOperator
 class LlmFilter(LogicalOperator):
     """LlmFilter uses a Large Language Model (LLM) to filter database records based on the
     value of a field. This operation is useful when the filtering to be performed is complex
-    and cannot be expressed either as a OpenSearch query (for QueryDatabase) or as a simple
-    range or match filter (for BasicFilter).
+    and cannot be expressed either as a OpenSearch query (for QueryDatabase), vector query (QueryVectorDatabase)
+    or as a simple range or match filter (for BasicFilter).
 
     For example, LlmFilter is useful when the filter is operating on the semantic content
     of a field. For example, if a field contains a description of an event and the filter
     is to only include events that are natural disasters, LlmFilter can be used to analyze
     the text of the field to determine if the event is a natural disaster.
 
-    Whenever possible, use the `query' parameter to the QueryDatabase operation to filter
-    data at the source, as this is more efficient than use of the BasicFilter operation.
+    Whenever possible, use the `query' parameter to the QueryDatabase operation or 'query_to_embed' parameter
+    to the QueryVectorDatabase operation to filter data at the source.
 
     The BasicFilter operation is preferred to LLMFilter when the filter is simple and does not
     require the complexity of an LLM model to analyze the data.

--- a/lib/sycamore/sycamore/query/operators/query_database.py
+++ b/lib/sycamore/sycamore/query/operators/query_database.py
@@ -93,6 +93,3 @@ class QueryVectorDatabase(LogicalOperator):
 
     The full range of OpenSearch Query DSL parameters for a filter query are supported.
     """
-
-
-

--- a/lib/sycamore/sycamore/query/operators/query_database.py
+++ b/lib/sycamore/sycamore/query/operators/query_database.py
@@ -45,32 +45,32 @@ class QueryDatabase(LogicalOperator):
 
 
 class QueryVectorDatabase(LogicalOperator):
-    """OpenSearch knn query to load records that are similar to a given query string. Returns the top k records
-    according to the cosine similarity between the query string and record's text content.
-    Use this if we need to filter on a field that can't suffice with an exact match, but also isn't complex enough to
+    """Vector search to load records that are similar to a given query string. Returns the top k records
+    according to the vector similarity between the query string and record's text content.
+    Use this if you need to filter on a field that can't suffice with an exact match, but also isn't complex enough to
     require a llm_filter, i.e. a record level LLM call.
 
     Here are some instructions about using QueryVectorDatabase instead of QueryDatabase:
     1. Use QueryVectorDatabase if the query plan uses an LLM operator (LLMFilter or LLMExtractEntity),
         and the final answer doesn't require you to scan the full dataset (e.g. find me an instance of a transcript
-        that talked about AI)
+        that talked about AI).
     2. Use QueryVectorDatabase for RAG-style questions where you need to retrieve a set of candidate records where the
         answer might exist.
-    3. Do not use QueryVectorDatabase where examining each record is essential (e.g. did all transcripts talk about AI?)
+    3. Do not use QueryVectorDatabase when examining each record is essential (e.g. did all transcripts talk about AI?).
     4. Do not use QueryVectorDatabase where you need to potentially return large datasets (e.g. give me all transcripts
-        that talked about AI)
+        that talked about AI).
 
     """
 
     index: str
     """The index to load data from."""
 
-    query_to_embed: str
+    query_phrase: str
     """The string to convert to a vector and perform vector search"""
 
-    filter: Optional[Dict] = None
+    opensearch_filter: Optional[Dict] = None
     """
-    A filter query in OpenSearch Query DSL format which represents a filter in a knn query. 
+    A filter query in OpenSearch Query DSL format which represents a filter in an OpenSearch knn query. 
     
     Here is an example of a filter to get records between July 1, 2023, and September 30, 2024. 
 

--- a/lib/sycamore/sycamore/query/operators/query_database.py
+++ b/lib/sycamore/sycamore/query/operators/query_database.py
@@ -42,3 +42,57 @@ class QueryDatabase(LogicalOperator):
     Whenever possible, use the query parameter to filter data at the source, as this is more
     efficient than filtering data in subsequent data filtering operators.
     """
+
+
+class QueryVectorDatabase(LogicalOperator):
+    """OpenSearch knn query to load records that are similar to a given query string. Returns the top k records
+    according to the cosine similarity between the query string and record's text content.
+    Use this if we need to filter on a field that can't suffice with an exact match, but also isn't complex enough to
+    require a llm_filter, i.e. a record level LLM call.
+
+    Here are some instructions about using QueryVectorDatabase instead of QueryDatabase:
+    1. Use QueryVectorDatabase if the query plan uses an LLM operator (LLMFilter or LLMExtractEntity),
+        and the final answer doesn't require you to scan the full dataset (e.g. find me an instance of a transcript
+        that talked about AI)
+    2. Use QueryVectorDatabase for RAG-style questions where you need to retrieve a set of candidate records where the
+        answer might exist.
+    3. Do not use QueryVectorDatabase where examining each record is essential (e.g. did all transcripts talk about AI?)
+    4. Do not use QueryVectorDatabase where you need to potentially return large datasets (e.g. give me all transcripts
+        that talked about AI)
+
+    """
+
+    index: str
+    """The index to load data from."""
+
+    query_to_embed: str
+    """The string to convert to a vector and perform vector search"""
+
+    filter: Optional[Dict] = None
+    """
+    A filter query in OpenSearch Query DSL format which represents a filter in a knn query. 
+    
+    Here is an example of a filter to get records between July 1, 2023, and September 30, 2024. 
+
+    {
+      "bool": {
+        "must":[
+            {
+                "range": {
+                    "properties.entity.isoDateTime": {
+                    "gte": "2023-07-01T00:00:00",
+                    "lte": "2024-09-30T23:59:59",
+                    "format": "strict_date_optional_time"
+                    }
+                }
+            },
+        ]
+      }
+    }
+
+
+    The full range of OpenSearch Query DSL parameters for a filter query are supported.
+    """
+
+
+

--- a/lib/sycamore/sycamore/query/planner.py
+++ b/lib/sycamore/sycamore/query/planner.py
@@ -431,7 +431,7 @@ class LlmPlanner:
                     "operatorName": "QueryVectorDatabase",
                     "description": "Get all the shipwreck records relating to sudden weather changes",
                     "index": "shipwrecks",
-                    "query_to_embed": "sudden weather changes",
+                    "query_phrase": "sudden weather changes",
                     "node_id": 0
                 }
             ]

--- a/lib/sycamore/sycamore/query/planner.py
+++ b/lib/sycamore/sycamore/query/planner.py
@@ -11,7 +11,7 @@ from sycamore.query.operators.count import Count
 from sycamore.query.operators.llm_filter import LlmFilter
 from sycamore.query.operators.basic_filter import BasicFilter
 from sycamore.query.operators.llm_extract_entity import LlmExtractEntity
-from sycamore.query.operators.query_database import QueryDatabase
+from sycamore.query.operators.query_database import QueryDatabase, QueryVectorDatabase
 from sycamore.query.operators.math import Math
 from sycamore.query.operators.sort import Sort
 from sycamore.query.operators.summarize_data import SummarizeData
@@ -29,6 +29,7 @@ if typing.TYPE_CHECKING:
 # If a class is not in this list, it will not be used.
 OPERATORS: List[Type[LogicalOperator]] = [
     QueryDatabase,
+    QueryVectorDatabase,
     BasicFilter,
     LlmFilter,
     LlmExtractEntity,
@@ -59,10 +60,11 @@ guidelines when generating a plan:
             Other than those, DO NOT USE ANY OTHER FIELD NAMES.
         5. If an optional field does not have a value in the query plan, return null in its place.
         6. If you cannot generate a plan to answer a question, return an empty list.
-        7. The first step of each plan MUST be a **QueryDatabase** operation that returns a database.
-           Whenever possible, include all possible filtering operations in the QueryDatabase step.
+        7. The first step of each plan MUST be a **QueryDatabase** or **QueryVectorDatabase" operation that returns a 
+           database. Whenever possible, include all possible filtering operations in the QueryDatabase step.
            That is, you should strive to construct an OpenSearch query that filters the data as
-           much as possible, reducing the need for further query operations.
+           much as possible, reducing the need for further query operations. Use a QueryVectorDatabase step instead of
+           an LLMFilter if the query looks reasonable.
 """
 
 # Variants on the last step in the query plan, based on whether the user has requested raw data
@@ -415,6 +417,26 @@ class LlmPlanner:
             ]
 
             EXAMPLE 6:
+            Data description: Database of shipwreck records and their respective properties
+            DATA_SCHEMA: 
+            {
+                'properties.entity.date': "(<class 'str'>) e.g. (2023-01-14), (2023-01-14), (2023-01-29),
+                'properties.entity.shipwreck_id': "(<class 'str'>) e.g. (ABFUHEU), (FUIHWHD), (FGHIOWB),
+                'text_representation': '(<class 'str'>) Can be assumed to have all other details'
+            }
+            USER QUESTION: Were there any shipwrecks because of sudden weather changes?
+            Answer:
+            [
+                {
+                    "operatorName": "QueryVectorDatabase",
+                    "description": "Get all the shipwreck records relating to sudden weather changes",
+                    "index": "shipwrecks",
+                    "query_to_embed": "sudden weather changes",
+                    "node_id": 0
+                }
+            ]
+
+            EXAMPLE 7:
             Data description: Database of hospital patients
             DATA_SCHEMA: 
             {

--- a/lib/sycamore/sycamore/tests/integration/query/execution/test_sycamore_query.py
+++ b/lib/sycamore/sycamore/tests/integration/query/execution/test_sycamore_query.py
@@ -1,6 +1,7 @@
 import pytest
 
 from sycamore.query.client import SycamoreQueryClient
+from sycamore.query.operators.query_database import QueryVectorDatabase
 
 
 class TestSycamoreQuery:
@@ -12,7 +13,8 @@ class TestSycamoreQuery:
         """
         client = SycamoreQueryClient()
         schema = client.get_opensearch_schema(query_integration_test_index)
-        plan = client.generate_plan("How many incidents happened in california?", query_integration_test_index, schema)
+        plan = client.generate_plan("How many incidents happened in california?",
+                                    query_integration_test_index, schema, natural_language_response=True)
         query_id, result = client.run_plan(plan, codegen_mode=codegen_mode)
         assert isinstance(result, str)
         assert len(result) > 0
@@ -25,7 +27,8 @@ class TestSycamoreQuery:
         client = SycamoreQueryClient()
         schema = client.get_opensearch_schema(query_integration_test_index)
         plan = client.generate_plan(
-            "What fraction of all incidents happened in california?", query_integration_test_index, schema
+            "What fraction of all incidents happened in california?", query_integration_test_index, schema,
+            natural_language_response=True
         )
         query_id, result = client.run_plan(plan, codegen_mode=codegen_mode)
         assert isinstance(result, str)
@@ -43,7 +46,8 @@ class TestSycamoreQuery:
         client = SycamoreQueryClient()
         schema = client.get_opensearch_schema(query_integration_test_index)
         plan = client.generate_plan(
-            "What fraction of all incidents happened in california?", query_integration_test_index, schema
+            "What fraction of all incidents happened in california?", query_integration_test_index, schema,
+            natural_language_response=True
         )
         ray.shutdown()
         query_id, result = client.run_plan(plan, dry_run=dry_run)
@@ -53,3 +57,20 @@ class TestSycamoreQuery:
             assert not ray.is_initialized()
         else:
             assert ray.is_initialized()
+
+    @pytest.mark.parametrize("codegen_mode", [True, False])
+    def test_vector_search(self, query_integration_test_index: str, codegen_mode: bool):
+        """
+        """
+
+        client = SycamoreQueryClient()
+        schema = client.get_opensearch_schema(query_integration_test_index)
+        plan = client.generate_plan(
+            "were there any environmentally caused incidents?", query_integration_test_index, schema,
+            natural_language_response=True
+        )
+        assert len(plan.nodes) == 2
+        assert isinstance(plan.nodes[0], QueryVectorDatabase)
+        query_id, result = client.run_plan(plan, codegen_mode=codegen_mode)
+        assert isinstance(result, str)
+        assert "No" in result or "no" in result

--- a/lib/sycamore/sycamore/tests/integration/query/execution/test_sycamore_query.py
+++ b/lib/sycamore/sycamore/tests/integration/query/execution/test_sycamore_query.py
@@ -13,8 +13,12 @@ class TestSycamoreQuery:
         """
         client = SycamoreQueryClient()
         schema = client.get_opensearch_schema(query_integration_test_index)
-        plan = client.generate_plan("How many incidents happened in california?",
-                                    query_integration_test_index, schema, natural_language_response=True)
+        plan = client.generate_plan(
+            "How many incidents happened in california?",
+            query_integration_test_index,
+            schema,
+            natural_language_response=True,
+        )
         query_id, result = client.run_plan(plan, codegen_mode=codegen_mode)
         assert isinstance(result, str)
         assert len(result) > 0
@@ -27,8 +31,10 @@ class TestSycamoreQuery:
         client = SycamoreQueryClient()
         schema = client.get_opensearch_schema(query_integration_test_index)
         plan = client.generate_plan(
-            "What fraction of all incidents happened in california?", query_integration_test_index, schema,
-            natural_language_response=True
+            "What fraction of all incidents happened in california?",
+            query_integration_test_index,
+            schema,
+            natural_language_response=True,
         )
         query_id, result = client.run_plan(plan, codegen_mode=codegen_mode)
         assert isinstance(result, str)
@@ -46,8 +52,10 @@ class TestSycamoreQuery:
         client = SycamoreQueryClient()
         schema = client.get_opensearch_schema(query_integration_test_index)
         plan = client.generate_plan(
-            "What fraction of all incidents happened in california?", query_integration_test_index, schema,
-            natural_language_response=True
+            "What fraction of all incidents happened in california?",
+            query_integration_test_index,
+            schema,
+            natural_language_response=True,
         )
         ray.shutdown()
         query_id, result = client.run_plan(plan, dry_run=dry_run)
@@ -60,14 +68,15 @@ class TestSycamoreQuery:
 
     @pytest.mark.parametrize("codegen_mode", [True, False])
     def test_vector_search(self, query_integration_test_index: str, codegen_mode: bool):
-        """
-        """
+        """ """
 
         client = SycamoreQueryClient()
         schema = client.get_opensearch_schema(query_integration_test_index)
         plan = client.generate_plan(
-            "were there any environmentally caused incidents?", query_integration_test_index, schema,
-            natural_language_response=True
+            "were there any environmentally caused incidents?",
+            query_integration_test_index,
+            schema,
+            natural_language_response=True,
         )
         assert len(plan.nodes) == 2
         assert isinstance(plan.nodes[0], QueryVectorDatabase)

--- a/lib/sycamore/sycamore/tests/unit/connectors/opensearch/test_opensearch.py
+++ b/lib/sycamore/sycamore/tests/unit/connectors/opensearch/test_opensearch.py
@@ -1,5 +1,9 @@
+from unittest.mock import Mock
+
 from opensearchpy import OpenSearch, RequestError, ConnectionError
 import pytest
+
+from sycamore import Context
 from sycamore.connectors.opensearch import (
     OpenSearchWriterClient,
     OpenSearchWriterClientParams,
@@ -7,7 +11,9 @@ from sycamore.connectors.opensearch import (
     OpenSearchWriterTargetParams,
 )
 from sycamore.connectors.common import HostAndPort
+from sycamore.connectors.opensearch.utils import get_knn_query
 from sycamore.data.document import Document
+from sycamore.transforms import Embedder
 
 
 class TestOpenSearchTargetParams:
@@ -224,3 +230,46 @@ class TestOpenSearchRecord:
         }
         assert record._id == document.doc_id
         assert record._index == tp.index_name
+
+class TestOpenSearchUtils:
+
+    def test_get_knn_query(self):
+        embedder = Mock(spec=Embedder)
+        embedding = [0.1, 0.2]
+        embedder.generate_text_embedding.return_value = embedding
+        context = Context(
+            params={
+                "opensearch": {
+                    "os_client_args": {
+                        "hosts": [{"host": "localhost", "port": 9200}],
+                        "http_compress": True,
+                        "http_auth": ("admin", "admin"),
+                        "use_ssl": True,
+                        "verify_certs": False,
+                        "ssl_assert_hostname": False,
+                        "ssl_show_warn": False,
+                        "timeout": 120,
+                    },
+                    "index_name": "test_index"
+                },
+                "default": {
+                    "text_embedder": embedder
+                }
+            }
+        )
+        expected_query = {
+            "query": {
+                "knn": {
+                    "embedding": {
+                        "vector": embedding,
+                        "k": 1000
+                    }
+                }
+            }
+        }
+        assert get_knn_query(query_phrase="test", k=1000, context=context) == expected_query
+        embedder.generate_text_embedding.assert_called_with("test")
+
+
+        assert get_knn_query(query_phrase="test", k=1000, text_embedder=embedder) == expected_query
+        embedder.generate_text_embedding.assert_called_with("test")

--- a/lib/sycamore/sycamore/tests/unit/connectors/opensearch/test_opensearch.py
+++ b/lib/sycamore/sycamore/tests/unit/connectors/opensearch/test_opensearch.py
@@ -231,6 +231,7 @@ class TestOpenSearchRecord:
         assert record._id == document.doc_id
         assert record._index == tp.index_name
 
+
 class TestOpenSearchUtils:
 
     def test_get_knn_query(self):
@@ -250,26 +251,14 @@ class TestOpenSearchUtils:
                         "ssl_show_warn": False,
                         "timeout": 120,
                     },
-                    "index_name": "test_index"
+                    "index_name": "test_index",
                 },
-                "default": {
-                    "text_embedder": embedder
-                }
+                "default": {"text_embedder": embedder},
             }
         )
-        expected_query = {
-            "query": {
-                "knn": {
-                    "embedding": {
-                        "vector": embedding,
-                        "k": 1000
-                    }
-                }
-            }
-        }
+        expected_query = {"query": {"knn": {"embedding": {"vector": embedding, "k": 1000}}}}
         assert get_knn_query(query_phrase="test", k=1000, context=context) == expected_query
         embedder.generate_text_embedding.assert_called_with("test")
-
 
         assert get_knn_query(query_phrase="test", k=1000, text_embedder=embedder) == expected_query
         embedder.generate_text_embedding.assert_called_with("test")

--- a/lib/sycamore/sycamore/tests/unit/query/execution/test_sycamore_operator.py
+++ b/lib/sycamore/sycamore/tests/unit/query/execution/test_sycamore_operator.py
@@ -19,7 +19,8 @@ from sycamore.query.execution.sycamore_operator import (
     SycamoreLlmExtractEntity,
     SycamoreSort,
     SycamoreTopK,
-    SycamoreLimit, SycamoreQueryVectorDatabase,
+    SycamoreLimit,
+    SycamoreQueryVectorDatabase,
 )
 from sycamore.query.operators.basic_filter import BasicFilter
 from sycamore.query.operators.sort import Sort
@@ -124,38 +125,25 @@ def test_vector_query_database():
                         "timeout": 120,
                     },
                     "index_name": "test_index",
-                    "text_embedder": embedder
+                    "text_embedder": embedder,
                 }
             }
         )
-        os_filter = {
-            "filterKey": {
-                "nestedKey": "some value"
-            }
-        }
-        logical_node = QueryVectorDatabase(node_id=0,
-                                           description="Load data",
-                                           index=context.params["opensearch"]["index_name"],
-                                           query_to_embed="question",
-                                           filter=os_filter
-                                           )
+        os_filter = {"filterKey": {"nestedKey": "some value"}}
+        logical_node = QueryVectorDatabase(
+            node_id=0,
+            description="Load data",
+            index=context.params["opensearch"]["index_name"],
+            query_to_embed="question",
+            filter=os_filter,
+        )
         sycamore_operator = SycamoreQueryVectorDatabase(context=context, logical_node=logical_node, query_id="test")
         sycamore_operator.execute()
 
         # Assert request
         mock_docset_reader_impl.opensearch.assert_called_once_with(
             index_name=context.params["opensearch"]["index_name"],
-            query={
-                "query": {
-                    "knn": {
-                        "embedding": {
-                            "vector": embedding,
-                            "k": 500,
-                            "filter": os_filter
-                        }
-                    }
-                }
-            }
+            query={"query": {"knn": {"embedding": {"vector": embedding, "k": 500, "filter": os_filter}}}},
         )
 
 

--- a/lib/sycamore/sycamore/tests/unit/query/execution/test_sycamore_operator.py
+++ b/lib/sycamore/sycamore/tests/unit/query/execution/test_sycamore_operator.py
@@ -134,8 +134,8 @@ def test_vector_query_database():
             node_id=0,
             description="Load data",
             index=context.params["opensearch"]["index_name"],
-            query_to_embed="question",
-            filter=os_filter,
+            query_phrase="question",
+            opensearch_filter=os_filter,
         )
         sycamore_operator = SycamoreQueryVectorDatabase(context=context, logical_node=logical_node, query_id="test")
         sycamore_operator.execute()

--- a/lib/sycamore/sycamore/tests/unit/test_context.py
+++ b/lib/sycamore/sycamore/tests/unit/test_context.py
@@ -74,17 +74,19 @@ def test_function_w_class_context():
 
 
 @context_params
-def two_positional_args_method(some_function_arg: str, some_other_arg: str, context: Optional[Context] = None):
+def two_positional_args_method(some_function_arg: str, some_other_arg: str, separator: str = " ",
+                               context: Optional[Context] = None):
     assert some_function_arg is not None
     assert some_other_arg is not None
-    return some_function_arg + " " + some_other_arg
+    return some_function_arg + separator + some_other_arg
 
 
 @context_params
-def two_positional_args_method_with_kwargs(some_function_arg: str, context: Optional[Context] = None, **kwargs):
+def two_positional_args_method_with_kwargs(some_function_arg: str, separator: str = " ",
+                                           context: Optional[Context] = None, **kwargs):
     assert some_function_arg is not None
     assert kwargs.get("some_other_arg") is not None
-    return some_function_arg + " " + str(kwargs.get("some_other_arg"))
+    return some_function_arg + separator + str(kwargs.get("some_other_arg"))
 
 
 def test_positional_args_and_context_args():

--- a/lib/sycamore/sycamore/tests/unit/test_context.py
+++ b/lib/sycamore/sycamore/tests/unit/test_context.py
@@ -74,16 +74,18 @@ def test_function_w_class_context():
 
 
 @context_params
-def two_positional_args_method(some_function_arg: str, some_other_arg: str, separator: str = " ",
-                               context: Optional[Context] = None):
+def two_positional_args_method(
+    some_function_arg: str, some_other_arg: str, separator: str = " ", context: Optional[Context] = None
+):
     assert some_function_arg is not None
     assert some_other_arg is not None
     return some_function_arg + separator + some_other_arg
 
 
 @context_params
-def two_positional_args_method_with_kwargs(some_function_arg: str, separator: str = " ",
-                                           context: Optional[Context] = None, **kwargs):
+def two_positional_args_method_with_kwargs(
+    some_function_arg: str, separator: str = " ", context: Optional[Context] = None, **kwargs
+):
     assert some_function_arg is not None
     assert kwargs.get("some_other_arg") is not None
     return some_function_arg + separator + str(kwargs.get("some_other_arg"))


### PR DESCRIPTION
1. Some bug fixes regarding default vars in context_params
2. Integ test fix for SycamoreQuery missing `natural_language_response=True`
3. Added QueryVectorDatabase operator

Will continue prompt tuning as we play with it. Will also want to port this as a native DocSetReader function at some point.