### PR TITLE
Get local mode working 1/n

### DIFF
--- a/examples/html_ingest.py
+++ b/examples/html_ingest.py
@@ -24,14 +24,14 @@ index = "demoindex0"
 davinci_llm = OpenAI(OpenAIModels.GPT_3_5_TURBO_INSTRUCT.value)
 tokenizer = HuggingFaceTokenizer("thenlper/gte-small")
 
-ctx = sycamore.init()
+ctx = sycamore.init(exec_mode=sycamore.EXEC_LOCAL)
 
 ds = (
     ctx.read.binary(paths, binary_format="html")
     .partition(
         partitioner=HtmlPartitioner(
             extract_tables=True,
-            text_chunker=TextOverlapChunker(chunk_token_count=1200, chunk_overlap_token_count=120),
+            text_chunker=TextOverlapChunker(chunk_token_count=1000, chunk_overlap_token_count=120),
         )
     )
     .regex_replace(COALESCE_WHITESPACE)

--- a/examples/ndd_debug.py
+++ b/examples/ndd_debug.py
@@ -22,10 +22,11 @@ fsys = pyarrow.fs.S3FileSystem(region="us-east-1", anonymous=True)
 
 tokenizer = HuggingFaceTokenizer("thenlper/gte-small")
 
-ctx = sycamore.init()
+ctx = sycamore.init(exec_mode=sycamore.EXEC_LOCAL)
 
 ds = (
     ctx.read.binary(paths, binary_format="pdf", filesystem=fsys)
+    .materialize("tmp/ndd_debug_read", source_mode=sycamore.MATERIALIZE_USE_STORED)
     .partition(partitioner=UnstructuredPdfPartitioner())
     .regex_replace(COALESCE_WHITESPACE)
     .mark_bbox_preset(tokenizer=tokenizer)

--- a/lib/sycamore/sycamore/__init__.py
+++ b/lib/sycamore/sycamore/__init__.py
@@ -3,6 +3,8 @@ from sycamore.docset import DocSet
 from sycamore.executor import Execution
 from sycamore.materialize_config import MaterializeSourceMode
 
+EXEC_RAY = ExecMode.RAY
+EXEC_LOCAL = ExecMode.LOCAL
 MATERIALIZE_RECOMPUTE = MaterializeSourceMode.RECOMPUTE
 MATERIALIZE_USE_STORED = MaterializeSourceMode.USE_STORED
 
@@ -14,6 +16,4 @@ __all__ = [
     "Execution",
     "ExecMode",
     "MaterializeSourceMode",
-    "MATERIALIZE_RECOMPUTE",
-    "MATERIALIZE_USE_STORED",
 ]

--- a/lib/sycamore/sycamore/connectors/file/file_scan.py
+++ b/lib/sycamore/sycamore/connectors/file/file_scan.py
@@ -166,7 +166,6 @@ class BinaryScan(FileScan):
         return files.map(self._to_document, **self.resource_args)
 
     def local_source(self, **kwargs) -> list[Document]:
-
         if isinstance(self._paths, str):
             paths = [self._paths]
         else:
@@ -198,12 +197,16 @@ class BinaryScan(FileScan):
 
             documents.append(document)
 
-        for path in paths:
-            path_info = self._filesystem.get_file_info(path)
+        for orig_path in paths:
+            from sycamore.utils.pyarrow import cross_check_infer_fs
+
+            (filesystem, path) = cross_check_infer_fs(self._filesystem, orig_path)
+
+            path_info = filesystem.get_file_info(path)
             if path_info.is_file:
                 process_file(path_info)
             else:
-                for info in self._filesystem.get_file_info(FileSelector(path, recursive=True)):
+                for info in filesystem.get_file_info(FileSelector(path, recursive=True)):
                     process_file(info)
         return documents
 

--- a/lib/sycamore/sycamore/materialize.py
+++ b/lib/sycamore/sycamore/materialize.py
@@ -225,9 +225,9 @@ class Materialize(UnaryNode):
 
     @staticmethod
     def infer_fs(path: str) -> Tuple["pyarrow.FileSystem", Path]:
-        from sycamore.utils.pyarrow import infer_fs
+        from sycamore.utils.pyarrow import infer_fs as util_infer_fs
 
-        (fs, path) = infer_fs(path)
+        (fs, path) = util_infer_fs(path)
         return (fs, Path(path))
 
     def save(self, doc: Document) -> None:

--- a/lib/sycamore/sycamore/materialize.py
+++ b/lib/sycamore/sycamore/materialize.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Any, Optional, Union, TYPE_CHECKING
+from typing import Any, Optional, Tuple, Union, TYPE_CHECKING
 
 from sycamore.context import Context
 from sycamore.data import Document, MetadataDocument
@@ -224,22 +224,11 @@ class Materialize(UnaryNode):
             assert self._fshelper.file_exists(self._success_path())
 
     @staticmethod
-    def infer_fs(path: str) -> "pyarrow.FileSystem":
-        import re
+    def infer_fs(path: str) -> Tuple["pyarrow.FileSystem", Path]:
+        from sycamore.utils.pyarrow import infer_fs
 
-        if not re.match("^[a-z0-9]+://.", path):
-            # pyarrow expects URIs, accepts /dir/path, but rejects ./dir/path
-            # normalize everything to a URI.
-            p = Path(path)
-            if p.is_absolute():
-                path = p.as_uri()
-            else:
-                path = p.absolute().as_uri()
-
-        from pyarrow import fs
-
-        (fs, root) = fs.FileSystem.from_uri(path)
-        return (fs, Path(root))
+        (fs, path) = infer_fs(path)
+        return (fs, Path(path))
 
     def save(self, doc: Document) -> None:
         bin = self._doc_to_binary(doc)

--- a/lib/sycamore/sycamore/tests/integration/connectors/file/test_file_writer.py
+++ b/lib/sycamore/sycamore/tests/integration/connectors/file/test_file_writer.py
@@ -1,0 +1,6 @@
+import sycamore
+from sycamore.tests.unit.connectors.file.test_file_writer import impl_test_json_bytes_with_bbox_image
+
+
+def test_json_bytes_with_bbox_image():
+    impl_test_json_bytes_with_bbox_image(sycamore.EXEC_RAY)

--- a/lib/sycamore/sycamore/tests/unit/connectors/file/test_file_writer.py
+++ b/lib/sycamore/sycamore/tests/unit/connectors/file/test_file_writer.py
@@ -1,6 +1,9 @@
+import glob
+import json
+import tempfile
+
 import sycamore
 from sycamore.tests.config import TEST_DIR
-from sycamore.connectors.file.file_writer import document_to_json_bytes
 
 # To re-generate the input file, change the False to True, and in the root directory, run
 # poetry run python lib/sycamore/sycamore/tests/unit/connectors/file/test_file_writer.py
@@ -8,25 +11,33 @@ if False:
     from sycamore.transforms.partition import ArynPartitioner
 
     (
-        sycamore.init()
+        sycamore.init(exec_mode=sycamore.EXEC_LOCAL)
         .read.binary(paths="./lib/sycamore/sycamore/tests/resources/data/pdfs/Ray_page11.pdf", binary_format="pdf")
         .partition(ArynPartitioner(extract_images=True, use_partitioning_service=False, use_cache=False))
-        .materialize(
-            path="./lib/sycamore/sycamore/tests/resources/data/materialize/json_writer",
-            source_mode=sycamore.MATERIALIZE_USE_STORED,
-        )
+        .materialize("./lib/sycamore/sycamore/tests/resources/data/materialize/json_writer")
         .execute()
     )
 
 
+def impl_test_json_bytes_with_bbox_image(exec_mode):
+    with tempfile.TemporaryDirectory() as tempdir:
+        (
+            sycamore.init(exec_mode=exec_mode)
+            .read.materialize(path=TEST_DIR / "resources/data/materialize/json_writer")
+            .write.json(tempdir)
+        )
+
+        nfiles = 0
+        for name in glob.glob(f"{tempdir}/*"):
+            with open(name, "r") as f:
+                data = f.read()
+                if len(data) == 0:  # ray test ends up with an empty file
+                    continue
+                nfiles = nfiles + 1
+                _ = json.loads(data)
+
+        assert nfiles == 1
+
+
 def test_json_bytes_with_bbox_image():
-    docs = (
-        sycamore.init(exec_mode=sycamore.ExecMode.LOCAL)
-        .read.materialize(path=TEST_DIR / "resources/data/materialize/json_writer")
-        .take_all()
-    )
-    # TODO: once we support writers in local mode, switch this to be
-    # .write.json(tmpdir)
-    # running as part of ray, it's too slow
-    for d in docs:
-        _ = document_to_json_bytes(d)
+    impl_test_json_bytes_with_bbox_image(sycamore.EXEC_LOCAL)

--- a/lib/sycamore/sycamore/utils/pyarrow.py
+++ b/lib/sycamore/sycamore/utils/pyarrow.py
@@ -1,0 +1,43 @@
+import logging
+from pathlib import Path
+from typing import Optional, Tuple
+
+from pyarrow.fs import FileSystem
+
+logger = logging.getLogger(__name__)
+
+
+def infer_fs(path: str) -> Tuple[FileSystem, str]:
+    import re
+
+    if not re.match("^[a-z0-9]+://.", path):
+        # pyarrow expects URIs, accepts /dir/path, but rejects ./dir/path
+        # normalize everything to a URI.
+        p = Path(path)
+        if p.is_absolute():
+            path = p.as_uri()
+        else:
+            path = p.absolute().as_uri()
+
+    from pyarrow import fs
+
+    (fs, root) = fs.FileSystem.from_uri(str(path))
+    return (fs, root)
+
+
+def cross_check_infer_fs(filesystem: Optional[FileSystem], path: str) -> Tuple[FileSystem, str]:
+    if filesystem is None:
+        return infer_fs(path)
+
+    (f, p) = infer_fs(path)
+    # ray allows you to specify a path like s3://bucket/object with the S3 Pyarrow filesystem
+    # and will silently fix the path to be acceptable. Do something similar here.
+    if isinstance(filesystem, f.__class__):
+        path = str(p)
+    else:
+        logger.warning(
+            f"path {path} infers a filesystem of class {f.__class__} and a path of {p}, but"
+            + f" the specified filesystem is {filesystem.__class__}. Using the path unchanged."
+        )
+
+    return (filesystem, path)

--- a/notebooks/default-prep-script.ipynb
+++ b/notebooks/default-prep-script.ipynb
@@ -222,7 +222,7 @@
     "    tokenizer = HuggingFaceTokenizer(\"sentence-transformers/all-MiniLM-L6-v2\")\n",
     "    merger = GreedyTextElementMerger(tokenizer, 256)\n",
     "\n",
-    "    ctx = sycamore.init()\n",
+    "    ctx = sycamore.init(exec_mode=sycamore.EXEC_LOCAL)\n",
     "    (\n",
     "        ctx.read.binary(paths, binary_format=\"pdf\", filter_paths_by_extension=False)\n",
     "        .partition(\n",
@@ -269,7 +269,7 @@
     "        print(\"WARNING: import_html called with empty directory\")\n",
     "        return\n",
     "\n",
-    "    ctx = sycamore.init()\n",
+    "    ctx = sycamore.init(exec_mode=sycamore.EXEC_LOCAL)\n",
     "    (\n",
     "        ctx.read.binary(paths, binary_format=\"html\", filter_paths_by_extension=False)\n",
     "        .partition(\n",
@@ -312,7 +312,16 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8",
-   "metadata": {},
+   "metadata": {
+    "nbmake": {
+     "post_cell_execute": [
+      "if sycamore.EXEC_LOCAL != sycamore.ExecMode.RAY:",
+      "    import sys",
+      "    # TODO: eric - remove the True",
+      "    assert True or 'ray' not in sys.modules"
+     ]
+    }
+   },
    "outputs": [],
    "source": [
     "if os.path.isdir(\"/etc/opt/aryn\"):\n",
@@ -339,7 +348,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Working for a few unit tests (file writer), examples (html_ingest, ndd_debug), and notebooks (default-prep-script).
* Update the file writers to work in local mode
* Refactor the code for the database writers to remove duplicate lines.
* Refactor infer_fs so we can use it in multiple places and a variant that will cross check that the user specified fs and the inferred one are the same, in which case we use the inferred path to be more similar to ray.
* Add constants for exec mode to sycamore namespace. Remove materialize constants from default imports.
* Add materialize in a bunch of places to speed up execution.
* Discover we have a strong ray dependency for specifing parallelism. Add TODO to fix this problem.