### PR TITLE
Sundry improvements while using luna in a customer.

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Run more tests
         run: poetry run python sycamore/tests/manual/test_fast_sycamore_import.py
         working-directory: lib/sycamore
+      - name: Run query-ui test
+        run: poetry run bash -c 'cd ../../apps/query-ui && PYTHONPATH=. pytest .'
+        working-directory: lib/sycamore
       - name: DF-6
         run: df
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -74,7 +74,8 @@ jobs:
         run: poetry run python sycamore/tests/manual/test_fast_sycamore_import.py
         working-directory: lib/sycamore
       - name: Run query-ui test
-        run: poetry run bash -c 'cd ../../apps/query-ui && PYTHONPATH=. pytest .'
+        run: poetry run bash -c 'cd ../../apps/query-ui/queryui && PYTHONPATH=. pytest .'
+        # run here because that's where the poetry venv is set up.
         working-directory: lib/sycamore
       - name: DF-6
         run: df

--- a/apps/jupyter/bind_dir/setup.sh
+++ b/apps/jupyter/bind_dir/setup.sh
@@ -34,6 +34,6 @@ if [[ -f /app/sycamore.git/README.md ]]; then
     done
     # Reinstall everything that's been installed
     for i in $(cat /app/.poetry.install); do
-        ./poetry-install.sh $i
+        ./poetry-install.sh $(echo $i | sed 's/,/ /')
     done
 fi

--- a/apps/query-ui/external_ray_wrapper.py
+++ b/apps/query-ui/external_ray_wrapper.py
@@ -13,8 +13,12 @@ while not ray.is_initialized():
     time.sleep(1)
 
 os.environ["EXTERNAL_RAY"] = "1"
+os.environ["PYTHONPATH"] = "apps/query-ui/queryui"
 
 while True:
     print("Starting streamlit process...", flush=True)
-    ret = subprocess.run(["python", "-m", "streamlit", "run", "apps/query-ui/queryui/Sycamore_Query.py"])
+    # Hardcode the port so you can't accidentally be using a previous run of the app
+    ret = subprocess.run(
+        ["python", "-m", "streamlit", "run", "apps/query-ui/queryui/Sycamore_Query.py", "--server.port", "8501"]
+    )
     print(f"Subprocess exited {ret}", flush=True)

--- a/apps/query-ui/queryui/configuration.py
+++ b/apps/query-ui/queryui/configuration.py
@@ -1,34 +1,29 @@
-from sycamore.context import Context
+from typing import Optional
 
 from sycamore.query.client import SycamoreQueryClient
 
-import logging
-
-logging.basicConfig(level=logging.INFO)
-
-
 """
-If you want to use custom LLMs (or just a custom context in general, you can create a file called custom_client.py
-and overload 
-    code:
-        def get_custom_sycamore_query_client(llm, s3_cache_path, os_client_args, trace_dir, **kwargs) -> Context:
+If you want to use custom LLMs or a custom context to override opensearch parameters, edit the
+get_sycamore_query_client function below.
+
+For example, you can write:
+    context = sycamore.init(params={
+        "default": {"llm": OpenAI(OpenAIModels.GPT_4O.value, cache=cache_from_path(s3_cache_path))},
+        "opensearch": {"os_client_args": get_opensearch_client_args(),
+                       "text_embedder": SycamoreQueryClient.default_text_embedder()}
+    })
+    return SycamoreQueryClient(context=context, trace_dir=trace_dir)
+
+Note that if you include keys in your configuration, it is safer to write:
+    import mycompany_configuration
+    return mycompany_configuration.get_sycamore_query_client(s3_cache_path, trace_dir)
+
+We require you to edit this file so that if the arguments to get_sycamore_query_client change you
+will get a merge conflict.
 """
 
 
-def get_default_sycamore_query_client(
-    llm=None, s3_cache_path=None, os_client_args=None, trace_dir=None, **kwargs
-) -> Context:
-    return SycamoreQueryClient(s3_cache_path=s3_cache_path, os_client_args=os_client_args, trace_dir=trace_dir)
-
-
-def get_sycamore_query_client(**kwargs) -> Context:
-    try:
-        import custom_client
-
-        get_sycamore_query_client_impl = custom_client.get_custom_sycamore_query_client
-        logging.info("Using custom `get_custom_sycamore_query_client(..)` from custom_client")
-    except (ImportError, AttributeError):
-        logging.info("Using default `get_sycamore_query_client(..)`")
-        get_sycamore_query_client_impl = get_default_sycamore_query_client
-
-    return get_sycamore_query_client_impl(**kwargs)
+def get_sycamore_query_client(
+    s3_cache_path: Optional[str] = None, trace_dir: Optional[str] = None
+) -> SycamoreQueryClient:
+    return SycamoreQueryClient(s3_cache_path=s3_cache_path, trace_dir=trace_dir)

--- a/apps/query-ui/queryui/custom_client.py.sample
+++ b/apps/query-ui/queryui/custom_client.py.sample
@@ -1,6 +1,0 @@
-from sycamore.context import Context
-from sycamore.query.client import SycamoreQueryClient
-
-
-def get_sycamore_query_client(llm= None, s3_cache_path=None, os_client_args=None, trace_dir=None, **kwargs) -> Context:
-    return SycamoreQueryClient(s3_cache_path=s3_cache_path, os_client_args=os_client_args, trace_dir=trace_dir)

--- a/apps/query-ui/queryui/test_configuration.py
+++ b/apps/query-ui/queryui/test_configuration.py
@@ -7,4 +7,4 @@ def test_configuration_sha():
         sha = sha256(bytes).hexdigest()
         # If the change was intentional, update the hash
         # Think about whether you have to make the change since everyone with a custom config will need to update it
-        assert sha == "c8805d3e9a641a6e29a947e179a8eb7441567ecbbc238bc7a39c8ea2e2c811cf", f"hash mismatch got {sha}"
+        assert sha == "1c12bf1d3437a494d24910bf2073b7461ac6dfa4c37c25d9929878fc35be9d40", f"hash mismatch got {sha}"

--- a/apps/query-ui/queryui/test_configuration.py
+++ b/apps/query-ui/queryui/test_configuration.py
@@ -1,0 +1,10 @@
+def test_configuration_sha():
+    from hashlib import sha256
+    import configuration
+
+    with open(configuration.__file__, "rb") as f:
+        bytes = f.read()
+        sha = sha256(bytes).hexdigest()
+        # If the change was intentional, update the hash
+        # Think about whether you have to make the change since everyone with a custom config will need to update it
+        assert sha == "c8805d3e9a641a6e29a947e179a8eb7441567ecbbc238bc7a39c8ea2e2c811cf", f"hash mismatch got {sha}"

--- a/examples/query/simple_ntsb.py
+++ b/examples/query/simple_ntsb.py
@@ -12,7 +12,7 @@ schema = client.get_opensearch_schema(OS_INDEX)
 # console.print(schema)
 
 plan = client.generate_plan(QUERY, OS_INDEX, schema)
-# plan.show(verbose=True)
+# from sycamore.query.visualize import visualize_plan
 # visualize_plan(plan)
 
 # WARNING: As of 2024-09-03, the results are inconsistent; you can get different results

--- a/lib/sycamore/sycamore/query/client.py
+++ b/lib/sycamore/sycamore/query/client.py
@@ -102,7 +102,7 @@ class SycamoreQueryClient:
         trace_dir (optional): Directory to write query execution trace.
 
     Notes:
-        If you override the context. You cannot override the s3_cache_path or os_client_args; you need
+        If you override the context, you cannot override the s3_cache_path or os_client_args; you need
         to pass those in via the context paramaters, i.e. sycamore.init(params={...})
 
         To override os_client_args, set params["opensearch"]["os_client_args"]. You are likely to also need
@@ -129,6 +129,8 @@ class SycamoreQueryClient:
         self.os_config = os_config
         self.trace_dir = trace_dir
 
+        # TODO: remove these assertions and simplify the code to get all customization via the
+        # context.
         if context and os_client_args:
             raise AssertionError("setting os_client_args requires context==None. See Notes in class documentation.")
 


### PR DESCRIPTION
setup.sh: Remove the , that was added. We need the , to get multiple simultaneous installs in a single bunch, and need to remove it for the script.

.force_directory_creation: Empty file to make sure the cache_dir exists to allow running the container

configuration.py: Change the way we hook a custom client into the query ui -- the existing approach
  was fragile. If the API for specifying the custom client changes, we want people to get a git
  conflict when they try to merge because they probably have to adjust how they configure the
  client. By always running the code we can be sure that it parses, it was very easy to have a bug
  in parsing cause it to not work. For example, the sample file had the wrong function name. Remove
  some parameters that are not useful, a custom client can't take an llm because it would not be able
  to replace the llm with whatever customization is needed. Similarly os_client_args don't make sense
  because the customization may have to specify those values. Luckily nothing used those parameters.
  Add an example of how to use the configuration to override things -- we should eventually add for
  overriding, but it probably makes sense to only do that for the query-demo UI since query-ui is
  mostly obsolete now.

test_configuration.py: Make sure that if people are changing stuff they intend it.

simple_ntsb.py: plan.show() no longer works, remove it.

client.py: Add documentation on the rules for overriding parameters, and have the assertions
  point people at that documentation. I had to read the code to understand the existing assertion messages.
  I think the text_embedder is also needed if you specify opensearch so document that as well.
  Fix bug where not specifying os_client_args in the context, but specifying the llm didn't work.