### PR TITLE
Element ordering and test improvements

### DIFF
--- a/lib/sycamore/sycamore/data/document.py
+++ b/lib/sycamore/sycamore/data/document.py
@@ -201,6 +201,7 @@ class Document(UserDict):
     @staticmethod
     def from_row(row: dict[str, bytes]) -> "Document":
         """Unserialize a Ray row back into a Document."""
+
         return Document.deserialize(row["doc"])
 
     def to_row(self) -> dict[str, bytes]:

--- a/lib/sycamore/sycamore/data/element.py
+++ b/lib/sycamore/sycamore/data/element.py
@@ -25,12 +25,12 @@ class Element(UserDict):
     @property
     def seq_no(self) -> Optional[int]:
         """A unique identifier for the element within a Document. Represents an order within the document"""
-        return self.data.get("seq_no")
+        return self.data.get("properties", {}).get("_seq_no")
 
     @seq_no.setter
     def seq_no(self, value: int) -> None:
         """Set the unique identifier of the element within a Document."""
-        self.data["seq_no"] = value
+        self.data["properties"]["_seq_no"] = value
 
     @property
     def type(self) -> Optional[str]:
@@ -222,7 +222,8 @@ class TableElement(Element):
         self.data["text_representation"] = text_representation
 
 
-def create_element(**kwargs) -> Element:
+def create_element(seq_no: Optional[int] = None, **kwargs) -> Element:
+    element: Element
     if "type" in kwargs and kwargs["type"].lower() == "table":
         if "properties" in kwargs:
             props = kwargs["properties"]
@@ -233,7 +234,7 @@ def create_element(**kwargs) -> Element:
             table = Table.from_dict(kwargs["table"])
             kwargs["table"] = table
 
-        return TableElement(**kwargs)
+        element = TableElement(**kwargs)
 
     elif "type" in kwargs and kwargs["type"].lower() in {"picture", "image", "figure"}:
         if "properties" in kwargs:
@@ -242,7 +243,10 @@ def create_element(**kwargs) -> Element:
             kwargs["image_mode"] = props.get("image_mode")
             kwargs["image_format"] = props.get("image_format")
 
-        return ImageElement(**kwargs)
+        element = ImageElement(**kwargs)
 
     else:
-        return Element(**kwargs)
+        element = Element(**kwargs)
+    if seq_no is not None:
+        element.seq_no = seq_no
+    return element

--- a/lib/sycamore/sycamore/data/element.py
+++ b/lib/sycamore/sycamore/data/element.py
@@ -23,14 +23,14 @@ class Element(UserDict):
             self.data["properties"] = {}
 
     @property
-    def seq_no(self) -> Optional[int]:
+    def element_index(self) -> Optional[int]:
         """A unique identifier for the element within a Document. Represents an order within the document"""
-        return self.data.get("properties", {}).get("_seq_no")
+        return self.data.get("properties", {}).get("_element_index")
 
-    @seq_no.setter
-    def seq_no(self, value: int) -> None:
+    @element_index.setter
+    def element_index(self, value: int) -> None:
         """Set the unique identifier of the element within a Document."""
-        self.data["properties"]["_seq_no"] = value
+        self.data["properties"]["_element_index"] = value
 
     @property
     def type(self) -> Optional[str]:
@@ -222,7 +222,7 @@ class TableElement(Element):
         self.data["text_representation"] = text_representation
 
 
-def create_element(seq_no: Optional[int] = None, **kwargs) -> Element:
+def create_element(element_index: Optional[int] = None, **kwargs) -> Element:
     element: Element
     if "type" in kwargs and kwargs["type"].lower() == "table":
         if "properties" in kwargs:
@@ -247,6 +247,6 @@ def create_element(seq_no: Optional[int] = None, **kwargs) -> Element:
 
     else:
         element = Element(**kwargs)
-    if seq_no is not None:
-        element.seq_no = seq_no
+    if element_index is not None:
+        element.element_index = element_index
     return element

--- a/lib/sycamore/sycamore/functions/document.py
+++ b/lib/sycamore/sycamore/functions/document.py
@@ -1,5 +1,7 @@
 from io import BytesIO
 from typing import Optional
+
+from sycamore.data.document import DocumentPropertyTypes
 from sycamore.data.element import TableElement
 
 import pdf2image
@@ -46,7 +48,7 @@ def split_and_convert_to_image(doc: Document) -> list[Document]:
     elements_by_page: dict[int, list[Element]] = {}
 
     for e in doc.elements:
-        page_number = e.properties["page_number"]
+        page_number = e.properties[DocumentPropertyTypes.PAGE_NUMBER]
         elements_by_page.setdefault(page_number, []).append(e)
 
     new_docs = []
@@ -54,7 +56,9 @@ def split_and_convert_to_image(doc: Document) -> list[Document]:
         elements = elements_by_page.get(page + 1, [])
         new_doc = Document(binary_representation=image.tobytes(), elements=elements)
         new_doc.properties.update(doc.properties)
-        new_doc.properties.update({"size": list(image.size), "mode": image.mode, "page_number": page + 1})
+        new_doc.properties.update(
+            {"size": list(image.size), "mode": image.mode, DocumentPropertyTypes.PAGE_NUMBER: page + 1}
+        )
         new_docs.append(new_doc)
     return new_docs
 

--- a/lib/sycamore/sycamore/tests/conftest.py
+++ b/lib/sycamore/sycamore/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 from pyarrow.fs import LocalFileSystem
 
+from sycamore import ExecMode
 from sycamore.data.document import Document
 
 
@@ -13,3 +14,8 @@ def read_local_binary(request) -> Document:
     document.binary_representation = input_stream.readall()
     document.properties["path"] = path
     return document
+
+
+@pytest.fixture(params=[ExecMode.LOCAL, ExecMode.RAY])
+def exec_mode(request):
+    return request.param

--- a/lib/sycamore/sycamore/tests/conftest.py
+++ b/lib/sycamore/sycamore/tests/conftest.py
@@ -16,6 +16,17 @@ def read_local_binary(request) -> Document:
     return document
 
 
-@pytest.fixture(params=[ExecMode.LOCAL, ExecMode.RAY])
+@pytest.fixture(params=(exec_mode for exec_mode in ExecMode if exec_mode != ExecMode.UNKNOWN))
 def exec_mode(request):
+    """
+    Use this to run a test against all available execution modes. You will need to pass this as a parameter to
+    the Context initialization. e.g.
+
+    Example:
+        .. code-block:: python
+
+            def test_example(exec_mode):
+                context = sycamore.init(exec_mode=exec_mode)
+                ...
+    """
     return request.param

--- a/lib/sycamore/sycamore/tests/integration/connectors/opensearch/test_html_to_opensearch.py
+++ b/lib/sycamore/sycamore/tests/integration/connectors/opensearch/test_html_to_opensearch.py
@@ -3,14 +3,13 @@ import tempfile
 
 from opensearchpy import OpenSearch
 import sycamore
-from sycamore import ExecMode
 from sycamore.connectors.file.file_scan import JsonManifestMetadataProvider
 from sycamore.tests.config import TEST_DIR
 from sycamore.transforms.embed import SentenceTransformerEmbedder
 from sycamore.transforms.partition import HtmlPartitioner
 
 
-def test_html_to_opensearch():
+def test_html_to_opensearch(exec_mode):
     os_client_args = {
         "hosts": [{"host": "localhost", "port": 9200}],
         "http_compress": True,
@@ -55,7 +54,7 @@ def test_html_to_opensearch():
         tmp_manifest.flush()
         manifest_path = tmp_manifest.name
 
-        context = sycamore.init(exec_mode=ExecMode.LOCAL)
+        context = sycamore.init(exec_mode=exec_mode)
         ds = (
             context.read.binary(
                 base_path, binary_format="html", metadata_provider=JsonManifestMetadataProvider(manifest_path)

--- a/lib/sycamore/sycamore/tests/integration/connectors/opensearch/test_opensearch_read.py
+++ b/lib/sycamore/sycamore/tests/integration/connectors/opensearch/test_opensearch_read.py
@@ -4,7 +4,6 @@ import pytest
 from opensearchpy import OpenSearch
 
 import sycamore
-from sycamore import ExecMode
 from sycamore.connectors.common import compare_docs
 from sycamore.tests.config import TEST_DIR
 from sycamore.transforms.partition import UnstructuredPdfPartitioner
@@ -54,13 +53,13 @@ class TestOpenSearchRead:
         "timeout": 120,
     }
 
-    def test_ingest_and_read(self, setup_index):
+    def test_ingest_and_read(self, setup_index, exec_mode):
         """
         Validates data is readable from OpenSearch, and that we can rebuild processed Sycamore documents.
         """
 
         path = str(TEST_DIR / "resources/data/pdfs/Ray.pdf")
-        context = sycamore.init(exec_mode=ExecMode.LOCAL)
+        context = sycamore.init(exec_mode=exec_mode)
         original_docs = (
             context.read.binary(path, binary_format="pdf")
             .partition(partitioner=UnstructuredPdfPartitioner())

--- a/lib/sycamore/sycamore/tests/integration/transforms/test_partition.py
+++ b/lib/sycamore/sycamore/tests/integration/transforms/test_partition.py
@@ -32,7 +32,7 @@ def test_aryn_partitioner_w_ocr():
 
     assert "Attention Is All You Need" in set(str(d.text_representation).strip() for d in docs)
     assert all(
-        docs[i].properties["_element_index"] <= docs[i + 1].properties["_element_index"] for i in range(len(docs) - 1)
+        docs[i].properties["_element_index"] < docs[i + 1].properties["_element_index"] for i in range(len(docs) - 1)
     )
 
 
@@ -84,7 +84,7 @@ def check_table_extraction(**kwargs):
     assert len(docs) == 1
     doc = docs[0]
     tables = [e for e in doc.elements if e.type == "table"]
-    assert all(tables[i].element_index <= tables[i + 1].element_index for i in range(len(tables) - 1))
+    assert all(tables[i].element_index < tables[i + 1].element_index for i in range(len(tables) - 1))
     assert len(tables) == 1
     assert isinstance(tables[0], TableElement)
     assert tables[0].table is not None
@@ -133,7 +133,7 @@ def test_aryn_partitioner():
 
     assert "Attention Is All You Need" in set(str(d.text_representation).strip() for d in docs)
     assert all(
-        docs[i].properties["_element_index"] <= docs[i + 1].properties["_element_index"] for i in range(len(docs) - 1)
+        docs[i].properties["_element_index"] < docs[i + 1].properties["_element_index"] for i in range(len(docs) - 1)
     )
 
 

--- a/lib/sycamore/sycamore/tests/integration/transforms/test_partition.py
+++ b/lib/sycamore/sycamore/tests/integration/transforms/test_partition.py
@@ -31,7 +31,9 @@ def test_aryn_partitioner_w_ocr():
     )
 
     assert "Attention Is All You Need" in set(str(d.text_representation).strip() for d in docs)
-    assert all(docs[i].properties["_seq_no"] <= docs[i + 1].properties["_seq_no"] for i in range(len(docs) - 1))
+    assert all(
+        docs[i].properties["_element_index"] <= docs[i + 1].properties["_element_index"] for i in range(len(docs) - 1)
+    )
 
 
 def check_table_extraction(**kwargs):
@@ -82,7 +84,7 @@ def check_table_extraction(**kwargs):
     assert len(docs) == 1
     doc = docs[0]
     tables = [e for e in doc.elements if e.type == "table"]
-    assert all(tables[i].seq_no <= tables[i + 1].seq_no for i in range(len(tables) - 1))
+    assert all(tables[i].element_index <= tables[i + 1].element_index for i in range(len(tables) - 1))
     assert len(tables) == 1
     assert isinstance(tables[0], TableElement)
     assert tables[0].table is not None
@@ -130,7 +132,9 @@ def test_aryn_partitioner():
     )
 
     assert "Attention Is All You Need" in set(str(d.text_representation).strip() for d in docs)
-    assert all(docs[i].properties["_seq_no"] <= docs[i + 1].properties["_seq_no"] for i in range(len(docs) - 1))
+    assert all(
+        docs[i].properties["_element_index"] <= docs[i + 1].properties["_element_index"] for i in range(len(docs) - 1)
+    )
 
 
 def test_table_extraction_with_ocr_batched():

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_aryn_partitioner.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_aryn_partitioner.py
@@ -32,8 +32,8 @@ class TestArynPDFPartitioner:
                 expected_json = json.loads(expected_text.read())
                 partitioner = ArynPDFPartitioner(None)
                 expected_elements = []
-                for element_json in expected_json:
-                    element = create_element(**element_json)
+                for i, element_json in enumerate(expected_json):
+                    element = create_element(i, **element_json)
                     if element.binary_representation:
                         element.binary_representation = base64.b64decode(element.binary_representation)
                     expected_elements.append(element)
@@ -49,8 +49,8 @@ class TestArynPDFPartitioner:
                 expected_json = json.loads(expected_text.read())
                 partitioner = ArynPDFPartitioner(None)
                 expected_elements = []
-                for element_json in expected_json:
-                    element = create_element(**element_json)
+                for i, element_json in enumerate(expected_json):
+                    element = create_element(i, **element_json)
                     if element.binary_representation:
                         element.binary_representation = base64.b64decode(element.binary_representation)
                     expected_elements.append(element)

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_partition.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_partition.py
@@ -45,7 +45,7 @@ class TestPartition:
             "metadata": {"filename": "Bert.pdf", "filetype": "application/pdf", "page_number": 1},
             "text": "BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding",
         }
-        element = UnstructuredPdfPartitioner.to_element(dict)
+        element = UnstructuredPdfPartitioner.to_element(dict, seq_no=1)
         assert element.type == "Title"
         assert (
             element.text_representation == "BERT: Pre-training of Deep Bidirectional Transformers for"
@@ -62,6 +62,7 @@ class TestPartition:
             "filename": "Bert.pdf",
             "filetype": "application/pdf",
             "page_number": 1,
+            "_seq_no": 1,
         }
 
     @pytest.mark.parametrize(

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_partition.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_partition.py
@@ -45,7 +45,7 @@ class TestPartition:
             "metadata": {"filename": "Bert.pdf", "filetype": "application/pdf", "page_number": 1},
             "text": "BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding",
         }
-        element = UnstructuredPdfPartitioner.to_element(dict, seq_no=1)
+        element = UnstructuredPdfPartitioner.to_element(dict, element_index=1)
         assert element.type == "Title"
         assert (
             element.text_representation == "BERT: Pre-training of Deep Bidirectional Transformers for"
@@ -62,7 +62,7 @@ class TestPartition:
             "filename": "Bert.pdf",
             "filetype": "application/pdf",
             "page_number": 1,
-            "_seq_no": 1,
+            "_element_index": 1,
         }
 
     @pytest.mark.parametrize(

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_similarity.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_similarity.py
@@ -24,8 +24,8 @@ class TestSimilarityScorer:
             {
                 "doc_id": 2,
                 "elements": [
-                    {"seq_no": 7, "text_representation": "this is a cat"},
-                    {"seq_no": 1, "text_representation": "here is an animal that moos"},
+                    {"element_index": 7, "text_representation": "this is a cat"},
+                    {"element_index": 1, "text_representation": "here is an animal that moos"},
                 ],
             },
             {
@@ -38,7 +38,7 @@ class TestSimilarityScorer:
             {  # handle empty element
                 "doc_id": 5,
                 "elements": [
-                    {"seq_no": 1},
+                    {"element_index": 1},
                 ],
             },
         ]
@@ -49,7 +49,7 @@ class TestSimilarityScorer:
         result.sort(key=lambda doc: doc.properties.get(score_property_name, float("-inf")), reverse=True)
         assert [doc.doc_id for doc in result] == [2, 1, 3, 4, 5]
 
-        assert result[0].properties[score_property_name + "_source_element_seq_no"] == 7
+        assert result[0].properties[score_property_name + "_source_element_element_index"] == 7
 
     def test_transformers_similarity_scorer_no_doc_structure(self):
         similarity_scorer = HuggingFaceTransformersSimilarityScorer(RERANKER_MODEL, ignore_doc_structure=True)

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_similarity.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_similarity.py
@@ -18,27 +18,35 @@ class TestSimilarityScorer:
             {
                 "doc_id": 1,
                 "elements": [
-                    {"text_representation": "here is an animal that meows"},
+                    {"text_representation": "here is an animal that meows", "properties": {"_element_index": 1}}
                 ],
             },
             {
                 "doc_id": 2,
                 "elements": [
-                    {"element_index": 7, "text_representation": "this is a cat"},
-                    {"element_index": 1, "text_representation": "here is an animal that moos"},
+                    {"properties": {"_element_index": 7}, "text_representation": "this is a cat"},
+                    {"properties": {"_element_index": 1}, "text_representation": "here is an animal that moos"},
                 ],
             },
             {
                 "doc_id": 3,
                 "elements": [
-                    {"text_representation": "here is an animal that moos"},
+                    {"properties": {"_element_index": 1}, "text_representation": "here is an animal that moos"},
                 ],
             },
-            {"doc_id": 4, "elements": [{"text_representation": "the number of pages in this document are 253"}]},
+            {
+                "doc_id": 4,
+                "elements": [
+                    {
+                        "properties": {"_element_index": 1},
+                        "text_representation": "the number of pages in this document are 253",
+                    }
+                ],
+            },
             {  # handle empty element
                 "doc_id": 5,
                 "elements": [
-                    {"element_index": 1},
+                    {"properties": {"_element_index": 1}},
                 ],
             },
         ]
@@ -49,7 +57,7 @@ class TestSimilarityScorer:
         result.sort(key=lambda doc: doc.properties.get(score_property_name, float("-inf")), reverse=True)
         assert [doc.doc_id for doc in result] == [2, 1, 3, 4, 5]
 
-        assert result[0].properties[score_property_name + "_source_element_element_index"] == 7
+        assert result[0].properties[score_property_name + "_source_element_index"] == 7
 
     def test_transformers_similarity_scorer_no_doc_structure(self):
         similarity_scorer = HuggingFaceTransformersSimilarityScorer(RERANKER_MODEL, ignore_doc_structure=True)

--- a/lib/sycamore/sycamore/tests/unit/utils/test_bbox_sort.py
+++ b/lib/sycamore/sycamore/tests/unit/utils/test_bbox_sort.py
@@ -100,7 +100,7 @@ def test_elements_basic() -> None:
     elems = bbox_sorted_elements(elems)
     answer = [e4, e5, e3, e6, e7, e8, e9, e1, e0, e2]
     assert elems == answer
-    assert_element_element_index_sorted(elems)
+    assert_element_index_sorted(elems)
 
 
 def test_document_basic() -> None:
@@ -115,10 +115,10 @@ def test_document_basic() -> None:
     bbox_sort_document(doc)
     answer = [e3, e2, e5, e4, e1, e0]
     assert doc.elements == answer
-    assert_element_element_index_sorted(doc.elements)
+    assert_element_index_sorted(doc.elements)
 
 
-def assert_element_element_index_sorted(elements: list[Element]):
+def assert_element_index_sorted(elements: list[Element]):
     assert all(
-        elements[i].element_index <= elements[i + 1].element_index for i in range(len(elements) - 1)  # type: ignore
+        elements[i].element_index < elements[i + 1].element_index for i in range(len(elements) - 1)  # type: ignore
     )

--- a/lib/sycamore/sycamore/tests/unit/utils/test_bbox_sort.py
+++ b/lib/sycamore/sycamore/tests/unit/utils/test_bbox_sort.py
@@ -100,7 +100,7 @@ def test_elements_basic() -> None:
     elems = bbox_sorted_elements(elems)
     answer = [e4, e5, e3, e6, e7, e8, e9, e1, e0, e2]
     assert elems == answer
-    assert_element_seq_no_sorted(elems)
+    assert_element_element_index_sorted(elems)
 
 
 def test_document_basic() -> None:
@@ -115,8 +115,10 @@ def test_document_basic() -> None:
     bbox_sort_document(doc)
     answer = [e3, e2, e5, e4, e1, e0]
     assert doc.elements == answer
-    assert_element_seq_no_sorted(doc.elements)
+    assert_element_element_index_sorted(doc.elements)
 
 
-def assert_element_seq_no_sorted(elements: list[Element]):
-    assert all(elements[i].seq_no <= elements[i + 1].seq_no for i in range(len(elements) - 1))  # type: ignore
+def assert_element_element_index_sorted(elements: list[Element]):
+    assert all(
+        elements[i].element_index <= elements[i + 1].element_index for i in range(len(elements) - 1)  # type: ignore
+    )

--- a/lib/sycamore/sycamore/tests/unit/utils/test_bbox_sort.py
+++ b/lib/sycamore/sycamore/tests/unit/utils/test_bbox_sort.py
@@ -100,6 +100,7 @@ def test_elements_basic() -> None:
     elems = bbox_sorted_elements(elems)
     answer = [e4, e5, e3, e6, e7, e8, e9, e1, e0, e2]
     assert elems == answer
+    assert_element_seq_no_sorted(elems)
 
 
 def test_document_basic() -> None:
@@ -114,3 +115,8 @@ def test_document_basic() -> None:
     bbox_sort_document(doc)
     answer = [e3, e2, e5, e4, e1, e0]
     assert doc.elements == answer
+    assert_element_seq_no_sorted(doc.elements)
+
+
+def assert_element_seq_no_sorted(elements: list[Element]):
+    assert all(elements[i].seq_no <= elements[i + 1].seq_no for i in range(len(elements) - 1))  # type: ignore

--- a/lib/sycamore/sycamore/transforms/bbox_merge.py
+++ b/lib/sycamore/sycamore/transforms/bbox_merge.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 
 from sycamore.data import Document, Element
+from sycamore.data.document import DocumentPropertyTypes
 from sycamore.plan_nodes import Node, SingleThreadUser, NonGPUUser
 from sycamore.transforms.map import Map
 from sycamore.utils.time_trace import TimeTrace, timetrace
@@ -26,9 +27,9 @@ def getBboxLeftTop(elem: Element):
 def getPageTopLeft(elem: Element):
     bbox = elem.data.get("bbox")
     if bbox is None:
-        return (elem.properties["page_number"], 0.0, 0.0)
+        return (elem.properties[DocumentPropertyTypes.PAGE_NUMBER], 0.0, 0.0)
     else:
-        return (elem.properties["page_number"], bbox[1], bbox[0])
+        return (elem.properties[DocumentPropertyTypes.PAGE_NUMBER], bbox[1], bbox[0])
 
 
 def getRow(elem: Element, elements: list[Element]) -> list[Element]:
@@ -41,7 +42,7 @@ def getRow(elem: Element, elements: list[Element]) -> list[Element]:
     top = bbox[1]
     right = bbox[2]
     bottom = bbox[3]
-    page = elem.properties["page_number"]
+    page = elem.properties[DocumentPropertyTypes.PAGE_NUMBER]
 
     # !!! assuming elements are sorted by y-values
     n = len(elements)
@@ -51,7 +52,7 @@ def getRow(elem: Element, elements: list[Element]) -> list[Element]:
     while beg < end:
         mid = beg + ((end - beg) // 2)
         melem = elements[mid]
-        mpage = melem.properties["page_number"]
+        mpage = melem.properties[DocumentPropertyTypes.PAGE_NUMBER]
         if mpage < page:
             beg = mid + 1
             idx = mid

--- a/lib/sycamore/sycamore/transforms/detr_partitioner.py
+++ b/lib/sycamore/sycamore/transforms/detr_partitioner.py
@@ -312,7 +312,7 @@ class ArynPDFPartitioner:
 
         elements = []
         for idx, element_json in enumerate(response_json):
-            element = create_element(seq_no=idx, **element_json)
+            element = create_element(element_index=idx, **element_json)
             if element.binary_representation:
                 element.binary_representation = base64.b64decode(element.binary_representation)
             elements.append(element)
@@ -684,7 +684,7 @@ class DeformableDetr(SycamoreObjectDetection):
                 # Potential fix if negative bbox is causing downstream failures
                 # box = [max(0.0, coord) for coord in box]
                 element = create_element(
-                    seq_no=idx,
+                    element_index=idx,
                     type=self.labels[label],
                     bbox=BoundingBox(box[0] / w, box[1] / h, box[2] / w, box[3] / h).coordinates,
                     properties={"score": score},

--- a/lib/sycamore/sycamore/transforms/extract_document_structure.py
+++ b/lib/sycamore/sycamore/transforms/extract_document_structure.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Optional, Union
 
-from sycamore.data.document import Document, HierarchicalDocument
+from sycamore.data.document import Document, HierarchicalDocument, DocumentPropertyTypes
 from sycamore.plan_nodes import Node
 from sycamore.transforms.map import Map
 
@@ -32,7 +32,7 @@ class StructureByImages(DocumentStructure):
                 {
                     "type": "Section-header",
                     "bbox": (0, 0, 0, 0),
-                    "properties": {"score": 1, "page_number": 1},
+                    "properties": {"score": 1, DocumentPropertyTypes.PAGE_NUMBER: 1},
                     "text_representation": "Document",
                     "binary_representation": b"Front Page",
                     "relationships": {},
@@ -78,7 +78,7 @@ class StructureBySection(DocumentStructure):
                 {
                     "type": "Section-header",
                     "bbox": (0, 0, 0, 0),
-                    "properties": {"score": 1, "page_number": 1},
+                    "properties": {"score": 1, DocumentPropertyTypes.PAGE_NUMBER: 1},
                     "text_representation": "Front Page",
                     "binary_representation": b"Front Page",
                 }
@@ -164,7 +164,7 @@ class StructureByDocument(DocumentStructure):
             {
                 "type": "Section-header",
                 "bbox": (0, 0, 0, 0),
-                "properties": {"score": 1, "page_number": 1},
+                "properties": {"score": 1, DocumentPropertyTypes.PAGE_NUMBER: 1},
                 "text_representation": "Document",
                 "binary_representation": b"Front Page",
                 "relationships": {},

--- a/lib/sycamore/sycamore/transforms/extract_table.py
+++ b/lib/sycamore/sycamore/transforms/extract_table.py
@@ -13,6 +13,7 @@ from textractor.data.constants import TextractFeatures
 from textractor.parsers import response_parser
 
 from sycamore.data import BoundingBox, Document, Element
+from sycamore.data.document import DocumentPropertyTypes
 
 logger = logging.getLogger("sycamore")
 
@@ -96,7 +97,7 @@ class TextractTableExtractor(TableExtractor):
             element.type = "Table"
             element.properties["boxes"] = []
             element.properties["id"] = table.id
-            element.properties["page_number"] = table.page
+            element.properties[DocumentPropertyTypes.PAGE_NUMBER] = table.page
 
             if table.title:
                 element.text_representation = table.title.text + "\n"
@@ -192,7 +193,11 @@ class CachedTextractTableExtractor(TextractTableExtractor):
 
         document_page_mapping = list(
             OrderedDict.fromkeys(
-                [element.properties["page_number"] for element in document.elements if element.type == "Table"]
+                [
+                    element.properties[DocumentPropertyTypes.PAGE_NUMBER]
+                    for element in document.elements
+                    if element.type == "Table"
+                ]
             )
         )
 
@@ -241,10 +246,10 @@ class CachedTextractTableExtractor(TextractTableExtractor):
             tables = self.get_tables_from_textract_result(textract_result)
             # put back actual page numbers
             for table in tables:
-                table.properties["page_number"] = (
-                    document_page_mapping[table.properties["page_number"] - 1]
+                table.properties[DocumentPropertyTypes.PAGE_NUMBER] = (
+                    document_page_mapping[table.properties[DocumentPropertyTypes.PAGE_NUMBER] - 1]
                     if document_page_mapping
-                    else table.properties["page_number"]
+                    else table.properties[DocumentPropertyTypes.PAGE_NUMBER]
                 )
             document.elements = document.elements + tables
         return document

--- a/lib/sycamore/sycamore/transforms/mark_misc.py
+++ b/lib/sycamore/sycamore/transforms/mark_misc.py
@@ -1,4 +1,5 @@
 from sycamore.data import Document
+from sycamore.data.document import DocumentPropertyTypes
 from sycamore.functions.tokenizer import Tokenizer
 from sycamore.plan_nodes import Node, SingleThreadUser, NonGPUUser
 from sycamore.transforms import Map
@@ -65,9 +66,9 @@ class MarkBreakPage(SingleThreadUser, NonGPUUser, Map):
     @timetrace("markBreakPage")
     def mark_break_page(parent: Document) -> Document:
         if len(parent.elements) > 1:
-            last = parent.elements[0].properties["page_number"]
+            last = parent.elements[0].properties[DocumentPropertyTypes.PAGE_NUMBER]
             for elem in parent.elements:
-                page = elem.properties["page_number"]
+                page = elem.properties[DocumentPropertyTypes.PAGE_NUMBER]
                 if page != last:
                     elem.data["_break"] = True  # mark for later
                     last = page

--- a/lib/sycamore/sycamore/transforms/markdown.py
+++ b/lib/sycamore/sycamore/transforms/markdown.py
@@ -1,4 +1,5 @@
 from sycamore.data import Document, Element
+from sycamore.data.document import DocumentPropertyTypes
 from sycamore.plan_nodes import Node, SingleThreadUser, NonGPUUser
 from sycamore.transforms.map import Map
 from sycamore.utils.markdown import elements_to_markdown
@@ -30,7 +31,7 @@ def make_markdown(doc: Document) -> Document:
     text = elements_to_markdown(elems)
     pageset: set[int] = set()
     for elem in elems:
-        pn = elem.properties.get("page_number")
+        pn = elem.properties.get(DocumentPropertyTypes.PAGE_NUMBER)
         if pn is not None:
             pageset.add(pn)
     pages = sorted(pageset)
@@ -42,7 +43,7 @@ def make_markdown(doc: Document) -> Document:
                 "type": "Text",
                 "bbox": (0.0, 0.0, 1.0, 1.0),  # best guess
                 "properties": {
-                    "page_number": pages[0],
+                    DocumentPropertyTypes.PAGE_NUMBER: pages[0],
                     "page_numbers": pages,
                 },
                 "text_representation": text,

--- a/lib/sycamore/sycamore/transforms/merge_elements.py
+++ b/lib/sycamore/sycamore/transforms/merge_elements.py
@@ -3,6 +3,7 @@ from typing import Any, Dict
 
 
 from sycamore.data import Document, Element, BoundingBox
+from sycamore.data.document import DocumentPropertyTypes
 from sycamore.plan_nodes import SingleThreadUser, NonGPUUser, Node
 from sycamore.functions.tokenizer import Tokenizer
 from sycamore.transforms.map import Map
@@ -72,7 +73,11 @@ class GreedyTextElementMerger(ElementMerger):
         return element
 
     def should_merge(self, element1: Element, element2: Element) -> bool:
-        if not self.merge_across_pages and element1.properties["page_number"] != element2.properties["page_number"]:
+        if (
+            not self.merge_across_pages
+            and element1.properties[DocumentPropertyTypes.PAGE_NUMBER]
+            != element2.properties[DocumentPropertyTypes.PAGE_NUMBER]
+        ):
             return False
         if element1.data["token_count"] + 1 + element2.data["token_count"] > self.max_tokens:
             return False
@@ -127,14 +132,14 @@ class GreedyTextElementMerger(ElementMerger):
         properties = new_elt.properties
         for k, v in elt1.properties.items():
             properties[k] = v
-            if k == "page_number":
+            if k == DocumentPropertyTypes.PAGE_NUMBER:
                 properties["page_numbers"] = properties.get("page_numbers", list())
                 properties["page_numbers"] = list(set(properties["page_numbers"] + [v]))
         for k, v in elt2.properties.items():
             if properties.get(k) is None:
                 properties[k] = v
             # if a page number exists, add it to the set of page numbers for this new element
-            if k == "page_number":
+            if k == DocumentPropertyTypes.PAGE_NUMBER:
                 properties["page_numbers"] = properties.get("page_numbers", list())
                 properties["page_numbers"] = list(set(properties["page_numbers"] + [v]))
 
@@ -172,15 +177,19 @@ class GreedySectionMerger(ElementMerger):
     def should_merge(self, element1: Element, element2: Element) -> bool:
         # deal with empty elements
         if (
-            "page_number" not in element1.properties
-            or "page_number" not in element2.properties
+            DocumentPropertyTypes.PAGE_NUMBER not in element1.properties
+            or DocumentPropertyTypes.PAGE_NUMBER not in element2.properties
             or element1.type is None
             or element2.type is None
         ):
             return False
 
         # DO NOT MERGE across pages
-        if not self.merge_across_pages and element1.properties["page_number"] != element2.properties["page_number"]:
+        if (
+            not self.merge_across_pages
+            and element1.properties[DocumentPropertyTypes.PAGE_NUMBER]
+            != element2.properties[DocumentPropertyTypes.PAGE_NUMBER]
+        ):
             return False
 
         if element1.data["token_count"] + 1 + element2.data["token_count"] > self.max_tokens:
@@ -312,14 +321,14 @@ class GreedySectionMerger(ElementMerger):
         properties = new_elt.properties
         for k, v in elt1.properties.items():
             properties[k] = v
-            if k == "page_number":
+            if k == DocumentPropertyTypes.PAGE_NUMBER:
                 properties["page_numbers"] = properties.get("page_numbers", list())
                 properties["page_numbers"] = list(set(properties["page_numbers"] + [v]))
         for k, v in elt2.properties.items():
             if properties.get(k) is None:
                 properties[k] = v
             # if a page number exists, add it to the set of page numbers for this new element
-            if k == "page_number":
+            if k == DocumentPropertyTypes.PAGE_NUMBER:
                 properties["page_numbers"] = properties.get("page_numbers", list())
                 properties["page_numbers"] = list(set(properties["page_numbers"] + [v]))
 
@@ -379,7 +388,7 @@ class MarkedMerger(ElementMerger):
             if elem.text_representation:
                 text += elem.text_representation + "\n"
             for k, v in elem.properties.items():
-                if k == "page_number":
+                if k == DocumentPropertyTypes.PAGE_NUMBER:
                     props["page_numbers"] = props.get("page_numbers", list())
                     props["page_numbers"] = list(set(props["page_numbers"] + [v]))
                 if k not in props:  # ??? order may matter here

--- a/lib/sycamore/sycamore/transforms/similarity.py
+++ b/lib/sycamore/sycamore/transforms/similarity.py
@@ -67,7 +67,7 @@ class SimilarityScorer(ABC):
         doc_score = document.properties.get(score_property_name, float("-inf"))
         if score > doc_score:
             document.properties[score_property_name] = score
-            document.properties[f"{score_property_name}_source_element_seq_no"] = element.seq_no
+            document.properties[f"{score_property_name}_source_element_element_index"] = element.element_index
         return document
 
     def generate_similarity_scores(
@@ -79,17 +79,17 @@ class SimilarityScorer(ABC):
 
         for doc_idx, doc in enumerate(doc_batch):
             candidate_elements = self._get_inputs_from_document(doc)
-            for element_seq_no, element_text in candidate_elements:
+            for element_element_index, element_text in candidate_elements:
                 input_pairs.append((query, element_text))
-                input_metadata.append([doc_idx, element_seq_no])
+                input_metadata.append([doc_idx, element_element_index])
 
         if not input_pairs:
             return doc_batch
 
         scores = self.score(input_pairs)
 
-        for i, (doc_idx, element_seq_no) in enumerate(input_metadata):
-            self._populate_score(scores[i], score_property_name, doc_batch[doc_idx], element_seq_no)
+        for i, (doc_idx, element_element_index) in enumerate(input_metadata):
+            self._populate_score(scores[i], score_property_name, doc_batch[doc_idx], element_element_index)
 
         return doc_batch
 

--- a/lib/sycamore/sycamore/transforms/similarity.py
+++ b/lib/sycamore/sycamore/transforms/similarity.py
@@ -5,7 +5,7 @@ from typing import Optional, TYPE_CHECKING
 from sycamore.data.document import DocumentPropertyTypes, DocumentSource
 from sycamore.utils.import_utils import requires_modules
 
-from sycamore.data import Document
+from sycamore.data import Document, Element
 from sycamore.plan_nodes import Node
 from sycamore.transforms import MapBatch
 from sycamore.utils import choose_device
@@ -41,55 +41,54 @@ class SimilarityScorer(ABC):
     def __call__(self, doc_batch: list[Document], query: str, score_property_name: str) -> list[Document]:
         return self.generate_similarity_scores(doc_batch, query, score_property_name)
 
-    def _get_inputs_from_document(self, document: Document) -> list[tuple[int, str]]:
+    def _get_inputs_from_document(self, document: Document) -> list[Element]:
         if self._ignore_doc_structure:
-            return [(-1, document.text_representation)] if document.text_representation else []
+            return [Element(document.data)] if document.text_representation else []
 
-        result: list[tuple[int, str]] = list()
-        for i, element in enumerate(document.elements):
+        result: list[Element] = list()
+        for element in document.elements:
+            assert element.element_index is not None, "generating similarity score requires element_index"
             if (
                 element.properties.get(DocumentPropertyTypes.SOURCE, "") not in self._ignore_element_sources
                 and element.text_representation
             ):
-                result.append((i, element.text_representation))
+                result.append(element)
         return result
 
-    def _populate_score(
-        self, score: float, score_property_name: str, document: Document, element_index: Optional[int] = None
-    ) -> Document:
+    def _populate_score(self, score: float, score_property_name: str, document: Document, element: Element) -> Document:
         if self._ignore_doc_structure:
             document.properties[score_property_name] = score
             return document
-        assert element_index is not None, "populating similarity score requires the element's index"
-        element = document.elements[element_index]
+        assert element.element_index is not None, "populating similarity score requires the element's index"
         element.properties[score_property_name] = score
 
         doc_score = document.properties.get(score_property_name, float("-inf"))
         if score > doc_score:
             document.properties[score_property_name] = score
-            document.properties[f"{score_property_name}_source_element_element_index"] = element.element_index
+            document.properties[f"{score_property_name}_source_element_index"] = element.element_index
         return document
 
     def generate_similarity_scores(
         self, doc_batch: list[Document], query: str, score_property_name: str
     ) -> list[Document]:
 
-        input_metadata = []
+        input_metadata: list[tuple[int, Element]] = []
         input_pairs = []
 
         for doc_idx, doc in enumerate(doc_batch):
             candidate_elements = self._get_inputs_from_document(doc)
-            for element_element_index, element_text in candidate_elements:
-                input_pairs.append((query, element_text))
-                input_metadata.append([doc_idx, element_element_index])
+            for element in candidate_elements:
+                assert element.text_representation is not None, "Found element without text_representation"
+                input_pairs.append((query, element.text_representation))
+                input_metadata.append((doc_idx, element))
 
         if not input_pairs:
             return doc_batch
 
         scores = self.score(input_pairs)
 
-        for i, (doc_idx, element_element_index) in enumerate(input_metadata):
-            self._populate_score(scores[i], score_property_name, doc_batch[doc_idx], element_element_index)
+        for i, (doc_idx, element) in enumerate(input_metadata):
+            self._populate_score(scores[i], score_property_name, doc_batch[doc_idx], element)
 
         return doc_batch
 

--- a/lib/sycamore/sycamore/transforms/sketcher.py
+++ b/lib/sycamore/sycamore/transforms/sketcher.py
@@ -4,6 +4,7 @@ import functools
 import unicodedata
 
 from sycamore.data import Document
+from sycamore.data.document import DocumentPropertyTypes
 from sycamore.functions.simhash import shinglesCalc, shinglesDist
 from sycamore.plan_nodes import Node, SingleThreadUser, NonGPUUser
 from sycamore.transforms.map import Map, FlatMap
@@ -154,7 +155,10 @@ class SketchDebug(SingleThreadUser, NonGPUUser, FlatMap):
             self.total += 1
             docSketch = doc.shingles
             docText = str(doc.text_representation)
-            docLoc = "%s:%s" % (doc.properties.get("path", "NoPath"), doc.properties.get("page_number", "NoPage"))
+            docLoc = "%s:%s" % (
+                doc.properties.get("path", "NoPath"),
+                doc.properties.get(DocumentPropertyTypes.PAGE_NUMBER, "NoPage"),
+            )
             if docSketch:
                 for ii, prevSketch in enumerate(self.seenSketches):
                     dist = shinglesDist(docSketch, prevSketch)

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -5,6 +5,7 @@ from PIL import Image
 import pdf2image
 
 from sycamore.data import BoundingBox, Element, Document, TableElement
+from sycamore.data.document import DocumentPropertyTypes
 from sycamore.plan_nodes import Node
 from sycamore.transforms.map import Map
 from sycamore.transforms.table_structure import table_transformers
@@ -50,8 +51,8 @@ class TableStructureExtractor:
 
         for elem in doc.elements:
             if isinstance(elem, TableElement):
-                if "page_number" in elem.properties:
-                    page_num = elem.properties["page_number"] - 1
+                if DocumentPropertyTypes.PAGE_NUMBER in elem.properties:
+                    page_num = elem.properties[DocumentPropertyTypes.PAGE_NUMBER] - 1
                 elif len(images) == 1:
                     page_num = 0
                 else:

--- a/lib/sycamore/sycamore/utils/bbox_sort.py
+++ b/lib/sycamore/sycamore/utils/bbox_sort.py
@@ -143,16 +143,16 @@ def bbox_sort_page(elems: list[Element]) -> None:
         elem.data.pop("_coltag", None)  # clean up tags
 
 
-def bbox_sorted_elements(elements: list[Element], update_seq_nos: bool = True) -> list[Element]:
+def bbox_sorted_elements(elements: list[Element], update_element_indexs: bool = True) -> list[Element]:
     pages = collect_pages(elements)
     for elems in pages:
         bbox_sort_page(elems)
     ordered_elements = [elem for elems in pages for elem in elems]  # flatten
-    if update_seq_nos:
+    if update_element_indexs:
         for idx, element in enumerate(ordered_elements):
-            element.seq_no = idx
+            element.element_index = idx
     return ordered_elements
 
 
-def bbox_sort_document(doc: Document, update_seq_nos: bool = True) -> None:
-    doc.elements = bbox_sorted_elements(doc.elements, update_seq_nos)
+def bbox_sort_document(doc: Document, update_element_indexs: bool = True) -> None:
+    doc.elements = bbox_sorted_elements(doc.elements, update_element_indexs)

--- a/lib/sycamore/sycamore/utils/bbox_sort.py
+++ b/lib/sycamore/sycamore/utils/bbox_sort.py
@@ -9,6 +9,7 @@ TODO:
 from typing import Optional
 
 from sycamore.data import Document, Element
+from sycamore.data.document import DocumentPropertyTypes
 
 
 def elem_top_left(elem: Element) -> tuple:
@@ -33,7 +34,7 @@ def collect_pages(elems: list[Element]) -> list[list[Element]]:
     """
     pagemap: dict[int, list[Element]] = {}
     for elem in elems:
-        page = elem.properties.get("page_number", 0)
+        page = elem.properties.get(DocumentPropertyTypes.PAGE_NUMBER, 0)
         ary = pagemap.get(page)
         if ary:
             ary.append(elem)
@@ -142,12 +143,16 @@ def bbox_sort_page(elems: list[Element]) -> None:
         elem.data.pop("_coltag", None)  # clean up tags
 
 
-def bbox_sorted_elements(elements: list[Element]) -> list[Element]:
+def bbox_sorted_elements(elements: list[Element], update_seq_nos: bool = True) -> list[Element]:
     pages = collect_pages(elements)
     for elems in pages:
         bbox_sort_page(elems)
-    return [elem for elems in pages for elem in elems]  # flatten
+    ordered_elements = [elem for elems in pages for elem in elems]  # flatten
+    if update_seq_nos:
+        for idx, element in enumerate(ordered_elements):
+            element.seq_no = idx
+    return ordered_elements
 
 
-def bbox_sort_document(doc: Document) -> None:
-    doc.elements = bbox_sorted_elements(doc.elements)
+def bbox_sort_document(doc: Document, update_seq_nos: bool = True) -> None:
+    doc.elements = bbox_sorted_elements(doc.elements, update_seq_nos)

--- a/lib/sycamore/sycamore/utils/html_utils.py
+++ b/lib/sycamore/sycamore/utils/html_utils.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from sycamore.data import Document, TableElement
+from sycamore.data.document import DocumentPropertyTypes
 
 
 def to_html_tables(doc: Document) -> list[Document]:
@@ -15,8 +16,8 @@ def to_html_tables(doc: Document) -> list[Document]:
 
         new_doc.properties["path"] = doc.properties["path"]
 
-        if "page_number" in doc.properties:
-            new_doc.properties["page_number"] = doc.properties["page_number"]
+        if DocumentPropertyTypes.PAGE_NUMBER in doc.properties:
+            new_doc.properties[DocumentPropertyTypes.PAGE_NUMBER] = doc.properties[DocumentPropertyTypes.PAGE_NUMBER]
         new_doc.properties["table_num"] = table_num
         new_docs.append(new_doc)
 

--- a/lib/sycamore/sycamore/utils/image_utils.py
+++ b/lib/sycamore/sycamore/utils/image_utils.py
@@ -7,6 +7,7 @@ import PIL
 from PIL import Image, ImageDraw, ImageFont
 from sycamore.data import Document
 from sycamore.data.bbox import BoundingBox
+from sycamore.data.document import DocumentPropertyTypes
 
 DEFAULT_PADDING = 10
 
@@ -65,7 +66,7 @@ def base64_data_url(image: Image.Image) -> str:
 def image_page_filename_fn(doc: Document) -> str:
     path = Path(doc.properties["path"])
     base_name = ".".join(path.name.split(".")[0:-1])
-    page_num = doc.properties["page_number"]
+    page_num = doc.properties[DocumentPropertyTypes.PAGE_NUMBER]
     return f"{base_name}_page_{page_num}.png"
 
 


### PR DESCRIPTION
1. Add a seq_no attribute to Element, this is meant to represent the order of elements resulting from a partitioner. The partitioner is still responsible for what that ordering means.
2. Add local and ray exec_mode tests for DB readers (via opensearch tests)
3. Lots of mypy fixes and "page_number" constant fixes
