### PR TITLE
Fix query trace viewer.

### DIFF
--- a/apps/query-demo/querydemo/Query_Demo.py
+++ b/apps/query-demo/querydemo/Query_Demo.py
@@ -336,7 +336,11 @@ class ChatMessage:
         data: Dict[str, List[Any]] = {col: [] for col in columns}
         for row in rows:
             for index, col in enumerate(columns):
-                data[col].append(row[index])
+                try:
+                    data[col].append(row[index])
+                except IndexError:
+                    # This can happen if we end up with missing cells in the MDX.
+                    data[col].append(None)
 
         df = pd.DataFrame(data)
         st.dataframe(df)

--- a/apps/query-demo/querydemo/util.py
+++ b/apps/query-demo/querydemo/util.py
@@ -3,7 +3,7 @@ import logging
 import os
 import pickle
 import pandas as pd
-from typing import Any, Dict, List, Set, Tuple
+from typing import Any, Dict, Set, Tuple
 
 import boto3
 import ray


### PR DESCRIPTION
This PR updates the query trace view code to be much more selective about how much data from the traces it retains in memory, and how much it throws at streamlit to render. It also ensures consistency in terms of the column ordering.

This fixes problems with, e.g., TopK queries crashing Streamlit due to OOM.
