### PR TITLE
Make metadata-extraction.ipynb work

### DIFF
--- a/lib/sycamore/sycamore/reader.py
+++ b/lib/sycamore/sycamore/reader.py
@@ -43,6 +43,9 @@ class DocSetReader:
         paths: Union[str, list[str]],
         binary_format: str,
         parallelism: Optional[str] = None,
+        # consider removing override_num_blocks unless we find a good case where specifying it
+        # helps. Specifying override_num_blocks=4 in metadata-extraction.py was causing slowness
+        # and hangs in eric@aryn.ai's experience.
         override_num_blocks: Optional[int] = None,
         filesystem: Optional[FileSystem] = None,
         metadata_provider: Optional[FileMetadataProvider] = None,
@@ -54,7 +57,8 @@ class DocSetReader:
         Args:
             paths: Paths to the Binary file
             binary_format:  Binary file format to read from
-            override_num_blocks: (Optional) Override the number of output blocks from all read tasks.
+            override_num_blocks: (Optional) Override the number of output blocks from all read
+                tasks.  You probably don't want to specify this.
             filesystem: (Optional) The PyArrow filesystem to read from. By default is selected based on the
                 scheme of the paths passed in
             kwargs: (Optional) Arguments to passed into the underlying execution engine
@@ -97,7 +101,8 @@ class DocSetReader:
         Args:
             metadata_provider: Metadata provider for each file, with the manifest being used as the paths to read from
             binary_format:  Binary file format to read from
-            override_num_blocks: (Optional) Override the number of output blocks from all read tasks.
+            override_num_blocks: (Optional) Override the number of output blocks from all read
+                tasks.  You probably don't want to specify this.
             filesystem: (Optional) The PyArrow filesystem to read from. By default is selected based on the scheme
                 of the paths passed in
             kwargs: (Optional) Arguments to passed into the underlying execution engine

--- a/lib/sycamore/sycamore/reader.py
+++ b/lib/sycamore/sycamore/reader.py
@@ -42,7 +42,8 @@ class DocSetReader:
         self,
         paths: Union[str, list[str]],
         binary_format: str,
-        parallelism: Optional[int] = None,
+        parallelism: Optional[str] = None,
+        override_num_blocks: Optional[int] = None,
         filesystem: Optional[FileSystem] = None,
         metadata_provider: Optional[FileMetadataProvider] = None,
         **kwargs,
@@ -53,8 +54,7 @@ class DocSetReader:
         Args:
             paths: Paths to the Binary file
             binary_format:  Binary file format to read from
-            parallelism: (Optional) Override the number of output blocks from all read tasks. Defaults to
-                -1 if not specified
+            override_num_blocks: (Optional) Override the number of output blocks from all read tasks.
             filesystem: (Optional) The PyArrow filesystem to read from. By default is selected based on the
                 scheme of the paths passed in
             kwargs: (Optional) Arguments to passed into the underlying execution engine
@@ -68,12 +68,13 @@ class DocSetReader:
             # Initializng sycamore which also initializes Ray underneath
             context = sycamore.init()
             # Creating a DocSet
-            docset = context.read.binary(paths, parallelism=1, binary_format="pdf")
+            docset = context.read.binary(paths, binary_format="pdf")
         """
         scan = BinaryScan(
             paths,
             binary_format=binary_format,
             parallelism=parallelism,
+            override_num_blocks=override_num_blocks,
             filesystem=filesystem,
             metadata_provider=metadata_provider,
             **kwargs,
@@ -85,7 +86,8 @@ class DocSetReader:
         self,
         metadata_provider: FileMetadataProvider,
         binary_format: str,
-        parallelism: Optional[int] = None,
+        parallelism: Optional[str] = None,
+        override_num_blocks: Optional[int] = None,
         filesystem: Optional[FileSystem] = None,
         **kwargs,
     ) -> DocSet:
@@ -95,8 +97,7 @@ class DocSetReader:
         Args:
             metadata_provider: Metadata provider for each file, with the manifest being used as the paths to read from
             binary_format:  Binary file format to read from
-            parallelism: (Optional) Override the number of output blocks from all read tasks. Defaults to
-                -1 if not specified
+            override_num_blocks: (Optional) Override the number of output blocks from all read tasks.
             filesystem: (Optional) The PyArrow filesystem to read from. By default is selected based on the scheme
                 of the paths passed in
             kwargs: (Optional) Arguments to passed into the underlying execution engine
@@ -124,6 +125,7 @@ class DocSetReader:
             paths,
             binary_format=binary_format,
             parallelism=parallelism,
+            override_num_blocks=override_num_blocks,
             filesystem=filesystem,
             metadata_provider=metadata_provider,
             **kwargs,

--- a/notebooks/metadata-extraction.ipynb
+++ b/notebooks/metadata-extraction.ipynb
@@ -102,6 +102,8 @@
    "outputs": [],
    "source": [
     "s3_path = \"s3://aryn-public/ntsb/\"\n",
+    "partition_materialize_path = \"s3://aryn-public/materialize/notebooks/partition-ntsb/2024-10-11\"\n",
+    "\n",
     "llm = OpenAI(OpenAIModels.GPT_3_5_TURBO.value)\n",
     "tokenizer = HuggingFaceTokenizer(\"thenlper/gte-small\")\n",
     "\n",
@@ -116,9 +118,11 @@
    "outputs": [],
    "source": [
     "docset = (\n",
-    "    ctx.read.binary(s3_path, parallelism=4, binary_format=\"pdf\")\n",
+    "    ctx.read.binary(s3_path, binary_format=\"pdf\")\n",
     "    .partition(partitioner=ArynPartitioner())\n",
-    "    )"
+    "    .materialize(path=partition_materialize_path, source_mode=sycamore.MATERIALIZE_USE_STORED) # avoid expensive re-partitioning step\n",
+    "    )\n",
+    "docset.execute()"
    ]
   },
   {
@@ -141,17 +145,9 @@
     "    .extract_batch_schema(schema_extractor=OpenAISchemaExtractor(\"FlightAccidentReport\", llm=llm, num_of_elements=35))\n",
     "    .extract_properties(property_extractor=OpenAIPropertyExtractor(llm=llm, num_of_elements=35))\n",
     "    .merge(GreedyTextElementMerger(tokenizer, 300))\n",
+    "    .map(convert_timestamp)\n",
+    "    .materialize(\"tmp/metadata-extraction/post-convert-timestamp\", source_mode=sycamore.MATERIALIZE_USE_STORED) # avoid recomputation after take\n",
     "    )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "docset = docset.map(convert_timestamp)"
    ]
   },
   {
@@ -307,7 +303,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
* Use materialize to save the work of re-partitioning which is >50% of notebook runtime.
* Use materialize to avoid re-computation from show/take/write
* Fix readers to use the override_num_blocks parameter instead of parallelism; that's the recommended parameter from ray, and using parallelism created confusion with the parallelism setting for ray execution
* Remove parallelism setting from the notebook. It was causing hangs.