### PR TITLE
Reverts README change to restore poetry build.

### DIFF
--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install
         run: poetry install
         working-directory: lib/sycamore
+      - name: Copy README
+        working-directory: lib/scyamore
+        run: cp ../../README.md README.md
       - name: build
         run: poetry build
         working-directory: lib/sycamore

--- a/lib/sycamore/pyproject.toml
+++ b/lib/sycamore/pyproject.toml
@@ -3,7 +3,7 @@ name = "sycamore-ai"
 version = "0.1.21"
 description = "Sycamore is an LLM-powered semantic data preparation system for building search applications."
 authors = ["aryn.ai <opensource@aryn.ai>"]
-readme = "../../README.md"
+readme = "README.md"
 repository = "https://github.com/aryn-ai/sycamore.git"
 packages = [{ include = "sycamore" }]
 


### PR DESCRIPTION
A previous change attempted to avoid our README files getting out of sync by referencing the README at the root of the repo using a relative path in the library pyproject.toml. This unfortunately breaks poetry build. This commit switches back to using the README in the lib directory, and adds a github action step to copy the README during the release process to hopefully avoid drift that way.