### PR TITLE
Add Table Merger

### DIFF
--- a/lib/sycamore/sycamore/data/__init__.py
+++ b/lib/sycamore/sycamore/data/__init__.py
@@ -1,5 +1,5 @@
 from sycamore.data.bbox import BoundingBox
-from sycamore.data.table import Table
+from sycamore.data.table import Table, TableCell
 from sycamore.data.element import Element, ImageElement, TableElement
 from sycamore.data.document import (
     Document,

--- a/lib/sycamore/sycamore/data/__init__.py
+++ b/lib/sycamore/sycamore/data/__init__.py
@@ -21,4 +21,5 @@ __all__ = [
     "OpenSearchQuery",
     "OpenSearchQueryResult",
     "Table",
+    "TableCell",
 ]

--- a/lib/sycamore/sycamore/transforms/llm_query.py
+++ b/lib/sycamore/sycamore/transforms/llm_query.py
@@ -72,7 +72,7 @@ class LLMTextQueryAgent:
                     if not self._table_cont:
                         document.elements[idx] = self._query_text_object(element)
                     else:
-                        if prev_table > 0:
+                        if prev_table >= 0:
                             document.elements[idx] = self._query_text_object(element, document.elements[prev_table])
                         else:
                             document.elements[idx] = self._query_text_object(element)
@@ -94,7 +94,7 @@ class LLMTextQueryAgent:
 
     @timetrace("LLMQueryText")
     def _query_text_object(
-        self, object: Union[Document, Element], objectPrev: Element = None
+        self, object: Union[Document, Element], objectPrev: Optional[Element] = None
     ) -> Union[Document, Element]:
         if object.text_representation:
             if self._format_kwargs:

--- a/lib/sycamore/sycamore/transforms/merge_elements.py
+++ b/lib/sycamore/sycamore/transforms/merge_elements.py
@@ -429,10 +429,14 @@ class TableMerger(ElementMerger):
 
             llm = OpenAI(OpenAIModels.GPT_4O, api_key = '')
 
-            prompt = "Analyze two CSV tables that may be parts of a single table split across pages. Determine if the second table is a continuation of the first with 100% certainty. Check either of the following:\
-            1. Column headers: Must be near identical in terms of text(the ordering/text may contain minor errors because of OCR quality) in both tables. If the headers are almost the same check the number of columns, they should be roughly the same.\
-            2. Missing headers: If the header/columns in the second table are missing, then the first row in the second table should logically be in continutaion of the last row in the first table.\
-            Respond with only 'true' or 'false' based on your certainty that the second table is a continuation. Certainty is determinedx if either of the two conditions is true."
+            prompt = "Analyze two CSV tables that may be parts of a single table split across pages. Determine if the second table\
+                      is a continuation of the first with 100% certainty. Check either of the following:\
+            1. Column headers: Must be near identical in terms of text(the ordering/text may contain minor errors because of OCR quality)\
+               in both tables. If the headers are almost the same check the number of columns, they should be roughly the same.\
+            2. Missing headers: If the header/columns in the second table are missing, then the first row in the second table should logically\
+               be in continutaion of the last row in the first table.\
+            Respond with only 'true' or 'false' based on your certainty that the second table is a continuation. \
+            Certainty is determined if either of the two conditions is true."
 
             regex_pattern = r"table \d+"
 

--- a/lib/sycamore/sycamore/transforms/merge_elements.py
+++ b/lib/sycamore/sycamore/transforms/merge_elements.py
@@ -493,6 +493,9 @@ class TableMerger(ElementMerger):
 
     def merge(self, elt1: Element, elt2: Element) -> Element:
 
+        # Check if both elements are TableElements
+        if not isinstance(elt1, TableElement) or not isinstance(elt2, TableElement):
+            raise TypeError("Both elements must be of type TableElement to perform merging.")
         # Combine the cells, adjusting the row indices for the second table
         offset_row = elt1.table.num_rows
         merged_cells = elt1.table.cells + [

--- a/lib/sycamore/sycamore/transforms/merge_elements.py
+++ b/lib/sycamore/sycamore/transforms/merge_elements.py
@@ -477,8 +477,6 @@ class TableMerger(ElementMerger):
 
     def merge(self, elt1: Element, elt2: Element) -> Element:
 
-        tok1 = elt1.data["token_count"]
-        tok2 = elt2.data["token_count"]
         new_elt = Element()
         new_elt.type = "table"
         # Merge binary representations by concatenation
@@ -489,22 +487,8 @@ class TableMerger(ElementMerger):
         # Merge text representations by concatenation with a newline
         if elt1.text_representation is None or elt2.text_representation is None:
             new_elt.text_representation = elt1.text_representation or elt2.text_representation
-            new_elt.data["token_count"] = max(tok1, tok2)
         else:
             new_elt.text_representation = elt1.text_representation + "\n" + elt2.text_representation
-            new_elt.data["token_count"] = tok1 + 1 + tok2
-        # Merge bbox by taking the coords that make the largest box
-        # if elt1.bbox is None and elt2.bbox is None:
-        #     pass
-        # elif elt1.bbox is None or elt2.bbox is None:
-        #     new_elt.bbox = elt1.bbox or elt2.bbox
-        # else:
-        #     new_elt.bbox = BoundingBox(
-        #         min(elt1.bbox.x1, elt2.bbox.x1),
-        #         min(elt1.bbox.y1, elt2.bbox.y1),
-        #         max(elt1.bbox.x2, elt2.bbox.x2),
-        #         max(elt1.bbox.y2, elt2.bbox.y2),
-        #     )
         # Merge properties by taking the union of the keys
         properties = new_elt.properties
         for k, v in elt1.properties.items():
@@ -550,9 +534,7 @@ class TableMerger(ElementMerger):
         return elements
 
     def process_llm_query(self, document):
-        # Here you can implement how to use the LLM prompt on merged elements
         llm_query_agent = LLMTextQueryAgent(prompt=self.llm_prompt, element_type="table", llm=self.llm, table_cont=True)
-        # Assume you have a method to extract relevant information from merged elements
         llm_results = llm_query_agent.execute_query(document)
         return llm_results
 

--- a/lib/sycamore/sycamore/transforms/merge_elements.py
+++ b/lib/sycamore/sycamore/transforms/merge_elements.py
@@ -497,6 +497,9 @@ class TableMerger(ElementMerger):
         if not isinstance(elt1, TableElement) or not isinstance(elt2, TableElement):
             raise TypeError("Both elements must be of type TableElement to perform merging.")
         # Combine the cells, adjusting the row indices for the second table
+        if elt1.table is None or elt2.table is None:
+            raise ValueError("Both elements must have a table to perform merging.")
+
         offset_row = elt1.table.num_rows
         merged_cells = elt1.table.cells + [
             TableCell(

--- a/lib/sycamore/sycamore/transforms/merge_elements.py
+++ b/lib/sycamore/sycamore/transforms/merge_elements.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Pattern
+from typing import Any, Dict, Pattern, Optional
 from collections import defaultdict
 import re
 
@@ -12,7 +12,6 @@ from sycamore.transforms.map import Map
 from sycamore.utils.time_trace import timetrace
 from sycamore.transforms.llm_query import LLMTextQueryAgent
 from sycamore.llms import LLM
-
 
 
 class ElementMerger(ABC):
@@ -445,7 +444,14 @@ class TableMerger(ElementMerger):
                 .merge(merger=merger)
     """
 
-    def __init__(self, regex_pattern: Optional[Pattern] = None, llm_prompt: Optional[str] = None, llm=Optional[LLM] = None, *args, **kwargs):
+    def __init__(
+        self,
+        regex_pattern: Optional[Pattern] = None,
+        llm_prompt: Optional[str] = None,
+        llm: Optional[LLM] = None,
+        *args,
+        **kwargs
+    ):
         self.regex_pattern = regex_pattern
         self.llm_prompt = llm_prompt
         self.llm = llm

--- a/lib/sycamore/sycamore/transforms/merge_elements.py
+++ b/lib/sycamore/sycamore/transforms/merge_elements.py
@@ -12,6 +12,7 @@ from sycamore.transforms.map import Map
 from sycamore.utils.time_trace import timetrace
 from sycamore.transforms.llm_query import LLMTextQueryAgent
 from sycamore.llms import LLM
+from sycamore.utils.bbox_sort import bbox_sort_document
 
 
 class ElementMerger(ABC):
@@ -481,6 +482,8 @@ class TableMerger(ElementMerger):
                 new_table_elements.append(element)
         other_elements.extend(new_table_elements)
         document.elements = other_elements
+        bbox_sort_document(document)
+
         return document
 
     def should_merge(self, element1: TableElement, element2: TableElement) -> bool:

--- a/lib/sycamore/sycamore/transforms/merge_elements.py
+++ b/lib/sycamore/sycamore/transforms/merge_elements.py
@@ -483,7 +483,9 @@ class TableMerger(ElementMerger):
         return document
 
     def should_merge(self, element1: Element, element2: Element) -> bool:
-        return "true" in element2["properties"]["table_continuation"].lower()
+        if "table_continuation" in element2["properties"]:
+            return "true" in element2["properties"]["table_continuation"].lower()
+        return False
 
     def merge(self, elt1: Element, elt2: Element) -> Element:
 

--- a/lib/sycamore/sycamore/transforms/merge_elements.py
+++ b/lib/sycamore/sycamore/transforms/merge_elements.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import Any, Dict, Pattern
 from collections import defaultdict
 import re
 
@@ -11,6 +11,8 @@ from sycamore.functions.tokenizer import Tokenizer
 from sycamore.transforms.map import Map
 from sycamore.utils.time_trace import timetrace
 from sycamore.transforms.llm_query import LLMTextQueryAgent
+from sycamore.llms import LLM
+
 
 
 class ElementMerger(ABC):
@@ -443,7 +445,7 @@ class TableMerger(ElementMerger):
                 .merge(merger=merger)
     """
 
-    def __init__(self, regex_pattern=None, llm_prompt=None, llm=None, *args, **kwargs):
+    def __init__(self, regex_pattern: Optional[Pattern] = None, llm_prompt: Optional[str] = None, llm=Optional[LLM] = None, *args, **kwargs):
         self.regex_pattern = regex_pattern
         self.llm_prompt = llm_prompt
         self.llm = llm
@@ -471,9 +473,7 @@ class TableMerger(ElementMerger):
         return document
 
     def should_merge(self, element1: Element, element2: Element) -> bool:
-        if "true" in element2["properties"]["table_continuation"].lower():
-            return True
-        return False
+        return "true" in element2["properties"]["table_continuation"].lower()
 
     def merge(self, elt1: Element, elt2: Element) -> Element:
 


### PR DESCRIPTION
The ``Table merger`` handles 3 operations
    1. If a text element (Caption, Section-header, Text...) contains the regex pattern anywhere in a page
     it is attached to the text_representation of the table on the page.
    2. LLMQuery is used for adding a table_continuation property to table elements. If the table is
     a continuation from a previous table the property is stored as true, else false.
    3. After LLMQuery, table elements which are continuations are merged as one element.