### PR TITLE
Fix DuckDB Spelling Error

### DIFF
--- a/lib/sycamore/sycamore/connectors/duckdb/duckdb_reader.py
+++ b/lib/sycamore/sycamore/connectors/duckdb/duckdb_reader.py
@@ -71,6 +71,8 @@ class DuckDBReaderQueryResponse(BaseDBReader.QueryResponse):
             val = object.get("properties")
             if val is not None:
                 object["properties"] = convert_from_str_dict(val)
+            if isinstance(object["embedding"], float):
+                object["embedding"] = []
             result.append(Document(object))
         return result
 

--- a/lib/sycamore/sycamore/connectors/duckdb/duckdb_writer.py
+++ b/lib/sycamore/sycamore/connectors/duckdb/duckdb_writer.py
@@ -25,7 +25,7 @@ class DuckDBWriterTargetParams(BaseDBWriter.TargetParams):
     schema: Dict[str, str] = field(
         default_factory=lambda: {
             "doc_id": "VARCHAR",
-            "embeddings": "FLOAT",
+            "embedding": "FLOAT",
             "properties": "MAP(VARCHAR, VARCHAR)",
             "text_representation": "VARCHAR",
             "bbox": "DOUBLE[]",
@@ -47,11 +47,11 @@ class DuckDBWriterTargetParams(BaseDBWriter.TargetParams):
             return False
         if other.schema and self.schema:
             if (
-                "embeddings" in other.schema
-                and "embeddings" in self.schema
-                and self.schema["embeddings"] != other.schema["embeddings"]
+                "embedding" in other.schema
+                and "embedding" in self.schema
+                and self.schema["embedding"] != other.schema["embedding"]
             ):
-                self.schema["embeddings"] = self.schema["embeddings"] + "[" + str(self.dimensions) + "]"
+                self.schema["embedding"] = self.schema["embedding"] + "[" + str(self.dimensions) + "]"
             return self.schema == other.schema
         return True
 
@@ -73,11 +73,11 @@ class DuckDBClient(BaseDBWriter.Client):
         ), f"Wrong kind of target parameters found: {target_params}"
         dict_params = asdict(target_params)
         N = target_params.batch_size * 1024  # Around 1 MB
-        headers = ["doc_id", "embeddings", "properties", "text_representation", "bbox", "shingles", "type"]
+        headers = ["doc_id", "embedding", "properties", "text_representation", "bbox", "shingles", "type"]
         schema = pa.schema(
             [
                 ("doc_id", pa.string()),
-                ("embeddings", pa.list_(pa.float32())),
+                ("embedding", pa.list_(pa.float32())),
                 ("properties", pa.map_(pa.string(), pa.string())),
                 ("text_representation", pa.string()),
                 ("bbox", pa.list_(pa.float32())),
@@ -100,7 +100,7 @@ class DuckDBClient(BaseDBWriter.Client):
         for r in records:
             # Append the new data to the batch
             batch_data["doc_id"].append(r.doc_id)
-            batch_data["embeddings"].append(r.embeddings)
+            batch_data["embedding"].append(r.embedding)
             batch_data["properties"].append(convert_to_str_dict(r.properties) if r.properties else {})
             batch_data["text_representation"].append(r.text_representation)
             batch_data["bbox"].append(r.bbox)
@@ -123,10 +123,10 @@ class DuckDBClient(BaseDBWriter.Client):
         client = duckdb.connect(str(dict_params.get("db_url")))
         try:
             if schema:
-                embedding_size = schema.get("embeddings") + "[" + str(dict_params.get("dimensions")) + "]"
+                embedding_size = schema.get("embedding") + "[" + str(dict_params.get("dimensions")) + "]"
                 client.sql(
                     f"""CREATE TABLE {dict_params.get('table_name')} (doc_id {schema.get('doc_id')},
-                      embeddings {embedding_size}, properties {schema.get('properties')},
+                      embedding {embedding_size}, properties {schema.get('properties')},
                       text_representation {schema.get('text_representation')}, bbox {schema.get('bbox')},
                       shingles {schema.get('shingles')}, type {schema.get('type')})"""
                 )
@@ -168,7 +168,7 @@ class DuckDBClient(BaseDBWriter.Client):
 @dataclass
 class DuckDBDocumentRecord(BaseDBWriter.Record):
     doc_id: str
-    embeddings: Optional[list[float]] = None
+    embedding: Optional[list[float]] = None
     properties: Optional[dict[str, Any]] = None
     text_representation: Optional[str] = None
     bbox: Optional[tuple[float, float, float, float]] = None
@@ -181,7 +181,6 @@ class DuckDBDocumentRecord(BaseDBWriter.Record):
         doc_id = document.doc_id
         if doc_id is None:
             raise ValueError(f"Cannot write documents without a doc_id. Found {document}")
-        embedding = document.embedding
         return DuckDBDocumentRecord(
             doc_id=doc_id,
             properties=document.properties,
@@ -189,7 +188,7 @@ class DuckDBDocumentRecord(BaseDBWriter.Record):
             text_representation=document.text_representation,
             bbox=document.bbox.coordinates if document.bbox else None,
             shingles=document.shingles,
-            embeddings=embedding,
+            embedding=document.embedding,
         )
 
 


### PR DESCRIPTION
Replaces `embeddings` with `embedding` and ensures we always get iterables from the DuckDB reader.