### PR TITLE
Fix bug where prompt is modified by OpenAIEntityExtractor.

### DIFF
--- a/apps/query-ui/poetry.lock
+++ b/apps/query-ui/poetry.lock
@@ -1266,6 +1266,28 @@ docs = ["ipython", "matplotlib", "numpydoc", "sphinx"]
 tests = ["pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
+name = "dateparser"
+version = "1.2.0"
+description = "Date parsing library designed to parse dates from HTML pages"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "dateparser-1.2.0-py2.py3-none-any.whl", hash = "sha256:0b21ad96534e562920a0083e97fd45fa959882d4162acc358705144520a35830"},
+    {file = "dateparser-1.2.0.tar.gz", hash = "sha256:7975b43a4222283e0ae15be7b4999d08c9a70e2d378ac87385b1ccf2cffbbb30"},
+]
+
+[package.dependencies]
+python-dateutil = "*"
+pytz = "*"
+regex = "<2019.02.19 || >2019.02.19,<2021.8.27 || >2021.8.27"
+tzlocal = "*"
+
+[package.extras]
+calendars = ["convertdate", "hijri-converter"]
+fasttext = ["fasttext"]
+langdetect = ["langdetect"]
+
+[[package]]
 name = "decorator"
 version = "5.1.1"
 description = "Decorators for Humans"
@@ -1398,6 +1420,16 @@ files = [
     {file = "editdistance-0.8.1-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b978c5927100a57791131dd2418040f4e5d33970d37b97a84c1a530ec481f557"},
     {file = "editdistance-0.8.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:0c96a8e981f385f0b7392d047c5caab8e0b24f94b71120787fd78241efc34237"},
     {file = "editdistance-0.8.1.tar.gz", hash = "sha256:d1cdf80a5d5014b0c9126a69a42ce55a457b457f6986ff69ca98e4fe4d2d8fed"},
+]
+
+[[package]]
+name = "events"
+version = "0.5"
+description = "Bringing the elegance of C# EventHandler to Python"
+optional = false
+python-versions = "*"
+files = [
+    {file = "Events-0.5-py3-none-any.whl", hash = "sha256:a7286af378ba3e46640ac9825156c93bdba7502174dd696090fdfcd4d80a1abd"},
 ]
 
 [[package]]
@@ -3246,6 +3278,34 @@ files = [
 ]
 
 [[package]]
+name = "opensearch-py"
+version = "2.6.0"
+description = "Python client for OpenSearch"
+optional = false
+python-versions = "<4,>=3.8"
+files = [
+    {file = "opensearch_py-2.6.0-py2.py3-none-any.whl", hash = "sha256:b6e78b685dd4e9c016d7a4299cf1de69e299c88322e3f81c716e6e23fe5683c1"},
+    {file = "opensearch_py-2.6.0.tar.gz", hash = "sha256:0b7c27e8ed84c03c99558406927b6161f186a72502ca6d0325413d8e5523ba96"},
+]
+
+[package.dependencies]
+certifi = ">=2022.12.07"
+Events = "*"
+python-dateutil = "*"
+requests = ">=2.4.0,<3.0.0"
+six = "*"
+urllib3 = [
+    {version = ">=1.26.18,<1.27", markers = "python_version < \"3.10\""},
+    {version = ">=1.26.18,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""},
+]
+
+[package.extras]
+async = ["aiohttp (>=3.9.4,<4)"]
+develop = ["black (>=24.3.0)", "botocore", "coverage (<8.0.0)", "jinja2", "mock", "myst-parser", "pytest (>=3.0.0)", "pytest-cov", "pytest-mock (<4.0.0)", "pytz", "pyyaml", "requests (>=2.0.0,<3.0.0)", "sphinx", "sphinx-copybutton", "sphinx-rtd-theme"]
+docs = ["aiohttp (>=3.9.4,<4)", "myst-parser", "sphinx", "sphinx-copybutton", "sphinx-rtd-theme"]
+kerberos = ["requests-kerberos"]
+
+[[package]]
 name = "ordered-set"
 version = "4.1.0"
 description = "An OrderedSet is a custom MutableSet that remembers its order, so that every"
@@ -4786,7 +4846,7 @@ typing = ["mypy (>=1.4)", "rich", "twisted"]
 
 [[package]]
 name = "sycamore-ai"
-version = "0.1.19"
+version = "0.1.21"
 description = "Sycamore is an LLM-powered semantic data preparation system for building search applications."
 optional = false
 python-versions = ">=3.9,<3.12"
@@ -4800,6 +4860,7 @@ async-timeout = ">4.0.0"
 beautifulsoup4 = "^4.12.2"
 boto3 = "^1.28.70"
 boto3-stubs = {version = "^1.35.12", extras = ["essential"]}
+dateparser = "^1.2.0"
 diskcache = "^5.6.3"
 fasteners = "^0.19"
 fsspec = "2024.2.0"
@@ -4807,6 +4868,7 @@ guidance = "0.1.14"
 jinja2 = "^3.1"
 numpy = "<2.0.0"
 openai = "^1.40.2"
+opensearch-py = {version = "^2.3.1", optional = true}
 overrides = "^7.7.0"
 pandas = "^2.1.1"
 pdf2image = "^1.16.3"
@@ -5183,6 +5245,23 @@ files = [
     {file = "tzdata-2024.1-py2.py3-none-any.whl", hash = "sha256:9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252"},
     {file = "tzdata-2024.1.tar.gz", hash = "sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd"},
 ]
+
+[[package]]
+name = "tzlocal"
+version = "5.2"
+description = "tzinfo object for the local timezone"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "tzlocal-5.2-py3-none-any.whl", hash = "sha256:49816ef2fe65ea8ac19d19aa7a1ae0551c834303d5014c6d5a62e4cbda8047b8"},
+    {file = "tzlocal-5.2.tar.gz", hash = "sha256:8d399205578f1a9342816409cc1e46a93ebd5755e39ea2d85334bea911bf0e6e"},
+]
+
+[package.dependencies]
+tzdata = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+devenv = ["check-manifest", "pytest (>=4.3)", "pytest-cov", "pytest-mock (>=3.3)", "zest.releaser"]
 
 [[package]]
 name = "uc-micro-py"
@@ -5600,4 +5679,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.9.7 || >3.9.7,<3.12"
-content-hash = "965d53a72d0ffa5c61d01000a5b4cc1ff370c104dd4de52d33f1df4656db751d"
+content-hash = "ef19a6b7784b03693e06991eae0440ee5096c986ac5ae66baf0dfe35085935e3"

--- a/lib/sycamore/sycamore/transforms/extract_entity.py
+++ b/lib/sycamore/sycamore/transforms/extract_entity.py
@@ -138,13 +138,11 @@ class OpenAIEntityExtractor(EntityExtractor):
         value = str(document.field_to_value(self._field))
 
         if isinstance(self._prompt, str):
-            self._prompt += value
-            response = self._llm.generate(prompt_kwargs={"prompt": self._prompt}, llm_kwargs={})
+            prompt = self._prompt + value
+            response = self._llm.generate(prompt_kwargs={"prompt": prompt}, llm_kwargs={})
         else:
-            if self._prompt is None:
-                self._prompt = []
-            self._prompt.append({"role": "user", "content": value})
-            response = self._llm.generate(prompt_kwargs={"messages": self._prompt}, llm_kwargs={})
+            messages = (self._prompt or []) + [{"role": "user", "content": value}]
+            response = self._llm.generate(prompt_kwargs={"messages": messages}, llm_kwargs={})
 
         return response
 


### PR DESCRIPTION
OpenAIEntityExtractor was internally modifying its prompt, causing it to send multiple user messages to the LLM, depending on how it was invoked. This PR fixes this by avoiding modification of the `self._prompt` field.