### PR TITLE
fix bug in weaviate writer causing api keys to be of wrong type

### DIFF
--- a/lib/sycamore/sycamore/connectors/weaviate/weaviate_writer.py
+++ b/lib/sycamore/sycamore/connectors/weaviate/weaviate_writer.py
@@ -111,7 +111,7 @@ class WeaviateWriterClient(BaseDBWriter.Client):
         from weaviate import WeaviateClient
 
         assert isinstance(params, WeaviateClientParams)
-        client = WeaviateClient(**asdict(params))
+        client = WeaviateClient(**params.__dict__)
         return WeaviateWriterClient(client)
 
     def write_many_records(self, records: list[BaseDBWriter.Record], target_params: BaseDBWriter.TargetParams):
@@ -171,7 +171,7 @@ class WeaviateCrossReferenceClient(WeaviateWriterClient):
         from weaviate import WeaviateClient
 
         assert isinstance(params, WeaviateClientParams)
-        client = WeaviateClient(**asdict(params))
+        client = WeaviateClient(**params.__dict__)
         return WeaviateCrossReferenceClient(client)
 
     def create_target_idempotent(self, target_params: BaseDBWriter.TargetParams):


### PR DESCRIPTION
asdict recurses into inner dataclasses, and ApiKey is a dataclass, so inside the weaviate client library it would see {"api_key": ";kaerjgnejrgheskrgjvnd"} and go "that's not an ApiKey!" and crash