### PR TITLE
Improve luna property handling

### DIFF
--- a/lib/sycamore/sycamore/data/document.py
+++ b/lib/sycamore/sycamore/data/document.py
@@ -225,15 +225,9 @@ class Document(UserDict):
             The value associated with the document field.
             Returns None if field does not exist in document.
         """
-        fields = field.split(".")
-        value = self.get(fields[0], None)
-        if len(fields) > 1:
-            for f in fields[1:]:
-                if isinstance(value, dict):
-                    value = value.get(f, None)
-                else:
-                    return None
-        return value
+        from sycamore.utils.nested import dotted_lookup
+
+        return dotted_lookup(self, field)
 
 
 class MetadataDocument(Document):

--- a/lib/sycamore/sycamore/query/client.py
+++ b/lib/sycamore/sycamore/query/client.py
@@ -152,7 +152,11 @@ class SycamoreQueryClient:
 
     @requires_modules("opensearchpy.client.indices", extra="opensearch")
     def get_opensearch_schema(self, index: str) -> OpenSearchSchema:
-        """Get the schema for the provided OpenSearch index."""
+        """Get the schema for the provided OpenSearch index.
+
+        To debug:
+        logging.getLogger("sycamore.query.schema").setLevel(logging.DEBUG)
+        """
         from opensearchpy.client.indices import IndicesClient
 
         schema_provider = OpenSearchSchemaFetcher(IndicesClient(self._os_client), index, self._os_query_executor)

--- a/lib/sycamore/sycamore/query/schema.py
+++ b/lib/sycamore/sycamore/query/schema.py
@@ -40,7 +40,6 @@ class OpenSearchSchemaFetcher:
         query["index"] = self._index
         query["query"] = {"query": {"match_all": {}}, "size": self.NUM_EXAMPLES}
         random_sample = self._query_executor.query(query)["result"]["hits"]["hits"]
-        # logger.debug(f"Random sample came back with {random_sample}")
         result: OpenSearchSchema = {}
         result["text_representation"] = ("<class 'str'>", {"Can be assumed to have all other details"})
 

--- a/lib/sycamore/sycamore/query/schema.py
+++ b/lib/sycamore/sycamore/query/schema.py
@@ -1,14 +1,18 @@
+import logging
 import typing
 from typing import Dict, Set, Tuple
 
 from sycamore.transforms.query import OpenSearchQueryExecutor
 from sycamore.data import OpenSearchQuery
+from sycamore.utils.nested import dotted_lookup
 
 if typing.TYPE_CHECKING:
     from opensearchpy.client.indices import IndicesClient
 
 OpenSearchSchema = Dict[str, Tuple[str, Set[str]]]
 """Represents a mapping from field name to field type and a set of example values."""
+
+logger = logging.getLogger(__name__)
 
 
 class OpenSearchSchemaFetcher:
@@ -31,32 +35,55 @@ class OpenSearchSchemaFetcher:
         schema = self._client.get_field_mapping(fields=["*"], index=self._index)
         query = OpenSearchQuery()
 
+        logger.debug(f"Getting schema for index {self._index}")
         # Fetch example values.
         query["index"] = self._index
         query["query"] = {"query": {"match_all": {}}, "size": self.NUM_EXAMPLES}
         random_sample = self._query_executor.query(query)["result"]["hits"]["hits"]
+        # logger.debug(f"Random sample came back with {random_sample}")
         result: OpenSearchSchema = {}
         result["text_representation"] = ("<class 'str'>", {"Can be assumed to have all other details"})
 
         # Get type and example values for each field.
         for key in schema[self._index]["mappings"].keys():
-            # We only care about fields with the "properties.entity" prefix.
-            if not key.startswith("properties.entity") or ".keyword" in key:
+            if key.endswith(".keyword"):
+                logger.debug(f"  Ignoring redundant exact match .keyword key {key}")
+                continue
+            if not key.startswith("properties."):
+                logger.debug(f"  Ignoring non-properties key {key} as they are likely not from sycamore")
                 continue
             try:
+                logger.debug(f"  Attempting to get samples for key {key}")
                 samples: set[str] = set()
                 sample_type = None
                 for sample in random_sample:
                     if len(samples) >= self.NUM_EXAMPLE_VALUES:
                         break
-                    sample_value = sample["_source"]["properties"]["entity"].get(key[18:], None)
+                    sample_value = dotted_lookup(sample["_source"], key)
                     if sample_value is not None:
                         if not sample_type:
                             sample_type = type(sample_value)
+                        else:
+                            t = type(sample_value)
+                            if str(t) != str(sample_type):
+                                if str(t) == "<class 'int'>" and str(sample_type) == "<class 'float'>":
+                                    pass  # compatible
+                                elif str(sample_type) == "<class 'int'>" and str(t) == "<class 'float'>":
+                                    sample_type = t  # upgrade
+                                else:
+                                    logger.warning(
+                                        "Got multiple sample types for key"
+                                        + f" {key}: {sample_type} and {t}. Keeping the former"
+                                    )
+
                         samples.add(str(sample_value))
                 if len(samples) > 0:
+                    logger.debug(f"  Got samples for {key} of type {sample_type}")
                     result[key] = (str(sample_type), {str(example) for example in samples})
+                else:
+                    logger.debug(f"  No samples for {key}; ignoring key")
             except KeyError:
+                logger.debug(f"  Error retrieving samples for {key}")
                 # This can happen if there are mappings that have no corresponding values.
                 # Skip them.
                 continue

--- a/lib/sycamore/sycamore/tests/unit/query/test_schema.py
+++ b/lib/sycamore/sycamore/tests/unit/query/test_schema.py
@@ -96,7 +96,7 @@ def test_opensearch_schema():
         }
     }
 
-    # Verify we can handle schems where int and float are both used
+    # Verify we can handle schemas where int and float are both used
     airspeeds = [500, 37.5, 300, 217.11]
     for i in airspeeds:
         mock_random_sample["result"]["hits"]["hits"].append({"_source": {"properties": {"entity": {"airspeed": i}}}})

--- a/lib/sycamore/sycamore/tests/unit/query/test_schema.py
+++ b/lib/sycamore/sycamore/tests/unit/query/test_schema.py
@@ -1,6 +1,10 @@
+import logging
+
 from unittest.mock import MagicMock
 
 from sycamore.query.schema import OpenSearchSchemaFetcher
+
+logging.getLogger("sycamore.query.schema").setLevel(logging.DEBUG)
 
 
 def test_opensearch_schema():
@@ -39,6 +43,24 @@ def test_opensearch_schema():
                         "colors": {"type": "array", "fields": {"keyword": {"type": "keyword", "ignore_above": 256}}}
                     },
                 },
+                "properties.entity.airspeed": {
+                    "full_name": "properties.entity.airspeed",
+                    "mapping": {
+                        "airspeed": {"type": "array", "fields": {"keyword": {"type": "keyword", "ignore_above": 256}}}
+                    },
+                },
+                "properties.entity.weird": {
+                    "full_name": "properties.entity.weird",
+                    "mapping": {
+                        "weird": {"type": "array", "fields": {"keyword": {"type": "keyword", "ignore_above": 256}}}
+                    },
+                },
+                "properties.happiness": {
+                    "full_name": "properties.happiness",
+                    "mapping": {
+                        "happiness": {"type": "array", "fields": {"keyword": {"type": "keyword", "ignore_above": 256}}}
+                    },
+                },
             }
         }
     }
@@ -52,7 +74,8 @@ def test_opensearch_schema():
                     {
                         "_source": {
                             "properties": {
-                                "entity": {"day": "2021-01-01", "aircraft": "Boeing 747", "colors": ["red", "blue"]}
+                                "entity": {"day": "2021-01-01", "aircraft": "Boeing 747", "colors": ["red", "blue"]},
+                                "happiness": "yes",
                             }
                         }
                     },
@@ -72,6 +95,16 @@ def test_opensearch_schema():
             }
         }
     }
+
+    # Verify we can handle schems where int and float are both used
+    airspeeds = [500, 37.5, 300, 217.11]
+    for i in airspeeds:
+        mock_random_sample["result"]["hits"]["hits"].append({"_source": {"properties": {"entity": {"airspeed": i}}}})
+
+    # Verify we tolerate schemas where the types are incompatible
+    weird = [True, 500, "alphabetical"]
+    for i in weird:
+        mock_random_sample["result"]["hits"]["hits"].append({"_source": {"properties": {"entity": {"weird": i}}}})
 
     # this is asserting we only take OpenSearchSchemaFetcher.NUM_EXAMPLE_VALUES examples
     for i in range(0, OpenSearchSchemaFetcher.NUM_EXAMPLE_VALUES + 5):
@@ -96,5 +129,8 @@ def test_opensearch_schema():
         "<class 'str'>",
         set([str(i) for i in range(OpenSearchSchemaFetcher.NUM_EXAMPLE_VALUES)]),
     )
+    assert got["properties.entity.airspeed"] == ("<class 'float'>", set([str(a) for a in airspeeds]))
+    assert got["properties.entity.weird"] == ("<class 'bool'>", set([str(w) for w in weird]))
+    assert got["properties.happiness"] == ("<class 'str'>", {"yes"})
 
     assert "properties.entity.location" not in got

--- a/lib/sycamore/sycamore/tests/unit/utils/test_nested.py
+++ b/lib/sycamore/sycamore/tests/unit/utils/test_nested.py
@@ -1,0 +1,25 @@
+from sycamore.utils.nested import nested_lookup, dotted_lookup
+
+
+def test_nested_lookup():
+    v = {"a": {"b": 1, "c": 2, "": 5}, "d": {}}
+    assert nested_lookup(v, ["a", "b"]) == 1
+    assert nested_lookup(v, ["a", "b", "c"]) is None
+    assert nested_lookup(v, ["a", "c"]) == 2
+    assert nested_lookup(v, ["a", ""]) == 5
+    assert nested_lookup(v, ["a", "d"]) is None
+    assert nested_lookup(v, ["d"]) == {}
+    assert nested_lookup(v, ["d", 1]) is None
+    assert nested_lookup(v, [3]) is None
+
+
+def test_dotted_lookup():
+    v = {"a": {"b": 1, "c": 2, "": 5}, "d": {}}
+    assert dotted_lookup(v, "a.b") == 1
+    assert dotted_lookup(v, "a.b.c") is None
+    assert dotted_lookup(v, "a.c") == 2
+    assert dotted_lookup(v, "a.") == 5
+    assert dotted_lookup(v, "a.d") is None
+    assert dotted_lookup(v, "d") == {}
+    assert dotted_lookup(v, "d.1") is None
+    assert dotted_lookup(v, "3") is None

--- a/lib/sycamore/sycamore/utils/nested.py
+++ b/lib/sycamore/sycamore/utils/nested.py
@@ -1,0 +1,18 @@
+from typing import Any
+
+
+def nested_lookup(d: Any, keys: list[str]) -> Any:
+    # Eventually we can support integer indexes into tuples and lists also
+    while len(keys) > 0:
+        if not isinstance(d, dict):
+            return None
+        if keys[0] not in d:
+            return None
+        d = d[keys[0]]
+        keys = keys[1:]
+
+    return d
+
+
+def dotted_lookup(d: Any, keys: str) -> Any:
+    return nested_lookup(d, keys.split("."))

--- a/lib/sycamore/sycamore/utils/nested.py
+++ b/lib/sycamore/sycamore/utils/nested.py
@@ -4,11 +4,13 @@ from typing import Any
 def nested_lookup(d: Any, keys: list[str]) -> Any:
     # Eventually we can support integer indexes into tuples and lists also
     while len(keys) > 0:
-        if not isinstance(d, dict):
+        if d is None:
             return None
-        if keys[0] not in d:
+        try:
+            d = d.get(keys[0])
+        except AttributeError:
             return None
-        d = d[keys[0]]
+
         keys = keys[1:]
 
     return d


### PR DESCRIPTION
* Include all properties instead of the ones just under properties.entity Keys are named with the full path, so it's easy to tell which properties are entity properties.

* Handle properties with varying types, for int/float it takes the most general type. For other cases it takes the first and logs a message since there are likely to be problems.