### PR TITLE
Query trace viewer for Luna demo, and better PDF previews.

### DIFF
--- a/apps/query-demo/querydemo/Query_Demo.py
+++ b/apps/query-demo/querydemo/Query_Demo.py
@@ -1,4 +1,3 @@
-import base64
 import datetime
 from html.parser import HTMLParser
 import json
@@ -8,7 +7,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 
-import boto3
 import marko
 from marko.md_renderer import MarkdownRenderer
 import requests
@@ -19,7 +17,7 @@ import sycamore
 from sycamore.data import OpenSearchQuery
 from sycamore.transforms.query import OpenSearchQueryExecutor
 from sycamore.query.client import SycamoreQueryClient
-from util import generate_plan, run_plan, ray_init, show_query_traces
+from util import generate_plan, run_plan, show_query_traces, show_pdf_preview
 
 NUM_DOCS_GENERATE = 60
 NUM_DOCS_PREVIEW = 10
@@ -55,7 +53,6 @@ If you're not sure what to ask, you can try one of the following example queries
 
 {"".join([f"<SuggestedQuery query='{query}' />" for query in EXAMPLE_QUERIES])}
 """
-
 
 SYSTEM_PROMPT = """You are a helpful agent that answers questions about NTSB
 (National Transportation Safety Board) incidents. You have access to a database of incident
@@ -148,6 +145,7 @@ class MDXParser(HTMLParser):
         self.chat_message = chat_message
         self.in_table = False
         self.in_header = False
+        self.in_header_cell = False
         self.in_row = False
         self.in_cell = False
         self.table_data: List[List[Any]] = []
@@ -166,8 +164,11 @@ class MDXParser(HTMLParser):
         elif tag == "tablerow" and self.in_table:
             self.in_row = True
             self.row_data = []
-        elif tag == "tablecell" and self.in_row:
-            self.in_cell = True
+        elif tag == "tablecell":
+            if self.in_header:
+                self.in_header_cell = True
+            elif self.in_row:
+                self.in_cell = True
         elif tag == "map":
             self.in_map = True
             self.map_data = []
@@ -177,17 +178,19 @@ class MDXParser(HTMLParser):
             self.map_data.append((lat, lon))
 
     def handle_endtag(self, tag):
-        if tag == "tablecell" and self.in_cell:
-            self.in_cell = False
+        if tag == "tablecell":
+            if self.in_header_cell:
+                self.in_header_cell = False
+            elif self.in_cell:
+                self.in_cell = False
         elif tag == "tableheader" and self.in_header:
             self.in_header = False
-            self.table_data.append(self.header_data)
         elif tag == "tablerow" and self.in_row:
             self.in_row = False
             self.table_data.append(self.row_data)
         elif tag == "table" and self.in_table:
             self.in_table = False
-            self.chat_message.render_table(self.table_data)
+            self.chat_message.render_table(self.header_data, self.table_data)
         elif tag == "map" and self.in_map:
             self.in_map = False
             self.chat_message.render_map(self.map_data)
@@ -214,7 +217,7 @@ class MDXParser(HTMLParser):
         data = data.strip()
         if not data:
             return
-        if self.in_header:
+        if self.in_header_cell:
             self.header_data.append(data)
         elif self.in_cell:
             self.row_data.append(data)
@@ -270,12 +273,18 @@ class ChatMessageTraces(ChatMessageExtra):
 
 
 class ChatMessage:
-    def __init__(self, message: Optional[Dict[str, Any]] = None, extras: Optional[List[ChatMessageExtra]] = None):
+    def __init__(
+        self,
+        message: Optional[Dict[str, Any]] = None,
+        before_extras: Optional[List[ChatMessageExtra]] = None,
+        after_extras: Optional[List[ChatMessageExtra]] = None,
+    ):
         self.message_id = st.session_state.next_message_id
         st.session_state.next_message_id += 1
         self.timestamp = datetime.datetime.now()
         self.message = message or {}
-        self.extras = extras or []
+        self.before_extras = before_extras or []
+        self.after_extras = after_extras or []
         self.widget_key = 0
 
     def show(self):
@@ -284,12 +293,15 @@ class ChatMessage:
             self.show_content()
 
     def show_content(self):
-        for extra in self.extras:
+        for extra in self.before_extras:
             with st.expander(extra.name):
                 extra.show()
         if self.message.get("content"):
             content = self.message.get("content")
             self.render_markdown_with_jsx(content)
+        for extra in self.after_extras:
+            with st.expander(extra.name):
+                extra.show()
 
     def button(self, label: str, **kwargs):
         return st.button(label, key=self.next_key(), **kwargs)
@@ -303,18 +315,40 @@ class ChatMessage:
         return key
 
     def render_markdown_with_jsx(self, text: str):
-        print(text)
+        print(f"Rendering MDX:\n{text}\n")
         mdxparser = MDXParser(self)
         mdxparser.feed(text)
 
     def render_markdown(self, text: str):
         st.markdown(text)
 
-    def render_table(self, data: List[Dict[str, Any]]):
-        st.dataframe(data)
+    def render_table(self, columns: List[str], rows: List[List[str]]):
+        if not rows:
+            return
+        num_cols = max([len(row) for row in rows])
+        if not columns:
+            columns = [f"Column {i}" for i in range(1, num_cols + 1)]
+        if len(columns) < num_cols:
+            columns += [f"Column {i}" for i in range(len(columns) + 1, num_cols + 1)]
+        if len(columns) > num_cols:
+            columns = columns[:num_cols]
+
+        data: Dict[str, List[Any]] = {col: [] for col in columns}
+        for row in rows:
+            for index, col in enumerate(columns):
+                data[col].append(row[index])
+
+        df = pd.DataFrame(data)
+        st.dataframe(df)
 
     def render_preview(self, path: str):
-        Preview(path, self).show()
+        with st.container(border=True):
+            col1, col2 = st.columns([0.75, 0.25])
+            with col1:
+                st.text("📄 " + path)
+            with col2:
+                if st.button("View document", key=self.next_key()):
+                    show_pdf_preview(path)
 
     def render_suggested_query(self, query: str):
         if self.button(query):
@@ -322,7 +356,7 @@ class ChatMessage:
 
     def render_map(self, data: List[Tuple[float, float]]):
         df = pd.DataFrame(data, columns=["lat", "lon"])
-        st.map(df)
+        st.map(df, color="#00ff00", size=100)
 
     def to_dict(self) -> Optional[Dict[str, Any]]:
         return self.message
@@ -376,43 +410,6 @@ TOOLS_RAG: List[ChatCompletionToolParam] = [
         },
     },
 ]
-
-
-def parse_s3_path(s3_path: str) -> Tuple[str, str]:
-    """Parse an S3 path into a bucket and key."""
-    s3_path = s3_path.replace("s3://", "")
-    bucket, key = s3_path.split("/", 1)
-    return bucket, key
-
-
-class Preview:
-    def __init__(self, path: str, chat_message: ChatMessage):
-        self.path = path
-        self.chat_message = chat_message
-
-    def show(self):
-        if self.path.startswith("s3://"):
-            bucket, key = parse_s3_path(self.path)
-            s3 = boto3.client("s3")
-            response = s3.get_object(Bucket=bucket, Key=key)
-            content = response["Body"].read()
-        elif self.path.startswith("http"):
-            content = requests.get(self.path, timeout=30).content
-        else:
-            st.write(f"Unknown path format: {self.path}")
-            return
-
-        if st.session_state.get("pagenum") is None:
-            st.session_state.pagenum = 1
-
-        with st.container(border=True):
-            st.write(f"`{self.path}`")
-            encoded = base64.b64encode(content).decode("utf-8")
-            pdf_display = (
-                f'<iframe src="data:application/pdf;base64,{encoded}" '
-                + 'width="600" height="800" type="application/pdf"></iframe>'
-            )
-            st.markdown(pdf_display, unsafe_allow_html=True)
 
 
 def get_embedding_model_id() -> str:
@@ -500,12 +497,15 @@ def query_data_source(query: str, index: str) -> Tuple[Any, Optional[Any], Optio
         )
         with st.spinner("Generating plan..."):
             plan = generate_plan(sqclient, query, index)
+            print(f"Generated plan:\n{plan}\n")
             # No need to show the prompt used in the demo.
             plan.llm_prompt = None
             with st.expander("Query plan"):
                 st.write(plan)
         with st.spinner("Running Sycamore query..."):
+            print("Running plan...")
             query_id, result = run_plan(sqclient, plan)
+            print(f"Ran query ID: {query_id}")
         return result, plan, query_id
 
 
@@ -547,12 +547,14 @@ def show_messages():
 def do_query():
     prompt = st.session_state.user_query
     st.session_state.user_query = None
+    print(f"User query: {prompt}")
     user_message = ChatMessage({"role": "user", "content": prompt})
     st.session_state.messages.append(user_message)
     user_message.show()
 
     assistant_message = None
     query_plan = None
+    query_id = None
     tool_response_str = None
     with st.chat_message("assistant"):
         # We loop here because tool calls require re-invoking the LLM.
@@ -602,6 +604,7 @@ def do_query():
                     st.error(f"Error running Sycamore query: {e}")
                     tool_response_str = f"There was an error running your query: {e}"
                 finally:
+                    print(f"\nTool response: {tool_response_str}")
                     tool_response_message = ChatMessage(
                         {
                             "role": "tool",
@@ -618,20 +621,20 @@ def do_query():
                 # No function call was made.
                 assistant_message.show_content()
                 if query_plan:
-                    assistant_message.extras.append(ChatMessageExtra("Query plan", query_plan))
+                    assistant_message.before_extras.append(ChatMessageExtra("Query plan", query_plan))
                 if tool_response_str:
-                    assistant_message.extras.append(ChatMessageExtra("Tool response", f"```{tool_response_str}```"))
+                    assistant_message.before_extras.append(
+                        ChatMessageExtra("Tool response", f"```{tool_response_str}```")
+                    )
                 if query_id:
                     cmt = ChatMessageTraces("Query trace", query_id)
                     with st.expander("Query trace"):
                         cmt.show()
-                    assistant_message.extras.append(cmt)
+                    assistant_message.after_extras.append(cmt)
                 break
 
 
 def main():
-    ray_init(address="auto")
-
     # Set a default model
     if "openai_model" not in st.session_state:
         st.session_state["openai_model"] = "gpt-4o"

--- a/apps/query-demo/querydemo/util.py
+++ b/apps/query-demo/querydemo/util.py
@@ -4,7 +4,7 @@ import os
 import pickle
 import zipfile
 import pandas as pd
-from typing import Any, Dict, Set, Tuple
+from typing import Any, Dict, List, Set, Tuple
 
 import ray
 import streamlit as st
@@ -80,13 +80,15 @@ def show_dag(plan: LogicalPlan):
     agraph(nodes=nodes, edges=edges, config=config)
 
 
-@st.experimental_fragment
-def show_query_traces(trace_dir: str, query_id: str):
-    """Show the query traces in the given trace_dir."""
-    trace_dir = os.path.join(trace_dir, query_id)
-    for node_id in sorted(os.listdir(trace_dir)):
-        data_list = []
-        directory = os.path.join(trace_dir, node_id)
+class QueryNodeTrace:
+    def __init__(self, trace_dir: str, node_id: str):
+        self.trace_dir = trace_dir
+        self.node_id = node_id
+        self.docs: List[Dict[str, Any]] = []
+        self.readdata()
+
+    def readdata(self):
+        directory = os.path.join(self.trace_dir, self.node_id)
         for filename in os.listdir(directory):
             f = os.path.join(directory, filename)
             if os.path.isfile(f):
@@ -94,12 +96,12 @@ def show_query_traces(trace_dir: str, query_id: str):
                     try:
                         doc = pickle.load(file)
                     except EOFError:
-                        doc = []
-
+                        continue
                     # For now, skip over MetadataDocuments.
-                    if "doc_id" not in doc:
+                    if "metadata" in doc.keys():
                         continue
 
+                    # Flatten properties.
                     if "properties" in doc:
                         for property in doc["properties"]:
                             if isinstance(doc["properties"][property], dict):
@@ -110,21 +112,67 @@ def show_query_traces(trace_dir: str, query_id: str):
                             else:
                                 doc[".".join(["properties", property])] = doc["properties"][property]
                         doc.pop("properties")
-                    data_list.append(doc)
 
-        df = pd.DataFrame(data_list)
-        st.write(f"Docset after node {node_id} — {len(df)} documents")
-        st.dataframe(df)
+                    self.docs.append(doc)
 
-    zip_buffer = io.BytesIO()
-    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
-        for root, _, files in os.walk(trace_dir):
-            for filename in files:
-                file_path = os.path.join(root, filename)
-                zf.write(file_path, os.path.relpath(file_path, trace_dir))
-    st.download_button(
-        label="Download Traces as ZIP",
-        data=zip_buffer.getvalue(),
-        file_name=f"traces_{query_id}.zip",
-        mime="application/zip",
-    )
+        # Group by the parent ID.
+        self.parent_docs = [x for x in self.docs if x.get("parent_id") is None]
+        print(self.parent_docs)
+        for doc in self.parent_docs:
+            doc["children"] = [x for x in self.docs if x.get("parent_id") == doc.get("doc_id")]
+
+    def show(self):
+        if not self.parent_docs:
+            st.write(f"Result of node {self.node_id} — **no** documents")
+            st.write("No data.")
+            return
+        st.write(f"Result of node {self.node_id} — **{len(self.parent_docs)}** documents")
+        DEFAULT_COLUMNS = [
+            "properties.path",
+            "properties.entity.accidentNumber",
+            "properties.entity.dateAndTime",
+            "properties.entity.location",
+            "properties.entity.aircraft",
+            "properties.entity.registration",
+            "properties.entity.injuries",
+            "properties.entity.aircraftDamage",
+        ]
+        all_columns = self.parent_docs[0].keys()
+        columns = DEFAULT_COLUMNS + [x for x in all_columns if x not in DEFAULT_COLUMNS]
+
+        # Transpose data to a dict where each key is a column, and each value is a list of rows.
+        data = {col: [] for col in columns}
+        for row in self.parent_docs:
+            for col in columns:
+                data[col].append(row.get(col))
+
+        df = pd.DataFrame(data)
+        st.dataframe(
+            df,
+            column_order=columns,
+            column_config={
+                "properties.path": st.column_config.LinkColumn(
+                    "Document link",
+                    validate=r"^[a-z]+://[a-z\.\/]+$",
+                    max_chars=100,
+                    #            display_text=r"https://(.*?)\.streamlit\.app"
+                )
+            },
+        )
+
+
+class QueryTrace:
+    def __init__(self, trace_dir: str):
+        self.trace_dir = trace_dir
+        self.node_traces = [QueryNodeTrace(trace_dir, node_id) for node_id in sorted(os.listdir(self.trace_dir))]
+
+    def show(self):
+        for node_trace in self.node_traces:
+            node_trace.show()
+
+
+@st.fragment
+def show_query_traces(trace_dir: str, query_id: str):
+    """Show the query traces in the given trace_dir."""
+    trace_dir = os.path.join(trace_dir, query_id)
+    QueryTrace(trace_dir).show()

--- a/apps/query-ui/poetry.lock
+++ b/apps/query-ui/poetry.lock
@@ -1266,6 +1266,28 @@ docs = ["ipython", "matplotlib", "numpydoc", "sphinx"]
 tests = ["pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
+name = "dateparser"
+version = "1.2.0"
+description = "Date parsing library designed to parse dates from HTML pages"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "dateparser-1.2.0-py2.py3-none-any.whl", hash = "sha256:0b21ad96534e562920a0083e97fd45fa959882d4162acc358705144520a35830"},
+    {file = "dateparser-1.2.0.tar.gz", hash = "sha256:7975b43a4222283e0ae15be7b4999d08c9a70e2d378ac87385b1ccf2cffbbb30"},
+]
+
+[package.dependencies]
+python-dateutil = "*"
+pytz = "*"
+regex = "<2019.02.19 || >2019.02.19,<2021.8.27 || >2021.8.27"
+tzlocal = "*"
+
+[package.extras]
+calendars = ["convertdate", "hijri-converter"]
+fasttext = ["fasttext"]
+langdetect = ["langdetect"]
+
+[[package]]
 name = "decorator"
 version = "5.1.1"
 description = "Decorators for Humans"
@@ -1398,6 +1420,16 @@ files = [
     {file = "editdistance-0.8.1-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b978c5927100a57791131dd2418040f4e5d33970d37b97a84c1a530ec481f557"},
     {file = "editdistance-0.8.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:0c96a8e981f385f0b7392d047c5caab8e0b24f94b71120787fd78241efc34237"},
     {file = "editdistance-0.8.1.tar.gz", hash = "sha256:d1cdf80a5d5014b0c9126a69a42ce55a457b457f6986ff69ca98e4fe4d2d8fed"},
+]
+
+[[package]]
+name = "events"
+version = "0.5"
+description = "Bringing the elegance of C# EventHandler to Python"
+optional = false
+python-versions = "*"
+files = [
+    {file = "Events-0.5-py3-none-any.whl", hash = "sha256:a7286af378ba3e46640ac9825156c93bdba7502174dd696090fdfcd4d80a1abd"},
 ]
 
 [[package]]
@@ -3246,6 +3278,34 @@ files = [
 ]
 
 [[package]]
+name = "opensearch-py"
+version = "2.6.0"
+description = "Python client for OpenSearch"
+optional = false
+python-versions = "<4,>=3.8"
+files = [
+    {file = "opensearch_py-2.6.0-py2.py3-none-any.whl", hash = "sha256:b6e78b685dd4e9c016d7a4299cf1de69e299c88322e3f81c716e6e23fe5683c1"},
+    {file = "opensearch_py-2.6.0.tar.gz", hash = "sha256:0b7c27e8ed84c03c99558406927b6161f186a72502ca6d0325413d8e5523ba96"},
+]
+
+[package.dependencies]
+certifi = ">=2022.12.07"
+Events = "*"
+python-dateutil = "*"
+requests = ">=2.4.0,<3.0.0"
+six = "*"
+urllib3 = [
+    {version = ">=1.26.18,<1.27", markers = "python_version < \"3.10\""},
+    {version = ">=1.26.18,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""},
+]
+
+[package.extras]
+async = ["aiohttp (>=3.9.4,<4)"]
+develop = ["black (>=24.3.0)", "botocore", "coverage (<8.0.0)", "jinja2", "mock", "myst-parser", "pytest (>=3.0.0)", "pytest-cov", "pytest-mock (<4.0.0)", "pytz", "pyyaml", "requests (>=2.0.0,<3.0.0)", "sphinx", "sphinx-copybutton", "sphinx-rtd-theme"]
+docs = ["aiohttp (>=3.9.4,<4)", "myst-parser", "sphinx", "sphinx-copybutton", "sphinx-rtd-theme"]
+kerberos = ["requests-kerberos"]
+
+[[package]]
 name = "ordered-set"
 version = "4.1.0"
 description = "An OrderedSet is a custom MutableSet that remembers its order, so that every"
@@ -4786,7 +4846,7 @@ typing = ["mypy (>=1.4)", "rich", "twisted"]
 
 [[package]]
 name = "sycamore-ai"
-version = "0.1.19"
+version = "0.1.21"
 description = "Sycamore is an LLM-powered semantic data preparation system for building search applications."
 optional = false
 python-versions = ">=3.9,<3.12"
@@ -4800,6 +4860,7 @@ async-timeout = ">4.0.0"
 beautifulsoup4 = "^4.12.2"
 boto3 = "^1.28.70"
 boto3-stubs = {version = "^1.35.12", extras = ["essential"]}
+dateparser = "^1.2.0"
 diskcache = "^5.6.3"
 fasteners = "^0.19"
 fsspec = "2024.2.0"
@@ -4807,6 +4868,7 @@ guidance = "0.1.14"
 jinja2 = "^3.1"
 numpy = "<2.0.0"
 openai = "^1.40.2"
+opensearch-py = {version = "^2.3.1", optional = true}
 overrides = "^7.7.0"
 pandas = "^2.1.1"
 pdf2image = "^1.16.3"
@@ -5183,6 +5245,23 @@ files = [
     {file = "tzdata-2024.1-py2.py3-none-any.whl", hash = "sha256:9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252"},
     {file = "tzdata-2024.1.tar.gz", hash = "sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd"},
 ]
+
+[[package]]
+name = "tzlocal"
+version = "5.2"
+description = "tzinfo object for the local timezone"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "tzlocal-5.2-py3-none-any.whl", hash = "sha256:49816ef2fe65ea8ac19d19aa7a1ae0551c834303d5014c6d5a62e4cbda8047b8"},
+    {file = "tzlocal-5.2.tar.gz", hash = "sha256:8d399205578f1a9342816409cc1e46a93ebd5755e39ea2d85334bea911bf0e6e"},
+]
+
+[package.dependencies]
+tzdata = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+devenv = ["check-manifest", "pytest (>=4.3)", "pytest-cov", "pytest-mock (>=3.3)", "zest.releaser"]
 
 [[package]]
 name = "uc-micro-py"
@@ -5600,4 +5679,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.9.7 || >3.9.7,<3.12"
-content-hash = "965d53a72d0ffa5c61d01000a5b4cc1ff370c104dd4de52d33f1df4656db751d"
+content-hash = "ef19a6b7784b03693e06991eae0440ee5096c986ac5ae66baf0dfe35085935e3"

--- a/apps/query-ui/queryui/util.py
+++ b/apps/query-ui/queryui/util.py
@@ -134,10 +134,10 @@ def show_query_traces(trace_dir: str, query_id: str):
                     try:
                         doc = pickle.load(file)
                     except EOFError:
-                        doc = []
+                        continue
 
                     # For now, skip over MetadataDocuments.
-                    if "doc_id" not in doc:
+                    if "metadata" in doc.keys():
                         continue
 
                     if "properties" in doc:

--- a/lib/sycamore/sycamore/transforms/extract_entity.py
+++ b/lib/sycamore/sycamore/transforms/extract_entity.py
@@ -138,13 +138,11 @@ class OpenAIEntityExtractor(EntityExtractor):
         value = str(document.field_to_value(self._field))
 
         if isinstance(self._prompt, str):
-            self._prompt += value
-            response = self._llm.generate(prompt_kwargs={"prompt": self._prompt}, llm_kwargs={})
+            prompt = self._prompt + value
+            response = self._llm.generate(prompt_kwargs={"prompt": prompt}, llm_kwargs={})
         else:
-            if self._prompt is None:
-                self._prompt = []
-            self._prompt.append({"role": "user", "content": value})
-            response = self._llm.generate(prompt_kwargs={"messages": self._prompt}, llm_kwargs={})
+            messages = (self._prompt or []) + [{"role": "user", "content": value}]
+            response = self._llm.generate(prompt_kwargs={"messages": messages}, llm_kwargs={})
 
         return response
 


### PR DESCRIPTION
This PR implements a query trace viewer for the Luna demo, which shows the top-level documents emitted from each stage of the query plan. I intend to improve this over time but wanted to get the first version out there.

I've also moved the PDF previews into a dialog so they don't clutter the conversation view.

![Screenshot 2024-09-19 at 10 12 01 AM](https://github.com/user-attachments/assets/5e52f765-092e-4a14-a2d7-1d9f08cd0420)
![Screenshot 2024-09-19 at 10 12 05 AM](https://github.com/user-attachments/assets/44334127-f78d-4641-855e-f7e30f104ba1)
