### PR TITLE
add read.opensearch(reconstruct_document =True) option

### DIFF
--- a/lib/sycamore/sycamore/connectors/opensearch/opensearch_reader.py
+++ b/lib/sycamore/sycamore/connectors/opensearch/opensearch_reader.py
@@ -1,7 +1,8 @@
 import logging
 
-from sycamore.data import Document
+from sycamore.data import Document, Element
 from sycamore.connectors.base_reader import BaseDBReader
+from sycamore.data.document import DocumentPropertyTypes, DocumentSource
 from sycamore.utils.import_utils import requires_modules
 from dataclasses import dataclass, field
 import typing
@@ -21,6 +22,7 @@ class OpenSearchReaderQueryParams(BaseDBReader.QueryParams):
     index_name: str
     query: Dict = field(default_factory=lambda: {"query": {"match_all": {}}})
     kwargs: Dict = field(default_factory=lambda: {})
+    implode: bool = False
 
 
 class OpenSearchReaderClient(BaseDBReader.Client):
@@ -60,7 +62,7 @@ class OpenSearchReaderClient(BaseDBReader.Client):
                 response = self._client.scroll(scroll_id=scroll_id, scroll=query_params.kwargs["scroll"])
         finally:
             self._client.clear_scroll(scroll_id=scroll_id)
-        return OpenSearchReaderQueryResponse(result)
+        return OpenSearchReaderQueryResponse(result, self._client)
 
     def check_target_presence(self, query_params: BaseDBReader.QueryParams):
         assert isinstance(query_params, OpenSearchReaderQueryParams)
@@ -71,17 +73,101 @@ class OpenSearchReaderClient(BaseDBReader.Client):
 class OpenSearchReaderQueryResponse(BaseDBReader.QueryResponse):
     output: list
 
+    """
+    The client used to implement an implosion. Can also be used for lazy loading.
+    """
+    client: typing.Optional["OpenSearch"] = None
+
     def to_docs(self, query_params: "BaseDBReader.QueryParams") -> list[Document]:
-        assert isinstance(self, OpenSearchReaderQueryResponse)
+        assert isinstance(query_params, OpenSearchReaderQueryParams)
         result = []
-        for data in self.output:
-            doc = Document(
-                {
-                    **data.get("_source", {}),
-                }
-            )
-            result.append(doc)
+        if not query_params.implode:
+            for data in self.output:
+                doc = Document(
+                    {
+                        **data.get("_source", {}),
+                    }
+                )
+                result.append(doc)
+        else:
+            assert (
+                self.client is not None
+            ), "Imploded reading requires an OpenSearch client in OpenSearchReaderQueryResponse"
+            """
+            Implode:
+            1. Construct a map of all unique parent Documents (i.e. no parent_id field)
+            2. Perform a terms query to retrieve all (including non-matched) other records for that parent_id
+            3. Add elements to unique parent Documents
+            """
+            # Get unique documents
+            unique_docs: dict[str, Document] = {}
+            query_result_elements_per_doc: dict[str, set[str]] = {}
+            for data in self.output:
+                doc = Document(
+                    {
+                        **data.get("_source", {}),
+                    }
+                )
+                doc.properties[DocumentPropertyTypes.SOURCE] = DocumentSource.DB_QUERY
+                assert doc.doc_id, "Retrieved invalid doc with missing doc_id"
+                if not doc.parent_id:
+                    unique_docs[doc.doc_id] = doc
+                else:
+                    elements = query_result_elements_per_doc.get(doc.parent_id, set())
+                    elements.add(doc.doc_id)
+                    query_result_elements_per_doc[doc.parent_id] = elements
+
+            # Batched retrieval of all elements belong to unique docs
+            doc_ids = list(unique_docs.keys())
+            imploded_elements = self._get_imploded_elements(doc_ids, query_params.index_name)
+
+            """
+            Add elements to unique docs. If they were not part of the original result, 
+            we set properties.implode_result = True
+            """
+            for imploded_element in imploded_elements:
+                doc = Document(
+                    {
+                        **imploded_element.get("_source", {}),
+                    }
+                )
+                assert doc.parent_id, "Got non-element record from OpenSearch implode query"
+                if doc.doc_id not in query_result_elements_per_doc.get(doc.parent_id, {}):
+                    doc.properties[DocumentPropertyTypes.SOURCE] = DocumentSource.IMPLODE_RETRIEVAL
+                else:
+                    doc.properties[DocumentPropertyTypes.SOURCE] = DocumentSource.DB_QUERY
+                parent = unique_docs[doc.parent_id]
+                parent.elements.append(Element(doc.data))
+
+            result = list(unique_docs.values())
+
         return result
+
+    def _get_imploded_elements(self, doc_ids: list[str], index: str) -> list[typing.Any]:
+        assert self.client, "_get_imploded_elements requires an OpenSearch client instance in this class"
+        """
+        Returns all records in OpenSearch belonging to a list of Document ids (element.parent_id)
+        """
+        batch_size = 1000
+        page_size = 1000
+
+        imploded_elements = []
+        for i in range(0, len(doc_ids), batch_size):
+            doc_ids_batch = doc_ids[i : i + batch_size]
+            from_offset = 0
+            while True:
+                query = {
+                    "query": {"terms": {"parent_id.keyword": doc_ids_batch}},
+                    "size": page_size,
+                    "from": from_offset,
+                }
+                response = self.client.search(index=index, body=query)
+                hits = response["hits"]["hits"]
+                imploded_elements.extend(hits)
+                if len(hits) < page_size:
+                    break
+                from_offset += page_size
+        return imploded_elements
 
 
 class OpenSearchReader(BaseDBReader):

--- a/lib/sycamore/sycamore/connectors/pinecone/pinecone_reader.py
+++ b/lib/sycamore/sycamore/connectors/pinecone/pinecone_reader.py
@@ -2,6 +2,7 @@ from sycamore.data import Document
 
 from sycamore.connectors.common import unflatten_data
 from sycamore.connectors.base_reader import BaseDBReader
+from sycamore.data.document import DocumentPropertyTypes, DocumentSource
 from sycamore.utils.import_utils import requires_modules
 from dataclasses import dataclass
 from typing import Optional, Dict
@@ -70,6 +71,7 @@ class PineconeReaderQueryResponse(BaseDBReader.QueryResponse):
                 data.metadata["properties.term_frequency"] = term_frequency
             metadata = data.metadata if data.metadata else {}
             doc = Document({"doc_id": doc_id, "embedding": data.values} | unflatten_data(metadata))
+            doc.properties[DocumentPropertyTypes.SOURCE] = DocumentSource.DB_QUERY
             result.append(doc)
         return result
 

--- a/lib/sycamore/sycamore/connectors/weaviate/weaviate_reader.py
+++ b/lib/sycamore/sycamore/connectors/weaviate/weaviate_reader.py
@@ -1,6 +1,7 @@
 from sycamore.data import Document
 from sycamore.connectors.common import unflatten_data
 from sycamore.connectors.base_reader import BaseDBReader
+from sycamore.data.document import DocumentPropertyTypes, DocumentSource
 from sycamore.utils.import_utils import requires_modules
 from dataclasses import dataclass
 import typing
@@ -92,6 +93,7 @@ class WeaviateReaderQueryResponse(BaseDBReader.QueryResponse):
                 | unflatten_data(dict(object.properties), "__")
                 | {"doc_id": str(object.uuid)}
             )  # type: ignore
+            doc.properties[DocumentPropertyTypes.SOURCE] = DocumentSource.DB_QUERY
             result.append(doc)
         return result
 

--- a/lib/sycamore/sycamore/data/document.py
+++ b/lib/sycamore/sycamore/data/document.py
@@ -1,10 +1,22 @@
 from collections import UserDict
 import json
+from enum import Enum
 from typing import Any, Optional
 import uuid
 
 from sycamore.data import BoundingBox, Element
 from sycamore.data.element import create_element
+
+
+class DocumentSource(Enum):
+    UNKNOWN: str = "UNKNOWN"
+    DB_QUERY: str = "DB_QUERY"
+    IMPLODE_RETRIEVAL: str = "IMPLODE_RETRIEVAL"
+
+
+class DocumentPropertyTypes:
+    SOURCE: str = "_doc_source"
+    PAGE_NUMBER: str = "page_number"
 
 
 class Document(UserDict):

--- a/lib/sycamore/sycamore/data/document.py
+++ b/lib/sycamore/sycamore/data/document.py
@@ -11,7 +11,7 @@ from sycamore.data.element import create_element
 class DocumentSource(Enum):
     UNKNOWN: str = "UNKNOWN"
     DB_QUERY: str = "DB_QUERY"
-    IMPLODE_RETRIEVAL: str = "IMPLODE_RETRIEVAL"
+    DOCUMENT_RECONSTRUCTION_RETRIEVAL: str = "DOCUMENT_RECONSTRUCTION_RETRIEVAL"
 
 
 class DocumentPropertyTypes:

--- a/lib/sycamore/sycamore/reader.py
+++ b/lib/sycamore/sycamore/reader.py
@@ -211,7 +211,9 @@ class DocSetReader:
 
     @requires_modules("opensearchpy", extra="opensearch")
     @context_params
-    def opensearch(self, os_client_args: dict, index_name: str, query: Optional[Dict] = None, **kwargs) -> DocSet:
+    def opensearch(
+        self, os_client_args: dict, index_name: str, query: Optional[Dict] = None, implode: bool = False, **kwargs
+    ) -> DocSet:
         """
         Reads the content of an OpenSearch index into a DocSet.
 
@@ -222,6 +224,10 @@ class DocSetReader:
             query: (Optional) Query to perform on the index. Note that this must be specified in the OpenSearch
                 Query DSL as a dictionary. Otherwise, it defaults to a full scan of the table. See more information at
                 https://opensearch.org/docs/latest/query-dsl/
+            implode: Used to decide whether the returned DocSet is imploded, i.e. reconstructed by collecting all
+                elements belong to a single parent document (parent_id). This requires OpenSearch to be an index of
+                docset.explode() type. Default to false.
+
         Example:
             The following shows how to write to data into a OpenSearch Index, and read it back into a DocSet.
 
@@ -268,9 +274,9 @@ class DocSetReader:
 
         client_params = OpenSearchReaderClientParams(os_client_args=os_client_args)
         query_params = (
-            OpenSearchReaderQueryParams(index_name=index_name, query=query)
+            OpenSearchReaderQueryParams(index_name=index_name, query=query, implode=implode)
             if query is not None
-            else OpenSearchReaderQueryParams(index_name=index_name)
+            else OpenSearchReaderQueryParams(index_name=index_name, implode=implode)
         )
         osr = OpenSearchReader(client_params=client_params, query_params=query_params)
         return DocSet(self._context, osr)

--- a/lib/sycamore/sycamore/reader.py
+++ b/lib/sycamore/sycamore/reader.py
@@ -212,7 +212,12 @@ class DocSetReader:
     @requires_modules("opensearchpy", extra="opensearch")
     @context_params
     def opensearch(
-        self, os_client_args: dict, index_name: str, query: Optional[Dict] = None, implode: bool = False, **kwargs
+        self,
+        os_client_args: dict,
+        index_name: str,
+        query: Optional[Dict] = None,
+        reconstruct_document: bool = False,
+        **kwargs
     ) -> DocSet:
         """
         Reads the content of an OpenSearch index into a DocSet.
@@ -224,9 +229,9 @@ class DocSetReader:
             query: (Optional) Query to perform on the index. Note that this must be specified in the OpenSearch
                 Query DSL as a dictionary. Otherwise, it defaults to a full scan of the table. See more information at
                 https://opensearch.org/docs/latest/query-dsl/
-            implode: Used to decide whether the returned DocSet is imploded, i.e. reconstructed by collecting all
-                elements belong to a single parent document (parent_id). This requires OpenSearch to be an index of
-                docset.explode() type. Default to false.
+            reconstruct_document: Used to decide whether the returned DocSet comprises reconstructed documents,
+                i.e. by collecting all elements belong to a single parent document (parent_id). This requires OpenSearch
+                to be an index of docset.explode() type. Default to false.
 
         Example:
             The following shows how to write to data into a OpenSearch Index, and read it back into a DocSet.
@@ -274,9 +279,9 @@ class DocSetReader:
 
         client_params = OpenSearchReaderClientParams(os_client_args=os_client_args)
         query_params = (
-            OpenSearchReaderQueryParams(index_name=index_name, query=query, implode=implode)
+            OpenSearchReaderQueryParams(index_name=index_name, query=query, reconstruct_document=reconstruct_document)
             if query is not None
-            else OpenSearchReaderQueryParams(index_name=index_name, implode=implode)
+            else OpenSearchReaderQueryParams(index_name=index_name, reconstruct_document=reconstruct_document)
         )
         osr = OpenSearchReader(client_params=client_params, query_params=query_params)
         return DocSet(self._context, osr)

--- a/lib/sycamore/sycamore/tests/integration/connectors/opensearch/test_opensearch_read.py
+++ b/lib/sycamore/sycamore/tests/integration/connectors/opensearch/test_opensearch_read.py
@@ -82,8 +82,10 @@ class TestOpenSearchRead:
             os_client_args=TestOpenSearchRead.OS_CLIENT_ARGS, index_name=TestOpenSearchRead.INDEX, query=query
         )
 
-        retrieved_docs_imploded = context.read.opensearch(
-            os_client_args=TestOpenSearchRead.OS_CLIENT_ARGS, index_name=TestOpenSearchRead.INDEX, implode=True
+        retrieved_docs_reconstructed = context.read.opensearch(
+            os_client_args=TestOpenSearchRead.OS_CLIENT_ARGS,
+            index_name=TestOpenSearchRead.INDEX,
+            reconstruct_document=True,
         )
         original_materialized = sorted(original_docs, key=lambda d: d.doc_id)
 
@@ -92,7 +94,7 @@ class TestOpenSearchRead:
         time.sleep(1)
         retrieved_materialized = sorted(retrieved_docs.take_all(), key=lambda d: d.doc_id)
         query_materialized = query_docs.take_all()
-        retrieved_materialized_imploded = sorted(retrieved_docs_imploded.take_all(), key=lambda d: d.doc_id)
+        retrieved_materialized_reconstructed = sorted(retrieved_docs_reconstructed.take_all(), key=lambda d: d.doc_id)
 
         with OpenSearch(**TestOpenSearchRead.OS_CLIENT_ARGS) as os_client:
             os_client.indices.delete(TestOpenSearchRead.INDEX)
@@ -101,6 +103,6 @@ class TestOpenSearchRead:
         for original, retrieved in zip(original_materialized, retrieved_materialized):
             assert compare_docs(original, retrieved)
 
-        assert len(retrieved_materialized_imploded) == 1
-        doc = retrieved_materialized_imploded[0]
+        assert len(retrieved_materialized_reconstructed) == 1
+        doc = retrieved_materialized_reconstructed[0]
         assert len(doc.elements) == len(retrieved_materialized) - 1  # drop the document parent record

--- a/lib/sycamore/sycamore/tests/unit/connectors/opensearch/test_opensearch.py
+++ b/lib/sycamore/sycamore/tests/unit/connectors/opensearch/test_opensearch.py
@@ -3,6 +3,8 @@ from unittest.mock import Mock
 from opensearchpy import OpenSearch, RequestError, ConnectionError
 import pytest
 
+from sycamore.connectors.opensearch.opensearch_reader import OpenSearchReaderQueryResponse, OpenSearchReaderQueryParams
+
 from sycamore import Context
 from sycamore.connectors.opensearch import (
     OpenSearchWriterClient,
@@ -12,7 +14,7 @@ from sycamore.connectors.opensearch import (
 )
 from sycamore.connectors.common import HostAndPort
 from sycamore.connectors.opensearch.utils import get_knn_query
-from sycamore.data.document import Document
+from sycamore.data.document import Document, DocumentPropertyTypes, DocumentSource
 from sycamore.transforms import Embedder
 
 
@@ -163,6 +165,155 @@ class TestOpenSearchClient:
         target_params = OpenSearchWriterTargetParams(index_name="test")
         osc_testing = OpenSearchWriterClient(client)
         osc_testing.write_many_records(records, target_params)
+
+
+class TestOpenSearchReaderQueryResponse:
+    def test_to_docs(self):
+        records = [
+            {
+                "text_representation": "this is an element",
+                "parent_id": "doc_1",
+            },
+            {"text_representation": "this is a parent doc", "parent_id": None, "doc_id": "doc_1"},
+        ]
+        hits = [{"_source": record} for record in records]
+        query_response = OpenSearchReaderQueryResponse(hits)
+        query_params = OpenSearchReaderQueryParams(index_name="some index")
+        docs = query_response.to_docs(query_params)
+
+        assert len(docs) == 2
+
+        for i in range(len(docs)):
+            assert docs[i].parent_id == records[i]["parent_id"]
+            assert docs[i].text_representation == records[i]["text_representation"]
+
+    def test_to_docs_implode_require_client(self):
+        query_response = OpenSearchReaderQueryResponse([])
+        query_params = OpenSearchReaderQueryParams(index_name="some index", implode=True)
+        with pytest.raises(AssertionError):
+            query_response.to_docs(query_params)
+
+    def test_to_docs_implode(self, mocker):
+        records = [
+            {
+                "text_representation": "this is an element belonging to parent doc 1",
+                "parent_id": "doc_1",
+                "doc_id": "element_1",
+            },
+            {
+                "text_representation": "this is an element belonging to parent doc 1",
+                "parent_id": "doc_1",
+                "doc_id": "element_2",
+            },
+            {
+                "text_representation": "this is an element belonging to parent doc 2",
+                "parent_id": "doc_2",
+                "doc_id": "element_1",
+            },
+            {"text_representation": "this is a parent doc 1", "parent_id": None, "doc_id": "doc_1"},
+            {"text_representation": "this is a parent doc 2", "parent_id": None, "doc_id": "doc_2"},
+            {"text_representation": "this is a parent doc 3", "parent_id": None, "doc_id": "doc_3"},
+        ]
+        client = mocker.Mock(spec=OpenSearch)
+
+        # no elements match
+        hits = [{"_source": record} for record in records]
+        return_val = {"hits": {"hits": [hit for hit in hits if hit["_source"].get("parent_id")]}}
+        return_val["hits"]["hits"] += [
+            {
+                "_source": {
+                    "text_representation": "this is an element belonging to parent doc 2 retrieved via implode",
+                    "parent_id": "doc_2",
+                    "doc_id": "element_2",
+                }
+            },
+            {
+                "_source": {
+                    "text_representation": "this is an element belonging to parent doc 2 retrieved via implode",
+                    "parent_id": "doc_2",
+                    "doc_id": "element_3",
+                }
+            },
+        ]
+        client.search.return_value = return_val
+        query_response = OpenSearchReaderQueryResponse(hits, client=client)
+        query_params = OpenSearchReaderQueryParams(index_name="some index", implode=True)
+        docs = query_response.to_docs(query_params)
+
+        assert len(docs) == 3
+
+        # since docs are unordered
+        doc_1 = [doc for doc in docs if doc.doc_id == "doc_1"][0]
+        doc_2 = [doc for doc in docs if doc.doc_id == "doc_2"][0]
+        doc_3 = [doc for doc in docs if doc.doc_id == "doc_3"][0]
+
+        assert len(doc_1.elements) == 2
+        assert len(doc_2.elements) == 3
+        assert len(doc_3.elements) == 0
+
+        assert doc_1.elements[0].text_representation == "this is an element belonging to parent doc 1"
+        assert doc_1.elements[1].text_representation == "this is an element belonging to parent doc 1"
+        assert doc_1.elements[0].properties[DocumentPropertyTypes.SOURCE] == DocumentSource.DB_QUERY
+        assert doc_1.elements[1].properties[DocumentPropertyTypes.SOURCE] == DocumentSource.DB_QUERY
+
+        assert doc_2.elements[0].text_representation == "this is an element belonging to parent doc 2"
+        assert (
+            doc_2.elements[1].text_representation
+            == "this is an element belonging to parent doc 2 retrieved via implode"
+        )
+        assert (
+            doc_2.elements[2].text_representation
+            == "this is an element belonging to parent doc 2 retrieved via implode"
+        )
+        assert doc_2.elements[0].properties[DocumentPropertyTypes.SOURCE] == DocumentSource.DB_QUERY
+        assert doc_2.elements[1].properties[DocumentPropertyTypes.SOURCE] == DocumentSource.IMPLODE_RETRIEVAL
+        assert doc_2.elements[2].properties[DocumentPropertyTypes.SOURCE] == DocumentSource.IMPLODE_RETRIEVAL
+
+    def test_to_docs_implode_no_additional_elements(self, mocker):
+        records = [
+            {
+                "text_representation": "this is an element belonging to parent doc 1",
+                "parent_id": "doc_1",
+                "doc_id": "element_1",
+            },
+            {
+                "text_representation": "this is an element belonging to parent doc 1",
+                "parent_id": "doc_1",
+                "doc_id": "element_2",
+            },
+            {
+                "text_representation": "this is an element belonging to parent doc 2",
+                "parent_id": "doc_2",
+                "doc_id": "element_1",
+            },
+            {"text_representation": "this is a parent doc 1", "parent_id": None, "doc_id": "doc_1"},
+            {"text_representation": "this is a parent doc 2", "parent_id": None, "doc_id": "doc_2"},
+            {"text_representation": "this is a parent doc 3", "parent_id": None, "doc_id": "doc_3"},
+        ]
+        client = mocker.Mock(spec=OpenSearch)
+
+        # no elements match
+        hits = [{"_source": record} for record in records]
+        client.search.return_value = {"hits": {"hits": [hit for hit in hits if hit["_source"].get("parent_id")]}}
+        query_response = OpenSearchReaderQueryResponse(hits, client=client)
+        query_params = OpenSearchReaderQueryParams(index_name="some index", implode=True)
+        docs = query_response.to_docs(query_params)
+
+        assert len(docs) == 3
+
+        # since docs are unordered
+        doc_1 = [doc for doc in docs if doc.doc_id == "doc_1"][0]
+        doc_2 = [doc for doc in docs if doc.doc_id == "doc_2"][0]
+        doc_3 = [doc for doc in docs if doc.doc_id == "doc_3"][0]
+
+        assert len(doc_1.elements) == 2
+        assert len(doc_2.elements) == 1
+        assert len(doc_3.elements) == 0
+
+        assert doc_1.elements[0].text_representation == "this is an element belonging to parent doc 1"
+        assert doc_1.elements[1].text_representation == "this is an element belonging to parent doc 1"
+
+        assert doc_2.elements[0].text_representation == "this is an element belonging to parent doc 2"
 
 
 class TestOpenSearchRecord:


### PR DESCRIPTION
Adds a reconstruct_document flag to the opensearch reader. This allows you to query an opensearch index and receive a DocSet in it's pre-exploded form. This is useful to do original document level transforms on a DocSet.

Added a "_doc_source" property to be able to identify which elements were loaded as query hits, and which were loaded as part of document reconstruction.

Eventually we might want to move this as a separate transform but this gives us some immediate value and can be moved out later.