### PR TITLE
Define parallelism on nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ traces/
 apps/jupyter/bind_dir/poetry_cache
 apps/query-ui/cache_dir
 docs/build
+notebooks/default-prep-data

--- a/examples/bench.py
+++ b/examples/bench.py
@@ -8,8 +8,6 @@
 
 import pyarrow.fs
 
-from ray.data import ActorPoolStrategy
-
 import sycamore
 from sycamore.functions.tokenizer import HuggingFaceTokenizer
 from sycamore.llms import OpenAIModels, OpenAI
@@ -34,7 +32,7 @@ ds = (
     ctx.read.binary(paths, binary_format="pdf", filesystem=fsys)
     .partition(
         partitioner=SycamorePartitioner(extract_table_structure=True, extract_images=True),
-        compute=ActorPoolStrategy(size=1),
+        parallelism=1,
     )
     .regex_replace(COALESCE_WHITESPACE)
     .extract_entity(entity_extractor=OpenAIEntityExtractor("title", llm=davinci_llm, prompt_template=title_template))

--- a/lib/sycamore/sycamore/connectors/base_reader.py
+++ b/lib/sycamore/sycamore/connectors/base_reader.py
@@ -1,12 +1,14 @@
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from abc import ABC, abstractmethod
-from ray.data import Dataset, from_items
 
 from sycamore.data.document import Document
 from sycamore.plan_nodes import Scan
-from sycamore.utils.ray_utils import check_serializable
 from sycamore.utils.time_trace import TimeTrace
+
+if TYPE_CHECKING:
+    from ray.data import Dataset
 
 
 class BaseDBReader(Scan):
@@ -51,7 +53,6 @@ class BaseDBReader(Scan):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        check_serializable(client_params, query_params)
         self._client_params = client_params
         self._query_params = query_params
 
@@ -64,7 +65,12 @@ class BaseDBReader(Scan):
         docs = records.to_docs(query_params=self._query_params)
         return docs
 
-    def execute(self, **kwargs) -> Dataset:
+    def execute(self, **kwargs) -> "Dataset":
+        from sycamore.utils.ray_utils import check_serializable
+
+        check_serializable(self._client_params, self._query_params)
+        from ray.data import from_items
+
         with TimeTrace("Reader"):
             return from_items(items=[{"doc": doc.serialize()} for doc in self.read_docs()])
 

--- a/lib/sycamore/sycamore/connectors/base_writer.py
+++ b/lib/sycamore/sycamore/connectors/base_writer.py
@@ -6,7 +6,6 @@ from typing import Callable
 from sycamore.data.document import Document
 from sycamore.plan_nodes import Node, Write
 from sycamore.transforms.map import MapBatch
-from sycamore.utils.ray_utils import check_serializable
 from sycamore.utils.time_trace import TimeTrace
 
 
@@ -59,7 +58,7 @@ class BaseDBWriter(MapBatch, Write):
         **kwargs,
     ):
         super().__init__(plan, f=self._write_docs_tt, **kwargs)
-        check_serializable(client_params, target_params, filter)
+
         self._filter = filter
         self._client_params = client_params
         self._target_params = target_params

--- a/lib/sycamore/sycamore/connectors/file/file_scan.py
+++ b/lib/sycamore/sycamore/connectors/file/file_scan.py
@@ -117,7 +117,6 @@ class BinaryScan(FileScan):
     ):
         super().__init__(paths, parallelism=parallelism, filesystem=filesystem, **resource_args)
         self._paths = paths
-        self.parallelism = -1 if parallelism is None else parallelism
         self._binary_format = binary_format
         self._metadata_provider = metadata_provider
         self._filter_paths_by_extension = filter_paths_by_extension
@@ -158,7 +157,7 @@ class BinaryScan(FileScan):
             self._paths,
             include_paths=True,
             filesystem=self._filesystem,
-            override_num_blocks=self.parallelism,
+            override_num_blocks=self.parallelism if self.parallelism is not None else -1,
             ray_remote_args=self.resource_args,
             file_extensions=file_extensions,
         )
@@ -229,7 +228,6 @@ class JsonScan(FileScan):
     ):
         super().__init__(paths, parallelism=parallelism, filesystem=filesystem, **resource_args)
         self._properties = properties
-        self.parallelism = -1 if parallelism is None else parallelism
         self._metadata_provider = metadata_provider
         self._document_body_field = document_body_field
         self._doc_extractor = doc_extractor
@@ -282,7 +280,7 @@ class JsonScan(FileScan):
             self._paths,
             include_paths=True,
             filesystem=self._filesystem,
-            parallelism=self.parallelism,
+            parallelism=self.parallelism if self.parallelism is not None else -1,
             ray_remote_args=self.resource_args,
         )
 
@@ -303,7 +301,6 @@ class JsonDocumentScan(FileScan):
         **resource_args,
     ):
         super().__init__(paths, parallelism=parallelism, filesystem=filesystem, **resource_args)
-        self.parallelism = -1 if parallelism is None else parallelism
 
     @staticmethod
     def json_as_document(json: dict[str, Any]) -> list[dict[str, Any]]:
@@ -318,7 +315,7 @@ class JsonDocumentScan(FileScan):
             self._paths,
             include_paths=True,
             filesystem=self._filesystem,
-            parallelism=self.parallelism,
+            parallelism=self.parallelism if self.parallelism is not None else -1,
             ray_remote_args=self.resource_args,
         )
         return ds.flat_map(self.json_as_document, **self.resource_args)

--- a/lib/sycamore/sycamore/docset.py
+++ b/lib/sycamore/sycamore/docset.py
@@ -661,8 +661,8 @@ class DocSet:
 
         class Wrapper(Node):
             def __init__(self, dataset):
+                super().__init__(children=[])
                 self._ds = dataset
-                self.children = []
 
             def execute(self, **kwargs):
                 return self._ds

--- a/lib/sycamore/sycamore/plan_nodes.py
+++ b/lib/sycamore/sycamore/plan_nodes.py
@@ -58,8 +58,16 @@ class Node(ABC):
     and then implemented
     """
 
-    def __init__(self, children: list[Optional["Node"]], materialize: dict = {}, **resource_args):
+    def __init__(
+        self,
+        children: list[Optional["Node"]],
+        materialize: dict = {},
+        parallelism: Optional[int] = None,
+        **resource_args
+    ):
         self.children = children
+        assert parallelism is None or parallelism > 0
+        self.parallelism = parallelism
         self.resource_args = resource_args
         self.properties = {}
         # copy because of https://stackoverflow.com/questions/1132941/least-astonishment-and-the-mutable-default-argument

--- a/lib/sycamore/sycamore/tests/integration/transforms/test_map.py
+++ b/lib/sycamore/sycamore/tests/integration/transforms/test_map.py
@@ -4,7 +4,6 @@ import math
 import time
 import uuid
 from sycamore.data import Document
-from ray.data import ActorPoolStrategy
 
 
 def make_docs(num):
@@ -33,7 +32,7 @@ def test_map_class_parallelism():
 
     num_actors = 4
     num_docs = 20
-    docs = ctx.read.document(make_docs(num_docs)).map(AgentMark, compute=ActorPoolStrategy(size=num_actors)).take()
+    docs = ctx.read.document(make_docs(num_docs)).map(AgentMark, parallelism=num_actors).take()
 
     count = {}
     for d in docs:

--- a/lib/sycamore/sycamore/tests/unit/connectors/common/test_base_writer.py
+++ b/lib/sycamore/sycamore/tests/unit/connectors/common/test_base_writer.py
@@ -72,7 +72,6 @@ class Common:
 
 
 class TestBaseDBWriter(Common):
-
     def test_fake_writer_e2e_happy(self, mocker, tmp_path) -> None:
         input_node = mocker.Mock(spec=Node)
         client_params = FakeClientParams(fspath=tmp_path)

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_base.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_base.py
@@ -5,8 +5,6 @@ from pathlib import Path
 import ray
 import pytest
 
-from ray.data import ActorPoolStrategy
-
 from sycamore.data import Document, MetadataDocument
 from sycamore.plan_nodes import Node
 from sycamore.transforms.base import BaseMapTransform, CompositeTransform, get_name_from_callable, rename
@@ -32,6 +30,10 @@ class Common:
 
     @staticmethod
     def outputs(node: Node, **kwargs):
+        if node.parallelism is not None:
+            from ray.data import ActorPoolStrategy
+
+            node.resource_args["compute"] = ActorPoolStrategy(size=node.parallelism)
         all_docs = [Document.from_row(r) for r in node.execute(**kwargs).take()]
         docs = [d for d in all_docs if not isinstance(d, MetadataDocument)]
         metadata = [d for d in all_docs if isinstance(d, MetadataDocument)]
@@ -255,9 +257,7 @@ class TestBaseMapTransform(Common):
             f=Test("as_function"),
             enable_auto_metadata=False,
         )
-        as_object = BaseMapTransform(
-            as_function, f=Test("as_object"), compute=ActorPoolStrategy(size=1), enable_auto_metadata=False
-        )
+        as_object = BaseMapTransform(as_function, f=Test("as_object"), parallelism=1, enable_auto_metadata=False)
 
         (docs, mds) = self.outputs(as_object)
 

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_mapping.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_mapping.py
@@ -51,6 +51,10 @@ class TestMapping:
         input_dataset = ray.data.from_items([{"doc": d.serialize()} for d in in_docs])
         execute = mocker.patch.object(node, "execute")
         execute.return_value = input_dataset
+        if mapping.parallelism is not None:
+            from ray.data import ActorPoolStrategy
+
+            mapping.resource_args["compute"] = ActorPoolStrategy(size=mapping.parallelism)
         output_dataset = mapping.execute()
         (output_docs, _) = take_separate(output_dataset)
         dicts = [d.data for d in output_docs]
@@ -109,6 +113,10 @@ class TestMapping:
         input_dataset = ray.data.from_items([{"doc": d.serialize()} for d in in_docs])
         execute = mocker.patch.object(node, "execute")
         execute.return_value = input_dataset
+        if mapping.parallelism is not None:
+            from ray.data import ActorPoolStrategy
+
+            mapping.resource_args["compute"] = ActorPoolStrategy(size=mapping.parallelism)
         output_dataset = mapping.execute()
         (data, metadata) = take_separate(output_dataset)
         assert len(data) == 4
@@ -145,6 +153,10 @@ class TestMapping:
         input_dataset = ray.data.from_items([{"doc": Document(dict).serialize()} for dict in dicts])
         execute = mocker.patch.object(node, "execute")
         execute.return_value = input_dataset
+        if mapping.parallelism is not None:
+            from ray.data import ActorPoolStrategy
+
+            mapping.resource_args["compute"] = ActorPoolStrategy(size=mapping.parallelism)
         output_dataset = mapping.execute()
         (output_docs, _) = take_separate(output_dataset)
         dicts = [d.data for d in output_docs]
@@ -186,6 +198,10 @@ class TestMapping:
         input_dataset = ray.data.from_items([{"doc": Document(dict).serialize()} for dict in dicts])
         execute = mocker.patch.object(node, "execute")
         execute.return_value = input_dataset
+        if mapping.parallelism is not None:
+            from ray.data import ActorPoolStrategy
+
+            mapping.resource_args["compute"] = ActorPoolStrategy(size=mapping.parallelism)
         output_dataset = mapping.execute()
         batch = output_dataset.take_batch()
         assert len(batch["doc"]) == 4 + 2

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_sketcher.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_sketcher.py
@@ -107,6 +107,10 @@ class TestSketchUniquify:
         )
         execute = mocker.patch.object(node, "execute")
         execute.return_value = in_ds
+        if uq.parallelism is not None:
+            from ray.data import ActorPoolStrategy
+
+            uq.resource_args["compute"] = ActorPoolStrategy(size=uq.parallelism)
         ds = uq.execute()
         (docs, _) = take_separate(ds)
         assert len(docs) == 1

--- a/lib/sycamore/sycamore/tests/unit/utils/test_ray_utils.py
+++ b/lib/sycamore/sycamore/tests/unit/utils/test_ray_utils.py
@@ -1,0 +1,15 @@
+import pytest
+
+from sycamore.utils.ray_utils import check_serializable
+
+
+def test_non_serializable():
+    import threading
+
+    lock = threading.Lock()
+    with pytest.raises(ValueError):
+        check_serializable(lock)
+
+
+def test_serializable():
+    check_serializable("a")

--- a/lib/sycamore/sycamore/transforms/embed.py
+++ b/lib/sycamore/sycamore/transforms/embed.py
@@ -325,10 +325,8 @@ class Embed(MapBatch):
                 self.resource_args["num_gpus"] = 1
             if self.resource_args["num_gpus"] <= 0:
                 raise RuntimeError("Invalid GPU Nums!")
-            if "compute" not in self.resource_args:
-                from ray.data import ActorPoolStrategy
-
-                self.resource_args["compute"] = ActorPoolStrategy(size=1)
+            if "parallelism" not in self.resource_args:
+                self.resource_args["parallelism"] = 1
         elif embedder.device == "cpu":
             self.resource_args.pop("num_gpus", None)
 

--- a/lib/sycamore/sycamore/transforms/extract_schema.py
+++ b/lib/sycamore/sycamore/transforms/extract_schema.py
@@ -246,10 +246,8 @@ class ExtractBatchSchema(Map):
     """
 
     def __init__(self, child: Node, schema_extractor: SchemaExtractor, **resource_args):
-        from ray.data import ActorPoolStrategy
-
         # Must run on a single instance so that the cached calculation of the schema works
-        resource_args["compute"] = ActorPoolStrategy(size=1)
+        resource_args["parallelism"] = 1
         # super().__init__(child, f=lambda d: d, **resource_args)
         super().__init__(child, f=ExtractBatchSchema.Extract, constructor_args=[schema_extractor], **resource_args)
 

--- a/lib/sycamore/sycamore/transforms/map.py
+++ b/lib/sycamore/sycamore/transforms/map.py
@@ -26,9 +26,7 @@ class Map(BaseMapTransform):
     change that with:
         .. code-block:: python
 
-           from ray.data import ActorPoolStrategy
-
-           ctx.map(ExampleClass, compute=ActorPoolStrategy(size=num_actors))
+           ctx.map(ExampleClass, parallelism=num_instances)
 
     Example:
          .. code-block:: python

--- a/lib/sycamore/sycamore/transforms/partition.py
+++ b/lib/sycamore/sycamore/transforms/partition.py
@@ -546,17 +546,15 @@ class Partition(CompositeTransform):
         self, child: Node, partitioner: Partitioner, table_extractor: Optional[TableExtractor] = None, **resource_args
     ):
         ops = []
-        from ray.data import ActorPoolStrategy
 
         if isinstance(partitioner, ArynPartitioner) and partitioner._use_partitioning_service:
-            resource_args["compute"] = ActorPoolStrategy(size=1)
+            resource_args["parallelism"] = 1
         if partitioner.device == "cuda":
             if "num_gpus" not in resource_args:
                 resource_args["num_gpus"] = 1.0
             assert resource_args["num_gpus"] >= 0
-            if "compute" not in resource_args:
-                resource_args["compute"] = ActorPoolStrategy(size=1)
-            assert isinstance(resource_args["compute"], ActorPoolStrategy)
+            if "parallelism" not in resource_args:
+                resource_args["parallelism"] = 1
             if "batch_size" not in resource_args:
                 resource_args["batch_size"] = partitioner.batch_size
         elif partitioner.device == "cpu":

--- a/lib/sycamore/sycamore/transforms/sketcher.py
+++ b/lib/sycamore/sycamore/transforms/sketcher.py
@@ -82,9 +82,7 @@ class SketchUniquify(SingleThreadUser, NonGPUUser, FlatMap):
 
     def __init__(self, child: Node, threshold: float = 0.4, **kwargs) -> None:
         # must run on 1 instance to get a global view
-        from ray.data import ActorPoolStrategy
-
-        kwargs["compute"] = ActorPoolStrategy(size=1)
+        kwargs["parallelism"] = 1
         super().__init__(child, f=SketchUniquify.Predicate, constructor_args=[threshold], **kwargs)
 
     class Predicate:
@@ -137,9 +135,7 @@ class SketchDebug(SingleThreadUser, NonGPUUser, FlatMap):
     """
 
     def __init__(self, child: Node, threshold: float = 0.4, **kwargs) -> None:
-        from ray.data import ActorPoolStrategy
-
-        kwargs["compute"] = ActorPoolStrategy(size=1)
+        kwargs["parallelism"] = 1
         super().__init__(child, f=SketchDebug.Predicate, constructor_args=[threshold], **kwargs)
         self.threshold = threshold
 

--- a/lib/sycamore/sycamore/writer.py
+++ b/lib/sycamore/sycamore/writer.py
@@ -440,9 +440,7 @@ class DocSetWriter:
                 if v is not None
             }  # type: ignore
         )
-        from ray.data import ActorPoolStrategy
-
-        kwargs["compute"] = ActorPoolStrategy(size=1)
+        kwargs["parallelism"] = 1
         ddb = DuckDBWriter(
             self.plan,
             client_params=client_params,

--- a/notebooks/default-prep-script.ipynb
+++ b/notebooks/default-prep-script.ipynb
@@ -317,8 +317,7 @@
      "post_cell_execute": [
       "if sycamore.EXEC_LOCAL != sycamore.ExecMode.RAY:",
       "    import sys",
-      "    # TODO: eric - remove the True",
-      "    assert True or 'ray' not in sys.modules"
+      "    assert 'ray' not in sys.modules"
      ]
     }
    },

--- a/notebooks/elasticsearch-writer.ipynb
+++ b/notebooks/elasticsearch-writer.ipynb
@@ -16,7 +16,6 @@
    "outputs": [],
    "source": [
     "import pyarrow.fs\n",
-    "from ray.data import ActorPoolStrategy\n",
     "import sycamore\n",
     "from elasticsearch import Elasticsearch\n",
     "from sycamore.functions.tokenizer import HuggingFaceTokenizer\n",

--- a/notebooks/subtask-sample.ipynb
+++ b/notebooks/subtask-sample.ipynb
@@ -25,9 +25,7 @@
     "from sycamore.transforms.partition import ArynPartitioner\n",
     "from sycamore.connectors.file.materialized_scan import DocScan\n",
     "from sycamore.docset import DocSet\n",
-    "import sycamore\n",
-    "\n",
-    "from ray.data import ActorPoolStrategy"
+    "import sycamore\n"
    ]
   },
   {
@@ -123,7 +121,7 @@
    "source": [
     "ds = (\n",
     "    context.read.binary(path, binary_format=\"pdf\")\n",
-    "    .partition(partitioner=ArynPartitioner(extract_table_structure=True, threshold=0.35, use_ocr=True), num_gpus=0.1, compute=ActorPoolStrategy(size=1))\n",
+    "    .partition(partitioner=ArynPartitioner(extract_table_structure=True, threshold=0.35, use_ocr=True), num_gpus=0.1, parallelism=1)\n",
     "    .regex_replace(COALESCE_WHITESPACE)\n",
     "    .merge(merger=GreedyTextElementMerger(tokenizer, 512))\n",
     "    .spread_properties([\"path\", \"company\", \"year\", \"doc-type\"])\n",


### PR DESCRIPTION
* Allows us to remove a dependency on importing ray.
* tests/integration/test_map.py confirms that the parallelism setting is working
* notebooks/default-prep-script.ipynb verifies we don't import ray in local mode
* moved serializability checks into the ray execution function. For the writer, I could just remove the serializeability check since it's done by basemap (manually verified)
* add check_serializable test as an example of something that can't be serialized.
* a fair bit of ugly code to patch in ray stuff in cases where we bypass the Executor in tests.
* fix handling of parallelism in file readers, they use -1 == unlimited, but ActorPoolStrategy asserts on size <= 0