### PR TITLE
Opensearch kwargs fix

### DIFF
--- a/lib/sycamore/sycamore/connectors/opensearch/opensearch_reader.py
+++ b/lib/sycamore/sycamore/connectors/opensearch/opensearch_reader.py
@@ -45,7 +45,7 @@ class OpenSearchReaderClient(BaseDBReader.Client):
         assert "index" not in query_params.kwargs and "body" not in query_params.kwargs
         if "scroll" not in query_params.kwargs:
             query_params.kwargs["scroll"] = "1m"
-        if "size" not in query_params.query:
+        if "size" not in query_params.query and "size" not in query_params.kwargs:
             query_params.kwargs["size"] = 200
         logging.debug(f"OpenSearch query on {query_params.index_name}: {query_params.query}")
         response = self._client.search(index=query_params.index_name, body=query_params.query, **query_params.kwargs)

--- a/lib/sycamore/sycamore/reader.py
+++ b/lib/sycamore/sycamore/reader.py
@@ -234,6 +234,7 @@ class DocSetReader:
                 i.e. by collecting all elements belong to a single parent document (parent_id). This requires OpenSearch
                 to be an index of docset.explode() type. Default to false.
             query_kwargs: (Optional) Parameters to configure the underlying OpenSearch search query.
+            **kwargs: (Optional) kwargs to pass undefined parameters around.
 
         Example:
             The following shows how to write to data into a OpenSearch Index, and read it back into a DocSet.

--- a/lib/sycamore/sycamore/reader.py
+++ b/lib/sycamore/sycamore/reader.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Callable, Dict
+from typing import Optional, Union, Callable, Dict, Any
 from pathlib import Path
 
 from pandas import DataFrame
@@ -217,6 +217,7 @@ class DocSetReader:
         index_name: str,
         query: Optional[Dict] = None,
         reconstruct_document: bool = False,
+        query_kwargs: dict[str, Any] = {},
         **kwargs,
     ) -> DocSet:
         """
@@ -232,6 +233,7 @@ class DocSetReader:
             reconstruct_document: Used to decide whether the returned DocSet comprises reconstructed documents,
                 i.e. by collecting all elements belong to a single parent document (parent_id). This requires OpenSearch
                 to be an index of docset.explode() type. Default to false.
+            query_kwargs: (Optional) Parameters to configure the underlying OpenSearch search query.
 
         Example:
             The following shows how to write to data into a OpenSearch Index, and read it back into a DocSet.
@@ -280,11 +282,11 @@ class DocSetReader:
         client_params = OpenSearchReaderClientParams(os_client_args=os_client_args)
         query_params = (
             OpenSearchReaderQueryParams(
-                index_name=index_name, query=query, reconstruct_document=reconstruct_document, kwargs=kwargs
+                index_name=index_name, query=query, reconstruct_document=reconstruct_document, kwargs=query_kwargs
             )
             if query is not None
             else OpenSearchReaderQueryParams(
-                index_name=index_name, reconstruct_document=reconstruct_document, kwargs=kwargs
+                index_name=index_name, reconstruct_document=reconstruct_document, kwargs=query_kwargs
             )
         )
         osr = OpenSearchReader(client_params=client_params, query_params=query_params)

--- a/lib/sycamore/sycamore/tests/integration/query/test_query_opensearch.py
+++ b/lib/sycamore/sycamore/tests/integration/query/test_query_opensearch.py
@@ -95,8 +95,8 @@ class TestQueryOpenSearch:
                 "default": {"llm": "some unrelated value"},
             },
         )
-        result = context.read.opensearch(query={"query": {"match_all": {}}, "size": 1}).take()
-        assert len(result) > 0
+        result = context.read.opensearch(query={"query": {"match_all": {}}, "size": 1}, reconstruct_document=True).take()
+        assert len(result) == 1
 
     def test_query_docset(self, setup_index):
         query_executor = OpenSearchQueryExecutor(self.OS_CLIENT_ARGS)

--- a/lib/sycamore/sycamore/tests/integration/query/test_query_opensearch.py
+++ b/lib/sycamore/sycamore/tests/integration/query/test_query_opensearch.py
@@ -95,7 +95,9 @@ class TestQueryOpenSearch:
                 "default": {"llm": "some unrelated value"},
             },
         )
-        result = context.read.opensearch(query={"query": {"match_all": {}}, "size": 1}, reconstruct_document=True).take()
+        result = context.read.opensearch(
+            query={"query": {"match_all": {}}, "size": 1}, reconstruct_document=True
+        ).take()
         assert len(result) == 1
 
     def test_query_docset(self, setup_index):

--- a/lib/sycamore/sycamore/tests/unit/connectors/opensearch/test_opensearch.py
+++ b/lib/sycamore/sycamore/tests/unit/connectors/opensearch/test_opensearch.py
@@ -420,7 +420,9 @@ class TestOpenSearchUtils:
                     },
                     "index_name": "test_index",
                 },
-                "default": {"text_embedder": embedder},
+                "default": {
+                    "text_embedder": embedder,
+                },
             }
         )
         expected_query = {"query": {"knn": {"embedding": {"vector": embedding, "k": 1000}}}}

--- a/lib/sycamore/sycamore/tests/unit/connectors/opensearch/test_opensearch.py
+++ b/lib/sycamore/sycamore/tests/unit/connectors/opensearch/test_opensearch.py
@@ -420,9 +420,7 @@ class TestOpenSearchUtils:
                     },
                     "index_name": "test_index",
                 },
-                "default": {
-                    "text_embedder": embedder,
-                },
+                "default": {"text_embedder": embedder},
             }
         )
         expected_query = {"query": {"knn": {"embedding": {"vector": embedding, "k": 1000}}}}

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_detr_partitioner.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_detr_partitioner.py
@@ -64,7 +64,7 @@ class TestArynPDFPartitioner:
         d = check_partition(s, TEST_DIR / "resources/data/pdfs/basic_table.pdf", use_ocr=True, use_cache=False)
         assert len(d) == 1
 
-    def test_partition_w_ocr_instance(self):
+    def test_partition_with_ocr_instance(self):
         s = ArynPDFPartitioner("Aryn/deformable-detr-DocLayNet")
         ocr = Mock(spec=OcrModel)
         dummy_text = "mocked ocr text"


### PR DESCRIPTION
When using `@context_params`, all kwargs specificied in the global Context would get passed into the reader.opensearch method. Those were being forwarded into the opensearchpy client. Changed the parameter to explicitly accept query_kwargs. I don't quiet know why we have kwargs anyway but don't want to mess with that