### PR TITLE
Bugfixes: DocumentSource enum serialization and missing element_id in old data

### DIFF
--- a/lib/sycamore/sycamore/data/document.py
+++ b/lib/sycamore/sycamore/data/document.py
@@ -1,6 +1,5 @@
 from collections import UserDict
 import json
-from enum import Enum
 from typing import Any, Optional
 import uuid
 
@@ -8,7 +7,7 @@ from sycamore.data import BoundingBox, Element
 from sycamore.data.element import create_element
 
 
-class DocumentSource(Enum):
+class DocumentSource:
     UNKNOWN = "UNKNOWN"
     DB_QUERY = "DB_QUERY"
     DOCUMENT_RECONSTRUCTION_RETRIEVAL = "DOCUMENT_RECONSTRUCTION_RETRIEVAL"

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_similarity.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_similarity.py
@@ -92,9 +92,7 @@ class TestSimilarityScorer:
         dicts = [
             {
                 "doc_id": 1,
-                "elements": [
-                    {"text_representation": "here is an animal that meows", "properties": {}}
-                ],
+                "elements": [{"text_representation": "here is an animal that meows", "properties": {}}],
             },
             {
                 "doc_id": 2,

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_similarity.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_similarity.py
@@ -111,7 +111,7 @@ class TestSimilarityScorer:
         result.sort(key=lambda doc: doc.properties.get(score_property_name, float("-inf")), reverse=True)
         assert [doc.doc_id for doc in result] == [2, 1]
 
-        assert result[0].properties[score_property_name + "_source_element_index"] == "Unknown"
+        assert f"{score_property_name}_source_element_index" not in result[0].properties
 
 
 class TestSimilarityTransform:

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_similarity.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_similarity.py
@@ -83,6 +83,36 @@ class TestSimilarityScorer:
         result.sort(key=lambda doc: doc.properties.get(score_property_name, float("-inf")), reverse=True)
         assert [doc.doc_id for doc in result] == [2, 1, 3, 5, 4]
 
+    def test_transformers_similarity_scorer_no_element_id(self):
+
+        similarity_scorer = HuggingFaceTransformersSimilarityScorer(RERANKER_MODEL)
+        score_property_name = "similarity_score"
+        query = "this is a cat"
+
+        dicts = [
+            {
+                "doc_id": 1,
+                "elements": [
+                    {"text_representation": "here is an animal that meows", "properties": {}}
+                ],
+            },
+            {
+                "doc_id": 2,
+                "elements": [
+                    {"properties": {}, "text_representation": "this is a cat"},
+                    {"properties": {"_element_index": 1}, "text_representation": "here is an animal that moos"},
+                ],
+            },
+        ]
+        docs = [Document(item) for item in dicts]
+        result = similarity_scorer.generate_similarity_scores(
+            docs, query=query, score_property_name=score_property_name
+        )
+        result.sort(key=lambda doc: doc.properties.get(score_property_name, float("-inf")), reverse=True)
+        assert [doc.doc_id for doc in result] == [2, 1]
+
+        assert result[0].properties[score_property_name + "_source_element_index"] == "Unknown"
+
 
 class TestSimilarityTransform:
 

--- a/lib/sycamore/sycamore/transforms/similarity.py
+++ b/lib/sycamore/sycamore/transforms/similarity.py
@@ -63,12 +63,11 @@ class SimilarityScorer(ABC):
         doc_score = document.properties.get(score_property_name, float("-inf"))
         if score > doc_score:
             document.properties[score_property_name] = score
-            source = element.element_index
-            if source is None:
+            if element.element_index is None:
                 # note: this is for backwards compatibility with older versions of sycamore
                 logger.warning("No element_index found, please update your index to trace document similarity scores.")
-                source = f"Unknown"
-            document.properties[f"{score_property_name}_source_element_index"] = source
+            else:
+                document.properties[f"{score_property_name}_source_element_index"] = element.element_index
         return document
 
     def generate_similarity_scores(

--- a/lib/sycamore/sycamore/transforms/similarity.py
+++ b/lib/sycamore/sycamore/transforms/similarity.py
@@ -108,6 +108,7 @@ class HuggingFaceTransformersSimilarityScorer(SimilarityScorer):
         max_tokens: Max tokens to use for tokenization, default is 512.
         device: Device (e.g., "cpu" or "cuda") on which to perform embedding.
         ignore_doc_structure: Ignore Document model (Document->Elements) in a DocSet
+        ignore_element_sources: Ignore elements that belong to a certain DocumentSource type.
 
     Example:
         .. code-block:: python
@@ -136,7 +137,7 @@ class HuggingFaceTransformersSimilarityScorer(SimilarityScorer):
         max_tokens: int = 512,
         device: Optional[str] = None,
         ignore_doc_structure: bool = False,
-        ignore_element_sources: Optional[list[DocumentSource]] = None,
+        ignore_element_sources: Optional[list[str]] = None,
     ):
         super().__init__(ignore_element_sources=ignore_element_sources, ignore_doc_structure=ignore_doc_structure)
         self.device = choose_device(device)

--- a/lib/sycamore/sycamore/transforms/similarity.py
+++ b/lib/sycamore/sycamore/transforms/similarity.py
@@ -30,9 +30,7 @@ class SimilarityScorer(ABC):
         ignore_doc_structure: Ignore Document model (Document->Elements) in a DocSet
     """
 
-    def __init__(
-        self, ignore_element_sources: Optional[list[DocumentSource]] = None, ignore_doc_structure: bool = False
-    ):
+    def __init__(self, ignore_element_sources: Optional[list[str]] = None, ignore_doc_structure: bool = False):
         if ignore_element_sources is None:
             ignore_element_sources = [DocumentSource.DOCUMENT_RECONSTRUCTION_RETRIEVAL]
         self._ignore_element_sources = ignore_element_sources


### PR DESCRIPTION
1. **Allow missing element_id in similarity score source for backwards compatibility**

Data loaded in opensearch prior to https://github.com/aryn-ai/sycamore/commit/0a3ad992a471d68658d0bebc9d50b73b599d092f fails in similarity scoring because of missing element_id. 

I'm choosing to explicitly handle the missing value here rather than defaulting when loading from the index to prevent unintended behavior.

2. **Un-enum DocumentSource because it causes json serialization problems**
To serialize a Document object we'd need to use a custom json encoder because of this which is overkill for what is essential a class of constant strings