### PR TITLE
Get llm_filter to support document structure + similarity sorting for elements

### DIFF
--- a/lib/sycamore/sycamore/connectors/opensearch/opensearch_reader.py
+++ b/lib/sycamore/sycamore/connectors/opensearch/opensearch_reader.py
@@ -143,8 +143,7 @@ class OpenSearchReaderQueryResponse(BaseDBReader.QueryResponse):
 
             # sort elements per doc
             for doc in result:
-                num_elements = len(doc.elements)
-                doc.elements.sort(key=lambda e: e.element_index if e.element_index is not None else num_elements)
+                doc.elements.sort(key=lambda e: e.element_index if e.element_index is not None else float("inf"))
 
         return result
 

--- a/lib/sycamore/sycamore/connectors/opensearch/opensearch_reader.py
+++ b/lib/sycamore/sycamore/connectors/opensearch/opensearch_reader.py
@@ -80,7 +80,7 @@ class OpenSearchReaderQueryResponse(BaseDBReader.QueryResponse):
 
     def to_docs(self, query_params: "BaseDBReader.QueryParams") -> list[Document]:
         assert isinstance(query_params, OpenSearchReaderQueryParams)
-        result = []
+        result: list[Document] = []
         if not query_params.reconstruct_document:
             for data in self.output:
                 doc = Document(
@@ -140,6 +140,11 @@ class OpenSearchReaderQueryResponse(BaseDBReader.QueryResponse):
                 parent.elements.append(Element(doc.data))
 
             result = list(unique_docs.values())
+
+            # sort elements per doc
+            for doc in result:
+                num_elements = len(doc.elements)
+                doc.elements.sort(key=lambda e: e.element_index if e.element_index is not None else num_elements)
 
         return result
 

--- a/lib/sycamore/sycamore/docset.py
+++ b/lib/sycamore/sycamore/docset.py
@@ -966,7 +966,6 @@ class DocSet:
         field: str = "text_representation",
         threshold: int = 3,
         ignore_doc_structure: bool = True,
-        sort_elements_by_similarity: bool = False,
         similarity_query: Optional[str] = None,
         similarity_scorer: Optional[SimilarityScorer] = None,
         **resource_args,
@@ -982,7 +981,7 @@ class DocSet:
             field: Document field to filter based on.
             threshold: Cutoff that determines whether or not to keep document.
             ignore_doc_structure: ignores document.element mapping.
-            sort_elements_by_similarity: sort elements by similarity to the prompt.
+            similarity_query: query string to compute similarity against.
             similarity_scorer: scorer to generate similarity if 'sort_elements_by_similarity' is True.
             **resource_args
 
@@ -1006,7 +1005,7 @@ class DocSet:
                 doc = entity_extractor.extract_entity(doc)
                 return int(re.findall(r"\d+", doc.properties[new_field])[0]) >= threshold
 
-            if sort_elements_by_similarity:
+            if similarity_query or similarity_scorer:
                 assert similarity_scorer is not None, "Similarity sorting requires a scorer"
                 assert similarity_query is not None, "Similarity sorting requires a string query"
                 score_property_name = f"{field}_similarity_score"

--- a/lib/sycamore/sycamore/docset.py
+++ b/lib/sycamore/sycamore/docset.py
@@ -980,12 +980,14 @@ class DocSet:
             new_field: The field that will be added to the DocSet with the outputs.
             prompt: LLM prompt.
             field: Document field to filter based on.
-            threshold: Cutoff that determines whether to keep document.
-            keep_none:  whether to keep records with a None value.
+            threshold:  If the value of the computed result is an integer value greater than or equal to this threshold,
+                        the document will be kept.
+            keep_none:  keep records with a None value for the provided field to filter on.
                         Warning: using this might hide data corruption issues.
             use_elements: use contents of a document's elements to filter as opposed to document level contents.
-            similarity_query: query string to compute similarity against.
-            similarity_scorer: scorer to generate similarity if 'sort_elements_by_similarity' is True.
+            similarity_query: query string to compute similarity against. Also requires a 'similarity_scorer'.
+            similarity_scorer: scorer used to generate similarity scores used in element sorting.
+                        Also requires a 'similarity_query'.
             **resource_args
 
         Returns:
@@ -1000,6 +1002,7 @@ class DocSet:
                 if doc.field_to_value(field) is None:
                     return keep_none
                 doc = entity_extractor.extract_entity(doc)
+                # todo: move data extraction and validation to entity extractor
                 return int(re.findall(r"\d+", doc.properties[new_field])[0]) >= threshold
 
             if similarity_query or similarity_scorer:
@@ -1017,6 +1020,7 @@ class DocSet:
                     continue
                 e_doc = entity_extractor.extract_entity(e_doc)
                 element.properties[new_field] = e_doc.properties[new_field]
+                # todo: move data extraction and validation to entity extractor
                 if int(re.findall(r"\d+", element.properties[new_field])[0]) >= threshold:
                     return True
                 evaluated_elements += 1

--- a/lib/sycamore/sycamore/tests/integration/connectors/opensearch/test_opensearch_read.py
+++ b/lib/sycamore/sycamore/tests/integration/connectors/opensearch/test_opensearch_read.py
@@ -106,3 +106,6 @@ class TestOpenSearchRead:
         assert len(retrieved_materialized_reconstructed) == 1
         doc = retrieved_materialized_reconstructed[0]
         assert len(doc.elements) == len(retrieved_materialized) - 1  # drop the document parent record
+
+        for i in range(len(doc.elements) - 1):
+            assert doc.elements[i].element_index < doc.elements[i + 1].element_index

--- a/lib/sycamore/sycamore/tests/unit/test_docset.py
+++ b/lib/sycamore/sycamore/tests/unit/test_docset.py
@@ -523,7 +523,7 @@ class TestDocSet:
             field="text_representation",
             threshold=4,
             ignore_doc_structure=False,
-            sort_elements_by_similarity=True,
+            similarity_scorer=similarity_scorer,
             similarity_query="this is an unused query because unit test",
         )
 
@@ -543,7 +543,8 @@ class TestDocSet:
             field="text_representation",
             threshold=2,
             ignore_doc_structure=False,
-            sort_elements_by_similarity=True,
+            similarity_scorer=similarity_scorer,
+            similarity_query="this is an unused query because unit test",
         )
 
         """


### PR DESCRIPTION
**1. Support document model in llm_filter and some performance improvements**
llm_filter will work on a DocSet made of original Documents (i.e. pre-exploded state) when using `use_elements=True`
* Element iteration "early stopping" - a record (document) passes the filter if any of the document's elements pass the llm_filter condition, we don't evaluate every element. This helps for documents which would be a hit, but doesn't for documents which would not (because we would still iterate over every element)
* Optionally, it sorts elements by a similarity score to get potential llm hits sooner
* `keep_none` flag to dictate behavior for a missing property value

None of these are perfect but they align with the use cases we have so far and can keep iterating.

**2. Sorted elements returned by OpenSearchReader in reconstructed documents**
 Use element.element_index field to sort elements when reconstructing a document. Does an explicit sort after each reconstruction which is okay based on the magnitude of data.

**Note:** the `ignore_doc_structure` flag is to prevent current usage from breaking, once we update other code to use the document model we can remove/flip it