### PR TITLE
Have Luna use .keyword field for path field.

### DIFF
--- a/apps/query-ui/queryui/Sycamore_Query.py
+++ b/apps/query-ui/queryui/Sycamore_Query.py
@@ -101,27 +101,29 @@ st.title("Sycamore Query")
 if "trace_dir" not in st.session_state:
     st.session_state.trace_dir = os.path.join(os.getcwd(), "traces")
 
+if "index" not in st.session_state:
+    st.session_state.index = None
+
 client = get_sycamore_query_client()
 st.selectbox("Index", util.get_opensearch_indices(), key="index")
-show_schema(client, st.session_state.index)
 
+if st.session_state.index:
+    show_schema(client, st.session_state.index)
+    with st.form("query_form"):
+        st.text_input("Query", key="query")
+        schema_container = st.container()
+        col1, col2, col3, col4 = st.columns(4)
+        with col1:
+            submitted = st.form_submit_button("Run query")
+        with col2:
+            st.toggle("Plan only", key="plan_only", value=False)
+        with col3:
+            st.toggle("Capture traces", key="do_trace", value=True)
+        with col4:
+            st.toggle("Use cache", key="use_cache", value=True)
+        with st.expander("Advanced"):
+            st.text_input("S3 cache path", key="s3_cache_path", value=DEFAULT_S3_CACHE_PATH)
+            st.session_state.trace_dir = st.text_input("Trace directory", value=st.session_state.trace_dir)
 
-with st.form("query_form"):
-    st.text_input("Query", key="query")
-    schema_container = st.container()
-    col1, col2, col3, col4 = st.columns(4)
-    with col1:
-        submitted = st.form_submit_button("Run query")
-    with col2:
-        st.toggle("Plan only", key="plan_only", value=False)
-    with col3:
-        st.toggle("Capture traces", key="do_trace", value=True)
-    with col4:
-        st.toggle("Use cache", key="use_cache", value=True)
-    with st.expander("Advanced"):
-        st.text_input("S3 cache path", key="s3_cache_path", value=DEFAULT_S3_CACHE_PATH)
-        st.session_state.trace_dir = st.text_input("Trace directory", value=st.session_state.trace_dir)
-
-
-if submitted:
-    run_query()
+    if submitted:
+        run_query()

--- a/lib/sycamore/sycamore/connectors/opensearch/opensearch_writer.py
+++ b/lib/sycamore/sycamore/connectors/opensearch/opensearch_writer.py
@@ -43,7 +43,7 @@ class OpenSearchWriterTargetParams(BaseDBWriter.TargetParams):
                     "type": "knn_vector",
                     "dimension": 384,
                     "method": {"name": "hnsw", "engine": "faiss"},
-                },
+                }
             }
         }
     )

--- a/lib/sycamore/sycamore/query/operators/query_database.py
+++ b/lib/sycamore/sycamore/query/operators/query_database.py
@@ -12,8 +12,9 @@ class QueryDatabase(LogicalOperator):
     query: Optional[Dict] = None
     """A query in OpenSearch Query DSL format. This can be used to perform full-text queries,
     term-level queries for specific fields, and more. Here is an example of a query that
-    retrieves all documents that have a properties.entity.location field containing the word
-    "Georgia" and an isoDateTime field between July 1, 2023, and September 30, 2024:
+    retrieves all documents where the "properties.path" field matches the wildcard
+    expression "/path/to/data/*.pdf", and that have a properties.entity.location field containing
+    the word "Georgia" and an isoDateTime field between July 1, 2023, and September 30, 2024.
 
     {
         "query": {
@@ -30,6 +31,7 @@ class QueryDatabase(LogicalOperator):
                     },
                     {
                         "match": {
+                            "properties.path.keyword": "/path/to/data/*.pdf",
                             "properties.entity.location": "Georgia"
                         }
                     }
@@ -37,6 +39,9 @@ class QueryDatabase(LogicalOperator):
             }
         }
     }
+
+    Use the ".keyword" subfield for "properties.path", as this field represents the filename of the
+    original document, and is generally accessed as a keyword field.
 
     The full range of OpenSearch Query DSL parameters are supported.
     Whenever possible, use the query parameter to filter data at the source, as this is more


### PR DESCRIPTION
This PR fixes an issue where Luna would issue an OpenSearch query using the `match` operator against the `properties.path` field, which does not do the right thing in most cases. This change has it use the `.keyword` version
of this field instead, with a wildcard match.

This pattern should probably generalize to other kinds of fields where a keyword match is more appropriate, but there
needs to be more thought into how that would be done.
