### PR TITLE
Add similarity scoring and rerank transform

### DIFF
--- a/lib/sycamore/sycamore/connectors/base_reader.py
+++ b/lib/sycamore/sycamore/connectors/base_reader.py
@@ -74,5 +74,8 @@ class BaseDBReader(Scan):
         with TimeTrace("Reader"):
             return from_items(items=[{"doc": doc.serialize()} for doc in self.read_docs()])
 
+    def local_source(self) -> list[Document]:
+        return self.read_docs()
+
     def format(self):
         return "reader"

--- a/lib/sycamore/sycamore/context.py
+++ b/lib/sycamore/sycamore/context.py
@@ -17,6 +17,7 @@ class OperationTypes(Enum):
     DEFAULT = "default"
     BINARY_CLASSIFIER = "binary_classifier"
     INFORMATION_EXTRACTOR = "information_extractor"
+    TEXT_SIMILARITY = "text_similarity"
 
 
 def _default_rewrite_rules():

--- a/lib/sycamore/sycamore/data/element.py
+++ b/lib/sycamore/sycamore/data/element.py
@@ -23,6 +23,16 @@ class Element(UserDict):
             self.data["properties"] = {}
 
     @property
+    def id(self) -> Optional[int]:
+        """A unique identifier for the element within a Document. Represents an order within the document"""
+        return self.data.get("id")
+
+    @id.setter
+    def id(self, value: int) -> None:
+        """Set the unique identifier of the element within a Document."""
+        self.data["id"] = value
+
+    @property
     def type(self) -> Optional[str]:
         return self.data.get("type")
 

--- a/lib/sycamore/sycamore/data/element.py
+++ b/lib/sycamore/sycamore/data/element.py
@@ -23,14 +23,14 @@ class Element(UserDict):
             self.data["properties"] = {}
 
     @property
-    def id(self) -> Optional[int]:
+    def seq_no(self) -> Optional[int]:
         """A unique identifier for the element within a Document. Represents an order within the document"""
-        return self.data.get("id")
+        return self.data.get("seq_no")
 
-    @id.setter
-    def id(self, value: int) -> None:
+    @seq_no.setter
+    def seq_no(self, value: int) -> None:
         """Set the unique identifier of the element within a Document."""
-        self.data["id"] = value
+        self.data["seq_no"] = value
 
     @property
     def type(self) -> Optional[str]:

--- a/lib/sycamore/sycamore/tests/integration/connectors/opensearch/test_html_to_opensearch.py
+++ b/lib/sycamore/sycamore/tests/integration/connectors/opensearch/test_html_to_opensearch.py
@@ -3,6 +3,7 @@ import tempfile
 
 from opensearchpy import OpenSearch
 import sycamore
+from sycamore import ExecMode
 from sycamore.connectors.file.file_scan import JsonManifestMetadataProvider
 from sycamore.tests.config import TEST_DIR
 from sycamore.transforms.embed import SentenceTransformerEmbedder
@@ -54,7 +55,7 @@ def test_html_to_opensearch():
         tmp_manifest.flush()
         manifest_path = tmp_manifest.name
 
-        context = sycamore.init()
+        context = sycamore.init(exec_mode=ExecMode.LOCAL)
         ds = (
             context.read.binary(
                 base_path, binary_format="html", metadata_provider=JsonManifestMetadataProvider(manifest_path)

--- a/lib/sycamore/sycamore/tests/integration/connectors/opensearch/test_opensearch_read.py
+++ b/lib/sycamore/sycamore/tests/integration/connectors/opensearch/test_opensearch_read.py
@@ -4,6 +4,7 @@ import pytest
 from opensearchpy import OpenSearch
 
 import sycamore
+from sycamore import ExecMode
 from sycamore.connectors.common import compare_docs
 from sycamore.tests.config import TEST_DIR
 from sycamore.transforms.partition import UnstructuredPdfPartitioner
@@ -59,7 +60,7 @@ class TestOpenSearchRead:
         """
 
         path = str(TEST_DIR / "resources/data/pdfs/Ray.pdf")
-        context = sycamore.init()
+        context = sycamore.init(exec_mode=ExecMode.LOCAL)
         original_docs = (
             context.read.binary(path, binary_format="pdf")
             .partition(partitioner=UnstructuredPdfPartitioner())

--- a/lib/sycamore/sycamore/tests/integration/transforms/test_rerank.py
+++ b/lib/sycamore/sycamore/tests/integration/transforms/test_rerank.py
@@ -1,0 +1,84 @@
+import sycamore
+
+from sycamore.data import Document
+from sycamore.transforms.similarity import HuggingFaceTransformersSimilarityScorer
+
+
+def test_rerank_docset():
+    similarity_scorer = HuggingFaceTransformersSimilarityScorer()
+    score_property_name = "similarity_score"
+    dicts = [
+        {
+            "doc_id": 1,
+            "elements": [
+                {"text_representation": "here is an animal with 4 legs and whiskers"},
+            ],
+        },
+        {
+            "doc_id": 2,
+            "elements": [
+                {"id": 7, "text_representation": "this is a cat"},
+                {"id": 1, "text_representation": "this is a dog"},
+            ],
+        },
+        {
+            "doc_id": 3,
+            "elements": [
+                {"text_representation": "this is a dog"},
+            ],
+        },
+        {"doc_id": 4, "elements": [{"text_representation": "the number of pages in this document are 253"}]},
+        {  # handle element with not text
+            "doc_id": 5,
+            "elements": [
+                {"id": 1},
+            ],
+        },
+    ]
+    docs = [Document(item) for item in dicts]
+
+    context = sycamore.init()
+    doc_set = context.read.document(docs).rerank(
+        similarity_scorer=similarity_scorer, query="is this a cat?", score_property_name=score_property_name
+    )
+    result = doc_set.take()
+
+    assert len(result) == len(docs)
+    assert [doc.doc_id for doc in result] == [2, 1, 3, 5, 4]
+
+    for doc in result:
+        if doc.doc_id == 5:
+            continue
+        assert float(doc.properties.get(score_property_name))
+
+
+def test_rerank_docset_exploded():
+    similarity_scorer = HuggingFaceTransformersSimilarityScorer(ignore_doc_structure=True)
+    score_property_name = "similarity_score"
+    dicts = [
+        {"doc_id": 1, "text_representation": "here is an animal with 4 legs and whiskers"},
+        {"doc_id": 2, "text_representation": "this is a cat"},
+        {"doc_id": 3, "text_representation": "this is a dog"},
+        {
+            "doc_id": 4,
+            "elements": [
+                {"text_representation": "this doc doesn't have a text representation but instead has an element"}
+            ],
+        },
+        {"doc_id": 5, "text_representation": "the number of pages in this document are 253"},
+    ]
+    docs = [Document(item) for item in dicts]
+
+    context = sycamore.init()
+    doc_set = context.read.document(docs).rerank(
+        similarity_scorer=similarity_scorer, query="is this a cat?", score_property_name=score_property_name
+    )
+    result = doc_set.take()
+
+    assert len(result) == len(docs)
+    assert [doc.doc_id for doc in result] == [2, 1, 3, 5, 4]
+
+    for doc in result:
+        if doc.doc_id == 4:
+            continue
+        assert float(doc.properties.get(score_property_name))

--- a/lib/sycamore/sycamore/tests/integration/transforms/test_rerank.py
+++ b/lib/sycamore/sycamore/tests/integration/transforms/test_rerank.py
@@ -27,9 +27,15 @@ def test_rerank_docset():
                 {"text_representation": "this is a dog"},
             ],
         },
-        {"doc_id": 4, "elements": [{"text_representation": "the number of pages in this document are 253"}]},
         {  # handle element with not text
-            "doc_id": 5,
+            "doc_id": 4,
+            "elements": [
+                {"id": 1},
+            ],
+        },
+        {"doc_id": 5, "elements": [{"text_representation": "the number of pages in this document are 253"}]},
+        {  # drop because of limit
+            "doc_id": 6,
             "elements": [
                 {"id": 1},
             ],
@@ -39,15 +45,15 @@ def test_rerank_docset():
 
     context = sycamore.init()
     doc_set = context.read.document(docs).rerank(
-        similarity_scorer=similarity_scorer, query="is this a cat?", score_property_name=score_property_name
+        similarity_scorer=similarity_scorer, query="is this a cat?", score_property_name=score_property_name, limit=5
     )
     result = doc_set.take()
 
-    assert len(result) == len(docs)
+    assert len(result) == len(docs) - 1
     assert [doc.doc_id for doc in result] == [2, 1, 3, 5, 4]
 
     for doc in result:
-        if doc.doc_id == 5:
+        if doc.doc_id == 4:
             continue
         assert float(doc.properties.get(score_property_name))
 

--- a/lib/sycamore/sycamore/tests/integration/transforms/test_rerank.py
+++ b/lib/sycamore/sycamore/tests/integration/transforms/test_rerank.py
@@ -3,28 +3,30 @@ import sycamore
 from sycamore.data import Document
 from sycamore.transforms.similarity import HuggingFaceTransformersSimilarityScorer
 
+RERANKER_MODEL = "cross-encoder/ms-marco-MiniLM-L-2-v2"
+
 
 def test_rerank_docset():
-    similarity_scorer = HuggingFaceTransformersSimilarityScorer()
+    similarity_scorer = HuggingFaceTransformersSimilarityScorer(RERANKER_MODEL)
     score_property_name = "similarity_score"
     dicts = [
         {
             "doc_id": 1,
             "elements": [
-                {"text_representation": "here is an animal with 4 legs and whiskers"},
+                {"text_representation": "here is an animal that meows"},
             ],
         },
         {
             "doc_id": 2,
             "elements": [
                 {"id": 7, "text_representation": "this is a cat"},
-                {"id": 1, "text_representation": "this is a dog"},
+                {"id": 1, "text_representation": "here is an animal that moos"},
             ],
         },
         {
             "doc_id": 3,
             "elements": [
-                {"text_representation": "this is a dog"},
+                {"text_representation": "here is an animal that moos"},
             ],
         },
         {  # handle element with not text
@@ -59,12 +61,12 @@ def test_rerank_docset():
 
 
 def test_rerank_docset_exploded():
-    similarity_scorer = HuggingFaceTransformersSimilarityScorer(ignore_doc_structure=True)
+    similarity_scorer = HuggingFaceTransformersSimilarityScorer(RERANKER_MODEL, ignore_doc_structure=True)
     score_property_name = "similarity_score"
     dicts = [
-        {"doc_id": 1, "text_representation": "here is an animal with 4 legs and whiskers"},
+        {"doc_id": 1, "text_representation": "here is an animal that meows"},
         {"doc_id": 2, "text_representation": "this is a cat"},
-        {"doc_id": 3, "text_representation": "this is a dog"},
+        {"doc_id": 3, "text_representation": "here is an animal that moos"},
         {
             "doc_id": 4,
             "elements": [

--- a/lib/sycamore/sycamore/tests/unit/test_docset.py
+++ b/lib/sycamore/sycamore/tests/unit/test_docset.py
@@ -33,6 +33,7 @@ from sycamore.transforms.base import get_name_from_callable
 from sycamore.transforms.extract_entity import OpenAIEntityExtractor
 from sycamore.transforms.extract_schema import SchemaExtractor
 from sycamore.transforms import Filter
+from sycamore.transforms.similarity import SimilarityScorer
 from sycamore.transforms.sort import Sort
 from sycamore.transforms.summarize import LLMElementTextSummarizer
 from sycamore.transforms.query import QueryExecutor
@@ -208,6 +209,12 @@ class TestDocSet:
         context = mocker.Mock(spec=Context)
         docset = DocSet(context, None)
         docset = docset.sort(None, None)
+        assert isinstance(docset.lineage(), Sort)
+
+    def test_rerank(self, mocker):
+        docset = DocSet(Context(), None)
+        similarity_scorer = mocker.Mock(spec=SimilarityScorer)
+        docset = docset.rerank(similarity_scorer, "")
         assert isinstance(docset.lineage(), Sort)
 
     def test_extract_schema(self, mocker):

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_similarity.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_similarity.py
@@ -1,0 +1,98 @@
+import ray
+
+from sycamore.data import Document, MetadataDocument
+from sycamore.plan_nodes import Node
+from sycamore.transforms.similarity import HuggingFaceTransformersSimilarityScorer, ScoreSimilarity
+
+
+class TestSimilarityScorer:
+
+    def test_transformers_similarity_scorer(self):
+        similarity_scorer = HuggingFaceTransformersSimilarityScorer()
+        score_property_name = "similarity_score"
+        query = "this is a cat"
+
+        dicts = [
+            {
+                "doc_id": 1,
+                "elements": [
+                    {"text_representation": "here is an animal with 4 legs and whiskers"},
+                ],
+            },
+            {
+                "doc_id": 2,
+                "elements": [
+                    {"id": 7, "text_representation": "this is a cat"},
+                    {"id": 1, "text_representation": "this is a dog"},
+                ],
+            },
+            {
+                "doc_id": 3,
+                "elements": [
+                    {"text_representation": "this is a dog"},
+                ],
+            },
+            {"doc_id": 4, "elements": [{"text_representation": "the number of pages in this document are 253"}]},
+            {  # handle empty element
+                "doc_id": 5,
+                "elements": [
+                    {"id": 1},
+                ],
+            },
+        ]
+        docs = [Document(item) for item in dicts]
+        result = similarity_scorer.generate_similarity_scores(
+            docs, query=query, score_property_name=score_property_name
+        )
+        result.sort(key=lambda doc: doc.properties.get(score_property_name, float("-inf")), reverse=True)
+        assert [doc.doc_id for doc in result] == [2, 1, 3, 4, 5]
+
+        assert result[0].properties[score_property_name + "_source_element_id"] == 7
+
+    def test_transformers_similarity_scorer_no_doc_structure(self):
+        similarity_scorer = HuggingFaceTransformersSimilarityScorer(ignore_doc_structure=True)
+        score_property_name = "similarity_score"
+        query = "this is a cat"
+
+        dicts = [
+            {"doc_id": 1, "text_representation": "here is an animal with 4 legs and whiskers"},
+            {"doc_id": 2, "text_representation": "this is a cat"},
+            {"doc_id": 3, "text_representation": "this is a dog"},
+            {
+                "doc_id": 4,
+                "elements": [
+                    {"text_representation": "this doc doesn't have a text representation but instead has an element"}
+                ],
+            },
+            {"doc_id": 5, "text_representation": "the number of pages in this document are 253"},
+        ]
+        docs = [Document(item) for item in dicts]
+        result = similarity_scorer.generate_similarity_scores(
+            docs, query=query, score_property_name=score_property_name
+        )
+        result.sort(key=lambda doc: doc.properties.get(score_property_name, float("-inf")), reverse=True)
+        assert [doc.doc_id for doc in result] == [2, 1, 3, 5, 4]
+
+
+class TestSimilarityTransform:
+
+    def test_sentence_transformer_embedding(self, mocker):
+        node = mocker.Mock(spec=Node)
+        similarity_scorer = HuggingFaceTransformersSimilarityScorer(ignore_doc_structure=True)
+        score_similarity = ScoreSimilarity(node, similarity_scorer=similarity_scorer, query="Is this a cat?")
+        dicts = [
+            {"doc_id": 1, "text_representation": "Members of a strike at Yale University.", "embedding": None},
+            {"doc_id": 2, "text_representation": "A woman is speaking at a podium outdoors.", "embedding": None},
+        ]
+        input_dataset = ray.data.from_items([{"doc": Document(dict).serialize()} for dict in dicts])
+        execute = mocker.patch.object(node, "execute")
+        execute.return_value = input_dataset
+        input_dataset.show()
+        output_dataset = score_similarity.execute()
+        taken = output_dataset.take_all()
+
+        for d in taken:
+            doc = Document.from_row(d)
+            if isinstance(doc, MetadataDocument):
+                continue
+            assert float(doc.properties.get("similarity_score"))

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_similarity.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_similarity.py
@@ -76,7 +76,7 @@ class TestSimilarityScorer:
 
 class TestSimilarityTransform:
 
-    def test_sentence_transformer_embedding(self, mocker):
+    def test_transformers_score_similarity(self, mocker):
         node = mocker.Mock(spec=Node)
         similarity_scorer = HuggingFaceTransformersSimilarityScorer(ignore_doc_structure=True)
         score_similarity = ScoreSimilarity(node, similarity_scorer=similarity_scorer, query="Is this a cat?")
@@ -84,7 +84,7 @@ class TestSimilarityTransform:
             {"doc_id": 1, "text_representation": "Members of a strike at Yale University.", "embedding": None},
             {"doc_id": 2, "text_representation": "A woman is speaking at a podium outdoors.", "embedding": None},
         ]
-        input_dataset = ray.data.from_items([{"doc": Document(dict).serialize()} for dict in dicts])
+        input_dataset = ray.data.from_items([{"doc": Document(doc_dict).serialize()} for doc_dict in dicts])
         execute = mocker.patch.object(node, "execute")
         execute.return_value = input_dataset
         input_dataset.show()
@@ -95,4 +95,4 @@ class TestSimilarityTransform:
             doc = Document.from_row(d)
             if isinstance(doc, MetadataDocument):
                 continue
-            assert float(doc.properties.get("similarity_score"))
+            assert float(doc.properties.get("_similarity_score"))

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_similarity.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_similarity.py
@@ -4,11 +4,13 @@ from sycamore.data import Document, MetadataDocument
 from sycamore.plan_nodes import Node
 from sycamore.transforms.similarity import HuggingFaceTransformersSimilarityScorer, ScoreSimilarity
 
+RERANKER_MODEL = "cross-encoder/ms-marco-MiniLM-L-2-v2"
+
 
 class TestSimilarityScorer:
 
     def test_transformers_similarity_scorer(self):
-        similarity_scorer = HuggingFaceTransformersSimilarityScorer()
+        similarity_scorer = HuggingFaceTransformersSimilarityScorer(RERANKER_MODEL)
         score_property_name = "similarity_score"
         query = "this is a cat"
 
@@ -16,27 +18,27 @@ class TestSimilarityScorer:
             {
                 "doc_id": 1,
                 "elements": [
-                    {"text_representation": "here is an animal with 4 legs and whiskers"},
+                    {"text_representation": "here is an animal that meows"},
                 ],
             },
             {
                 "doc_id": 2,
                 "elements": [
-                    {"id": 7, "text_representation": "this is a cat"},
-                    {"id": 1, "text_representation": "this is a dog"},
+                    {"seq_no": 7, "text_representation": "this is a cat"},
+                    {"seq_no": 1, "text_representation": "here is an animal that moos"},
                 ],
             },
             {
                 "doc_id": 3,
                 "elements": [
-                    {"text_representation": "this is a dog"},
+                    {"text_representation": "here is an animal that moos"},
                 ],
             },
             {"doc_id": 4, "elements": [{"text_representation": "the number of pages in this document are 253"}]},
             {  # handle empty element
                 "doc_id": 5,
                 "elements": [
-                    {"id": 1},
+                    {"seq_no": 1},
                 ],
             },
         ]
@@ -47,17 +49,17 @@ class TestSimilarityScorer:
         result.sort(key=lambda doc: doc.properties.get(score_property_name, float("-inf")), reverse=True)
         assert [doc.doc_id for doc in result] == [2, 1, 3, 4, 5]
 
-        assert result[0].properties[score_property_name + "_source_element_id"] == 7
+        assert result[0].properties[score_property_name + "_source_element_seq_no"] == 7
 
     def test_transformers_similarity_scorer_no_doc_structure(self):
-        similarity_scorer = HuggingFaceTransformersSimilarityScorer(ignore_doc_structure=True)
+        similarity_scorer = HuggingFaceTransformersSimilarityScorer(RERANKER_MODEL, ignore_doc_structure=True)
         score_property_name = "similarity_score"
         query = "this is a cat"
 
         dicts = [
-            {"doc_id": 1, "text_representation": "here is an animal with 4 legs and whiskers"},
+            {"doc_id": 1, "text_representation": "here is an animal that meows"},
             {"doc_id": 2, "text_representation": "this is a cat"},
-            {"doc_id": 3, "text_representation": "this is a dog"},
+            {"doc_id": 3, "text_representation": "here is an animal that moos"},
             {
                 "doc_id": 4,
                 "elements": [
@@ -78,7 +80,7 @@ class TestSimilarityTransform:
 
     def test_transformers_score_similarity(self, mocker):
         node = mocker.Mock(spec=Node)
-        similarity_scorer = HuggingFaceTransformersSimilarityScorer(ignore_doc_structure=True)
+        similarity_scorer = HuggingFaceTransformersSimilarityScorer(RERANKER_MODEL, ignore_doc_structure=True)
         score_similarity = ScoreSimilarity(node, similarity_scorer=similarity_scorer, query="Is this a cat?")
         dicts = [
             {"doc_id": 1, "text_representation": "Members of a strike at Yale University.", "embedding": None},

--- a/lib/sycamore/sycamore/transforms/__init__.py
+++ b/lib/sycamore/sycamore/transforms/__init__.py
@@ -7,6 +7,7 @@ from sycamore.transforms.map import Map, FlatMap, MapBatch
 from sycamore.transforms.partition import Partition, Partitioner
 from sycamore.transforms.extract_table import TableExtractor
 from sycamore.transforms.regex_replace import COALESCE_WHITESPACE, RegexReplace
+from sycamore.transforms.similarity import ScoreSimilarity
 from sycamore.transforms.sketcher import Sketcher, SketchUniquify, SketchDebug
 from sycamore.transforms.spread_properties import SpreadProperties
 from sycamore.transforms.assign_doc_properties import AssignDocProperties
@@ -97,4 +98,5 @@ __all__ = [
     "ExtractTableProperties",
     "GroupByCount",
     "DatasetScan",
+    "ScoreSimilarity",
 ]

--- a/lib/sycamore/sycamore/transforms/map.py
+++ b/lib/sycamore/sycamore/transforms/map.py
@@ -1,6 +1,5 @@
 from typing import Any, Callable, Iterable, Optional
 
-
 from sycamore.data import Document
 from sycamore.plan_nodes import Node
 from sycamore.transforms.base import BaseMapTransform, get_name_from_callable

--- a/lib/sycamore/sycamore/transforms/similarity.py
+++ b/lib/sycamore/sycamore/transforms/similarity.py
@@ -1,0 +1,225 @@
+import logging
+from abc import ABC, abstractmethod
+from typing import Optional, TYPE_CHECKING
+
+from sycamore.data.document import DocumentPropertyTypes, DocumentSource
+from sycamore.utils.import_utils import requires_modules
+
+from sycamore.data import Document
+from sycamore.plan_nodes import Node
+from sycamore.transforms import MapBatch
+from sycamore.utils import choose_device
+from sycamore.utils.time_trace import timetrace
+
+if TYPE_CHECKING:
+    pass
+logger = logging.getLogger(__name__)
+
+
+class SimilarityScorer(ABC):
+    """
+    SimilarityScorer is an abstract class to compute similarity scores between a query string and a Document's
+    contents. It requires a child class to implement the score(..) method to compute similarity scores for a batch
+    of pairs of strings.
+
+    Currently, it will score each element in each provided document (unless ignores via ignore_element_sources).
+    It will also propagate the highest score to a document level property along with the element_id of the source.
+
+    Args:
+        ignore_element_sources: Ignore elements if they belong to these sources
+        ignore_doc_structure: Ignore Document model (Document->Elements) in a DocSet
+    """
+
+    def __init__(
+        self, ignore_element_sources: Optional[list[DocumentSource]] = None, ignore_doc_structure: bool = False
+    ):
+        if ignore_element_sources is None:
+            ignore_element_sources = [DocumentSource.DOCUMENT_RECONSTRUCTION_RETRIEVAL]
+        self._ignore_element_sources = ignore_element_sources
+        self._ignore_doc_structure = ignore_doc_structure
+
+    def __call__(self, doc_batch: list[Document], query: str, score_property_name: str) -> list[Document]:
+        return self.generate_similarity_scores(doc_batch, query, score_property_name)
+
+    def _get_inputs_from_document(self, document: Document) -> list[tuple[int, str]]:
+        if self._ignore_doc_structure:
+            return [(-1, document.text_representation)] if document.text_representation else []
+
+        result: list[tuple[int, str]] = list()
+        for i, element in enumerate(document.elements):
+            if (
+                element.properties.get(DocumentPropertyTypes.SOURCE, "") not in self._ignore_element_sources
+                and element.text_representation
+            ):
+                result.append((i, element.text_representation))
+        return result
+
+    def _populate_score(
+        self, score: float, score_property_name: str, document: Document, element_index: Optional[int] = None
+    ) -> Document:
+        if self._ignore_doc_structure:
+            document.properties[score_property_name] = score
+            return document
+        assert element_index is not None, "populating similarity score requires the element's index"
+        element = document.elements[element_index]
+        element.properties[score_property_name] = score
+
+        doc_score = document.properties.get(score_property_name, float("-inf"))
+        if score > doc_score:
+            document.properties[score_property_name] = score
+            document.properties[f"{score_property_name}_source_element_id"] = element.id
+        return document
+
+    def generate_similarity_scores(
+        self, doc_batch: list[Document], query: str, score_property_name: str
+    ) -> list[Document]:
+
+        input_metadata = []
+        input_pairs = []
+
+        for i, doc in enumerate(doc_batch):
+            elements = self._get_inputs_from_document(doc)
+            for element in elements:
+                input_pairs.append((query, element[1]))
+                input_metadata.append([i, element[0]])
+
+        if not input_pairs:
+            return doc_batch
+
+        scores = self.score(input_pairs)
+
+        for i, (doc_index, element_index) in enumerate(input_metadata):
+            self._populate_score(scores[i], score_property_name, doc_batch[doc_index], element_index)
+
+        return doc_batch
+
+    @abstractmethod
+    def score(self, inputs: list[tuple[str, str]]) -> list[float]:
+        pass
+
+
+class HuggingFaceTransformersSimilarityScorer(SimilarityScorer):
+    """
+    HuggingFaceTransformersSimilarityScorer is an SimilarityScorer class for generating sentence similarity using the
+    transformers package.
+
+    Args:
+        model_name: Name or path of the Transformers model to use for similarity scoring.
+        model_batch_size: Batch size used by the underlying Transformers model for similarity scoring, default is 16.
+        max_tokens: Max tokens to use for tokenization, default is 512.
+        device: Device (e.g., "cpu" or "cuda") on which to perform embedding.
+        ignore_doc_structure: Ignore Document model (Document->Elements) in a DocSet
+
+    Example:
+        .. code-block:: python
+
+            similarity_scorer = HuggingFaceTransformersSimilarityScorer(ignore_doc_structure=True)
+
+            doc = Document(
+                {
+                    "doc_id": 1,
+                    "elements": [
+                        {"text_representation": "here is an animal with 4 legs and whiskers"},
+                    ],
+                }
+            )
+            result = similarity_scorer.generate_similarity_scores(
+                [doc], query="is this a cat?", score_property_name="similarity_score"
+            )
+            print(result.properties["similarity_score"])
+
+    """
+
+    import torch
+
+    def __init__(
+        self,
+        model_name: str = "BAAI/bge-reranker-large",
+        model_batch_size: int = 16,
+        max_tokens: int = 512,
+        device: Optional[str] = None,
+        ignore_doc_structure: bool = False,
+        ignore_element_sources: Optional[list[DocumentSource]] = None,
+    ):
+        super().__init__(ignore_element_sources=ignore_element_sources, ignore_doc_structure=ignore_doc_structure)
+        self.device = choose_device(device)
+        self.model_name = model_name
+        self.model_batch_size = model_batch_size
+        self.max_tokens = max_tokens
+
+        self._model = None
+        self._tokenizer = None
+
+    @requires_modules(["transformers", "torch"], extra="local-inference")
+    def __call__(self, doc_batch: list[Document], query: str, score_property_name: str) -> list[Document]:
+        return self.generate_similarity_scores(doc_batch, query, score_property_name)
+
+    @timetrace("TransformersSimilarity")
+    @torch.no_grad()
+    def score(self, inputs: list[tuple[str, str]]) -> list[float]:
+        if not self._model or not self._tokenizer:
+            logger.info(f"Initializing transformers model: {self.model_name}")
+            from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+            self._tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+            self._model = AutoModelForSequenceClassification.from_pretrained(self.model_name).to(self.device)
+
+        assert self._model is not None
+        assert self._tokenizer is not None
+
+        scores = []
+
+        for i in range(0, len(inputs), self.model_batch_size):
+            input_batch = inputs[i : i + self.model_batch_size]
+
+            tokenized = self._tokenizer(
+                input_batch, padding=True, truncation=True, return_tensors="pt", max_length=self.max_tokens
+            )
+            scores.extend(
+                (
+                    self._model(**tokenized, return_dict=True)
+                    .logits.view(
+                        -1,
+                    )
+                    .float()
+                )
+            )
+        return scores
+
+
+class ScoreSimilarity(MapBatch):
+    """
+    ScoreSimilarity is a Map class for executing a similarity scoring function on Documents. These
+    similarity scores can then be used to rank documents for search use cases, or filter irrelevant documents.
+
+    Args:
+        child: The source node or component that provides the dataset containing text data.
+        similarity_scorer: An instance of an SimilarityScorer class that executes the scoring function.
+        query: The query string to compute similarity against.
+        score_property_name: The name of the key where the score will be stored in document.properties
+        resource_args: Additional resource-related arguments that can be passed to the extraction operation.
+
+    Example:
+         .. code-block:: python
+
+            source_node = ...  # Define a source node or component that provides a dataset with text data.
+            custom_scorer = MyScoringTechnique(entity_extraction_params)
+            scoring_transform = ScoreSimilarity(child=source_node, similarity_scorer=custom_scorer, query="Cats?")
+            scored_dataset = scoring_transform.execute()
+
+    """
+
+    def __init__(
+        self,
+        child: Node,
+        similarity_scorer: SimilarityScorer,
+        query: str,
+        score_property_name: str = "_similarity_score",
+        **resource_args,
+    ):
+        super().__init__(
+            child,
+            f=similarity_scorer.generate_similarity_scores,  # type: ignore
+            f_args=[query, score_property_name],
+            **resource_args,
+        )

--- a/lib/sycamore/sycamore/transforms/similarity.py
+++ b/lib/sycamore/sycamore/transforms/similarity.py
@@ -67,7 +67,7 @@ class SimilarityScorer(ABC):
         doc_score = document.properties.get(score_property_name, float("-inf"))
         if score > doc_score:
             document.properties[score_property_name] = score
-            document.properties[f"{score_property_name}_source_element_id"] = element.id
+            document.properties[f"{score_property_name}_source_element_seq_no"] = element.seq_no
         return document
 
     def generate_similarity_scores(
@@ -79,17 +79,17 @@ class SimilarityScorer(ABC):
 
         for doc_idx, doc in enumerate(doc_batch):
             candidate_elements = self._get_inputs_from_document(doc)
-            for element_idx, element_text in candidate_elements:
+            for element_seq_no, element_text in candidate_elements:
                 input_pairs.append((query, element_text))
-                input_metadata.append([doc_idx, element_idx])
+                input_metadata.append([doc_idx, element_seq_no])
 
         if not input_pairs:
             return doc_batch
 
         scores = self.score(input_pairs)
 
-        for i, (doc_idx, element_idx) in enumerate(input_metadata):
-            self._populate_score(scores[i], score_property_name, doc_batch[doc_idx], element_idx)
+        for i, (doc_idx, element_seq_no) in enumerate(input_metadata):
+            self._populate_score(scores[i], score_property_name, doc_batch[doc_idx], element_seq_no)
 
         return doc_batch
 

--- a/lib/sycamore/sycamore/transforms/similarity.py
+++ b/lib/sycamore/sycamore/transforms/similarity.py
@@ -219,7 +219,7 @@ class ScoreSimilarity(MapBatch):
     ):
         super().__init__(
             child,
-            f=similarity_scorer.generate_similarity_scores,  # type: ignore
+            f=similarity_scorer,  # type: ignore
             f_args=[query, score_property_name],
             **resource_args,
         )

--- a/lib/sycamore/sycamore/transforms/similarity.py
+++ b/lib/sycamore/sycamore/transforms/similarity.py
@@ -77,19 +77,19 @@ class SimilarityScorer(ABC):
         input_metadata = []
         input_pairs = []
 
-        for i, doc in enumerate(doc_batch):
-            elements = self._get_inputs_from_document(doc)
-            for element in elements:
-                input_pairs.append((query, element[1]))
-                input_metadata.append([i, element[0]])
+        for doc_idx, doc in enumerate(doc_batch):
+            candidate_elements = self._get_inputs_from_document(doc)
+            for element_idx, element_text in candidate_elements:
+                input_pairs.append((query, element_text))
+                input_metadata.append([doc_idx, element_idx])
 
         if not input_pairs:
             return doc_batch
 
         scores = self.score(input_pairs)
 
-        for i, (doc_index, element_index) in enumerate(input_metadata):
-            self._populate_score(scores[i], score_property_name, doc_batch[doc_index], element_index)
+        for i, (doc_idx, element_idx) in enumerate(input_metadata):
+            self._populate_score(scores[i], score_property_name, doc_batch[doc_idx], element_idx)
 
         return doc_batch
 


### PR DESCRIPTION
Allows you to do:

```python
similarity_scorer = HuggingFaceTransformersSimilarityScorer(ignore_doc_structure=True)
doc_set = context.read.binary(paths).rerank(
    similarity_scorer=similarity_scorer, query="is this a cat?", score_property_name=score_property_name, limit=5
)
result = doc_set.take()
```
A key callout here is if we're doing a rerank on a non-exploded DocSet (i.e. not rag on chunks style), we will order Documents by their highest matching chunk, even though another Document might have slightly lower scoring but more chunks that are similar.

This PR also adds a local mode for BaseDBReader, will update our integration tests touching DBs to test both local and ray modes.