### PR TITLE
Expose local easyocr kwargs

### DIFF
--- a/lib/sycamore/sycamore/transforms/text_extraction/ocr_models.py
+++ b/lib/sycamore/sycamore/transforms/text_extraction/ocr_models.py
@@ -67,10 +67,10 @@ class OcrModel(TextExtractor):
 
 class EasyOcr(OcrModel):
     @requires_modules("easyocr", extra="local-inference")
-    def __init__(self, lang_list=["en"]):
+    def __init__(self, lang_list=["en"], **kwargs):
         import easyocr
 
-        self.reader = easyocr.Reader(lang_list=lang_list)
+        self.reader = easyocr.Reader(lang_list=lang_list, **kwargs)
 
     def get_text(self, image: Image.Image) -> str:
         image_bytes = BytesIO()


### PR DESCRIPTION
Allow custom args for easyocr
```python
with Image.open(TEST_DIR / "resources/data/imgs/sample-detr-image.png") as image:
    e = EasyOcr(model_storage_directory="/Users/vinayakthapliyal/.EasyOCR/model/", download_enabled=False)
    print(e.get_text(image))

```