### PR TITLE
Fix issue with empty tool response leading to hallucinations.

### DIFF
--- a/apps/query-demo/querydemo/Query_Demo.py
+++ b/apps/query-demo/querydemo/Query_Demo.py
@@ -580,6 +580,8 @@ def do_query():
                         else:
                             # Fall back to string representation.
                             tool_response_str = str(tool_response)
+                        if not tool_response_str:
+                            tool_response_str = "No results found for your query."
                 except Exception as e:
                     st.error(f"Error running Sycamore query: {e}")
                     tool_response_str = f"There was an error running your query: {e}"


### PR DESCRIPTION
When the DocSet returned by the Sycamore query is empty, the resulting string representation is empty, which leads the LLM to hallucinate in interesting ways. This avoids that problem.
