### PR TITLE
Basic Bedrock LLM client.

### DIFF
--- a/lib/sycamore/sycamore/llms/__init__.py
+++ b/lib/sycamore/sycamore/llms/__init__.py
@@ -1,6 +1,6 @@
 from sycamore.llms.llms import LLM
 from sycamore.llms.openai import OpenAI, OpenAIClientType, OpenAIModels, OpenAIClientParameters, OpenAIClientWrapper
-from sycamore.llms.bedrock import Bedrock
+from sycamore.llms.bedrock import Bedrock, BedrockModels
 
 __all__ = [
     "LLM",
@@ -10,4 +10,5 @@ __all__ = [
     "OpenAIClientParameters",
     "OpenAIClientWrapper",
     "Bedrock",
+    "BedrockModels",
 ]

--- a/lib/sycamore/sycamore/llms/__init__.py
+++ b/lib/sycamore/sycamore/llms/__init__.py
@@ -1,4 +1,13 @@
 from sycamore.llms.llms import LLM
 from sycamore.llms.openai import OpenAI, OpenAIClientType, OpenAIModels, OpenAIClientParameters, OpenAIClientWrapper
+from sycamore.llms.bedrock import Bedrock
 
-__all__ = ["LLM", "OpenAI", "OpenAIClientType", "OpenAIModels", "OpenAIClientParameters", "OpenAIClientWrapper"]
+__all__ = [
+    "LLM",
+    "OpenAI",
+    "OpenAIClientType",
+    "OpenAIModels",
+    "OpenAIClientParameters",
+    "OpenAIClientWrapper",
+    "Bedrock",
+]

--- a/lib/sycamore/sycamore/llms/bedrock.py
+++ b/lib/sycamore/sycamore/llms/bedrock.py
@@ -1,0 +1,70 @@
+import boto3
+import json
+from sycamore.utils.cache import Cache
+from typing import Dict, Optional
+
+
+from sycamore.llms.llms import LLM
+
+DEFAULT_BEDROCK_MODEL = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+DEFAULT_MAX_TOKENS = 1000
+DEFAULT_ANTHROPIC_VERSION = "bedrock-2023-05-31"
+
+
+class Bedrock(LLM):
+    """This is an LLM implementation that uses the AWS Bedrock API to generate text.
+
+    Args:
+        model_name: The name of the Bedrock model to use.
+        cache: A cache object to use for caching results.
+    """
+
+    def __init__(
+        self,
+        model_name: str = DEFAULT_BEDROCK_MODEL,
+        cache: Optional[Cache] = None,
+    ):
+        self._client = boto3.client(service_name="bedrock-runtime")
+        super().__init__(model_name, cache)
+
+    def is_chat_mode(self) -> bool:
+        """Returns True if the LLM is in chat mode, False otherwise."""
+        return True
+
+    def _get_generate_kwargs(self, prompt_kwargs: Dict, llm_kwargs: Optional[Dict] = None) -> Dict:
+        kwargs = {
+            **(llm_kwargs or {}),
+        }
+        if self._model_name.startswith("anthropic."):
+            kwargs["anthropic_version"] = kwargs.get("anthropic_version", DEFAULT_ANTHROPIC_VERSION)
+            kwargs["max_tokens"] = kwargs.get("max_tokens", DEFAULT_MAX_TOKENS)
+
+        if "prompt" in prompt_kwargs:
+            prompt = prompt_kwargs.get("prompt")
+            kwargs.update({"messages": [{"role": "user", "content": f"{prompt}"}]})
+        elif "messages" in prompt_kwargs:
+            kwargs.update({"messages": prompt_kwargs["messages"]})
+        else:
+            raise ValueError("Either prompt or messages must be present in prompt_kwargs.")
+        return kwargs
+
+    def generate(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> str:
+        key, ret = self._cache_get(prompt_kwargs, llm_kwargs)
+        if ret is not None:
+            return ret
+
+        kwargs = self._get_generate_kwargs(prompt_kwargs, llm_kwargs)
+        body = json.dumps(kwargs)
+        response = self._client.invoke_model(
+            body=body, modelId=self._model_name, accept="application/json", contentType="application/json"
+        )
+        response_body = json.loads(response.get("body").read())
+        ret = response_body.get("content", {})[0].get("text", "")
+        value = {
+            "result": ret,
+            "prompt_kwargs": prompt_kwargs,
+            "llm_kwargs": llm_kwargs,
+            "model_name": self._model_name,
+        }
+        self._cache_set(key, value)
+        return ret

--- a/lib/sycamore/sycamore/llms/llms.py
+++ b/lib/sycamore/sycamore/llms/llms.py
@@ -1,36 +1,66 @@
 from abc import ABC, abstractmethod
-from typing import Optional
+import pickle
+from typing import Optional, Tuple
 
 from sycamore.utils.cache import Cache
 
 
 class LLM(ABC):
-    """
-    Initializes a new LLM instance. This class is abstract and should be subclassed to implement specific LLM providers.
-    """
+    """Abstract representation of an LLM instance. and should be subclassed to implement specific LLM providers."""
 
     def __init__(self, model_name, cache: Optional[Cache] = None):
         self._model_name = model_name
         self._cache = cache
 
-    """
-    Generates a response from the LLM for the given prompt and LLM parameters.
-    """
-
     @abstractmethod
     def generate(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> str:
+        """Generates a response from the LLM for the given prompt and LLM parameters."""
         pass
-
-    """
-    Returns True if the LLM is in chat mode, False otherwise.
-    """
 
     @abstractmethod
     def is_chat_mode(self) -> bool:
+        """Returns True if the LLM is in chat mode, False otherwise."""
         pass
 
     async def generate_async(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> str:
-        raise ValueError("No implementation for llm futures exists")
+        """Generates a response from the LLM for the given prompt and LLM parameters asynchronously."""
+        raise NotImplementedError("This LLM does not support asynchronous generation.")
+
+    def _get_cache_key(self, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> str:
+        """Return a cache key for the given prompt and LLM parameters."""
+        assert self._cache
+        combined = {"prompt_kwargs": prompt_kwargs, "llm_kwargs": llm_kwargs, "model_name": self._model_name}
+        data = pickle.dumps(combined)
+        return self._cache.get_hash_context(data).hexdigest()
+
+    def _cache_get(self, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> Tuple[Optional[str], Optional[str]]:
+        """Get a cached result for the given prompt and LLM parameters. Returns the cache key
+        and the cached result if found, otherwise returns None for both."""
+        if (llm_kwargs or {}).get("temperature", 0) != 0 or not self._cache:
+            # Never cache when temperature setting is nonzero.
+            return (None, None)
+
+        key = self._get_cache_key(prompt_kwargs, llm_kwargs)
+        hit = self._cache.get(key)
+        if hit:
+            assert (
+                hit.get("prompt_kwargs") == prompt_kwargs
+                and hit.get("llm_kwargs") == llm_kwargs
+                and hit.get("model_name") == self._model_name
+            ), f"""
+            Found LLM cache content mismatch:
+            key={key}
+            prompt_kwargs={prompt_kwargs}, cached={hit.get("prompt_kwargs")}
+            llm_kwargs={llm_kwargs}, cached={hit.get("llm_kwargs")}
+            model_name={self._model_name}, cached={hit.get("model_name")}"""
+            return (key, hit.get("result"))
+        return (key, None)
+
+    def _cache_set(self, key, result):
+        """Set a cached result for the given key."""
+        if key is None or not self._cache:
+            return
+        self._cache.set(key, result)
 
 
 class FakeLLM(LLM):

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -363,8 +363,10 @@ class OpenAI(LLM):
     def is_chat_mode(self):
         return self.model.is_chat
 
-    def _convert_response_format(self, llm_kwargs: Dict) -> Dict:
+    def _convert_response_format(self, llm_kwargs: Optional[Dict]) -> Optional[Dict]:
         """Convert the response_format parameter to the appropriate OpenAI format."""
+        if llm_kwargs is None:
+            return None
         response_format = llm_kwargs.get("response_format")
         if response_format is None:
             return llm_kwargs
@@ -400,7 +402,7 @@ class OpenAI(LLM):
             return False
 
     def generate(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> str:
-        llm_kwargs = self._convert_response_format(llm_kwargs) if llm_kwargs else None
+        llm_kwargs = self._convert_response_format(llm_kwargs)
         key, ret = self._cache_get(prompt_kwargs, llm_kwargs)
         if ret is not None:
             return ret

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -299,10 +299,25 @@ def openai_deserializer(kwargs):
 
 
 class OpenAI(LLM):
+    """An LLM interface to OpenAI models.
+
+    Args:
+        model_name: The name of the OpenAI model to use. This can be an instance of OpenAIModels, an instance of
+            OpenAIModel, or a string. If a string is provided, it must be the name of the model.
+        api_key: The API key to use for the OpenAI client. If not provided, the key will be read from the
+            OPENAI_API_KEY environment variable.
+        client_wrapper: An instance of OpenAIClientWrapper to use for the OpenAI client. If not provided, a new
+            instance will be created using the provided parameters.
+        params: An instance of OpenAIClientParameters to use for the OpenAI client. If not provided, a new instance
+            will be created using the provided parameters.
+        cache: An instance of Cache to use for caching responses. If not provided, no caching will be used.
+        **kwargs: Additional parameters to pass to the OpenAI client.
+    """
+
     def __init__(
         self,
         model_name: Union[OpenAIModels, OpenAIModel, str],
-        api_key=None,
+        api_key: Optional[str] = None,
         client_wrapper: Optional[OpenAIClientWrapper] = None,
         params: Optional[OpenAIClientParameters] = None,
         cache: Optional[Cache] = None,
@@ -350,41 +365,15 @@ class OpenAI(LLM):
         return self.model.is_chat
 
     def _get_cache_key(self, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> str:
+        """Override _get_cache_key to include response_format param."""
         assert self._cache
+        llm_kwargs = llm_kwargs.copy() if llm_kwargs else {}
+        response_format = (llm_kwargs or {}).get("response_format")
+        if inspect.isclass(response_format) and issubclass(response_format, pydantic.BaseModel):
+            llm_kwargs["response_format"] = type_to_response_format_param(response_format)
         combined = {"prompt_kwargs": prompt_kwargs, "llm_kwargs": llm_kwargs, "model_name": self.model.name}
         data = pickle.dumps(combined)
         return self._cache.get_hash_context(data).hexdigest()
-
-    def _cache_get(self, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None):
-        if (llm_kwargs or {}).get("temperature", 0) != 0 or not self._cache:
-            # Never cache when temperature setting is nonzero.
-            return (None, None)
-
-        response_format = (llm_kwargs or {}).get("response_format")
-        if inspect.isclass(response_format) and issubclass(response_format, pydantic.BaseModel):
-            assert llm_kwargs
-            llm_kwargs["response_format"] = type_to_response_format_param(response_format)
-
-        key = self._get_cache_key(prompt_kwargs, llm_kwargs)
-        hit = self._cache.get(key)
-        if hit:
-            assert (
-                hit.get("prompt_kwargs") == prompt_kwargs
-                and hit.get("llm_kwargs") == llm_kwargs
-                and hit.get("model_name") == self.model.name
-            ), f"""
-            Found cache content mismatch:
-            key={key}
-            prompt_kwargs={prompt_kwargs}, cached={hit.get("prompt_kwargs")}
-            llm_kwargs={llm_kwargs}, cached={hit.get("llm_kwargs")}
-            model_name={self.model.name}, cached={hit.get("model_name")}"""
-            return (key, hit.get("result"))
-        return (key, None)
-
-    def _cache_set(self, key, result):
-        if key is None or not self._cache:
-            return
-        self._cache.set(key, result)
 
     def _get_generate_kwargs(self, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> dict:
         kwargs = {

--- a/lib/sycamore/sycamore/tests/integration/llms/test_bedrock.py
+++ b/lib/sycamore/sycamore/tests/integration/llms/test_bedrock.py
@@ -1,0 +1,112 @@
+from pathlib import Path
+
+from sycamore.llms import Bedrock, BedrockModels
+from sycamore.utils.cache import DiskCache
+
+
+# Note: These tests assume your environment has been configured to access Amazon Bedrock.
+
+
+def test_bedrock_defaults():
+    llm = Bedrock(BedrockModels.CLAUDE_3_HAIKU)
+    prompt_kwargs = {"prompt": "Write a limerick about large language models."}
+
+    res = llm.generate(prompt_kwargs=prompt_kwargs, llm_kwargs={})
+
+    assert len(res) > 0
+
+
+def test_bedrock_messages_defaults():
+    llm = Bedrock(BedrockModels.CLAUDE_3_HAIKU)
+    messages = [
+        {
+            "role": "user",
+            "content": "Write a caption for a recent trip to a sunny beach",
+        },
+    ]
+    prompt_kwargs = {"messages": messages}
+
+    res = llm.generate(prompt_kwargs=prompt_kwargs, llm_kwargs={})
+
+    assert len(res) > 0
+
+
+def test_cached_bedrock(tmp_path: Path):
+    cache = DiskCache(str(tmp_path))
+    llm = Bedrock(BedrockModels.CLAUDE_3_HAIKU, cache=cache)
+    prompt_kwargs = {"prompt": "Write a limerick about large language models."}
+
+    # pylint: disable=protected-access
+    key = llm._get_cache_key(prompt_kwargs, {})
+
+    res = llm.generate(prompt_kwargs=prompt_kwargs, llm_kwargs={})
+
+    # assert result is cached
+    assert cache.get(key).get("result") == res
+    assert cache.get(key).get("prompt_kwargs") == prompt_kwargs
+    assert cache.get(key).get("llm_kwargs") == {}
+    assert cache.get(key).get("model_name") == BedrockModels.CLAUDE_3_HAIKU.value.name
+
+    # assert llm.generate is using cached result
+    custom_output = {
+        "result": "This is a custom response",
+        "prompt_kwargs": prompt_kwargs,
+        "llm_kwargs": {},
+        "model_name": BedrockModels.CLAUDE_3_HAIKU.value.name,
+    }
+    cache.set(key, custom_output)
+
+    assert llm.generate(prompt_kwargs=prompt_kwargs, llm_kwargs={}) == custom_output["result"]
+
+
+def test_cached_bedrock_different_prompts(tmp_path: Path):
+    cache = DiskCache(str(tmp_path))
+    llm = Bedrock(BedrockModels.CLAUDE_3_HAIKU, cache=cache)
+    prompt_kwargs_1 = {"prompt": "Write a limerick about large language models."}
+    prompt_kwargs_2 = {"prompt": "Write a short limerick about large language models."}
+    prompt_kwargs_3 = {"prompt": "Write a poem about large language models."}
+    prompt_kwargs_4 = {"prompt": "Write a short poem about large language models."}
+
+    key_1 = llm._get_cache_key(prompt_kwargs_1, {})
+    key_2 = llm._get_cache_key(prompt_kwargs_2, {})
+    key_3 = llm._get_cache_key(prompt_kwargs_3, {})
+    key_4 = llm._get_cache_key(prompt_kwargs_4, {})
+    keys = [key_1, key_2, key_3, key_4]
+
+    assert len(keys) == len(
+        set(keys)
+    ), f"""
+    Cached query keys are not unique:
+    key_1: {key_1}
+    key_2: {key_2}
+    key_3: {key_3}
+    key_4: {key_4}
+    """
+
+
+def test_cached_bedrock_different_models(tmp_path: Path):
+    cache = DiskCache(str(tmp_path))
+    llm_HAIKU = Bedrock(BedrockModels.CLAUDE_3_HAIKU, cache=cache)
+    llm_SONNET = Bedrock(BedrockModels.CLAUDE_3_SONNET, cache=cache)
+
+    prompt_kwargs = {"prompt": "Write a limerick about large language models."}
+
+    # populate cache
+    key_HAIKU = llm_HAIKU._get_cache_key(prompt_kwargs, {})
+    res_HAIKU = llm_HAIKU.generate(prompt_kwargs=prompt_kwargs, llm_kwargs={})
+    key_SONNET = llm_SONNET._get_cache_key(prompt_kwargs, {})
+    res_SONNET = llm_SONNET.generate(prompt_kwargs=prompt_kwargs, llm_kwargs={})
+
+    # check proper cached results
+    assert cache.get(key_HAIKU).get("result") == res_HAIKU
+    assert cache.get(key_HAIKU).get("prompt_kwargs") == prompt_kwargs
+    assert cache.get(key_HAIKU).get("llm_kwargs") == {}
+    assert cache.get(key_HAIKU).get("model_name") == BedrockModels.CLAUDE_3_HAIKU.value.name
+    assert cache.get(key_SONNET).get("result") == res_SONNET
+    assert cache.get(key_SONNET).get("prompt_kwargs") == prompt_kwargs
+    assert cache.get(key_SONNET).get("llm_kwargs") == {}
+    assert cache.get(key_SONNET).get("model_name") == BedrockModels.CLAUDE_3_SONNET.value.name
+
+    # check for difference with model change
+    assert key_HAIKU != key_SONNET
+    assert res_HAIKU != res_SONNET

--- a/lib/sycamore/sycamore/tests/integration/llms/test_openai.py
+++ b/lib/sycamore/sycamore/tests/integration/llms/test_openai.py
@@ -159,7 +159,8 @@ def test_cached_openai_pydantic_model(tmp_path: Path):
     llm_kwargs_cached = {"response_format": type_to_response_format_param(Statement)}
 
     # populate cache
-    key_GPT_4O_MINI, _res = llm_GPT_4O_MINI._cache_get(prompt_kwargs, llm_kwargs)
+    # pylint: disable=protected-access
+    key_GPT_4O_MINI, _ = llm_GPT_4O_MINI._cache_get(prompt_kwargs, llm_kwargs_cached)
     res_GPT_4O_MINI = llm_GPT_4O_MINI.generate(prompt_kwargs=prompt_kwargs, llm_kwargs=llm_kwargs)
     assert key_GPT_4O_MINI is not None
     # check cache

--- a/lib/sycamore/sycamore/tests/integration/llms/test_openai.py
+++ b/lib/sycamore/sycamore/tests/integration/llms/test_openai.py
@@ -161,6 +161,7 @@ def test_cached_openai_pydantic_model(tmp_path: Path):
     # populate cache
     key_GPT_4O_MINI, _res = llm_GPT_4O_MINI._cache_get(prompt_kwargs, llm_kwargs)
     res_GPT_4O_MINI = llm_GPT_4O_MINI.generate(prompt_kwargs=prompt_kwargs, llm_kwargs=llm_kwargs)
+    assert key_GPT_4O_MINI is not None
     # check cache
     assert cache.get(key_GPT_4O_MINI).get("result") == res_GPT_4O_MINI
     assert cache.get(key_GPT_4O_MINI).get("prompt_kwargs") == prompt_kwargs

--- a/lib/sycamore/sycamore/tests/unit/llms/test_bedrock.py
+++ b/lib/sycamore/sycamore/tests/unit/llms/test_bedrock.py
@@ -31,6 +31,7 @@ def test_bedrock(mock_boto3_client):
         "messages": [{"role": "user", "content": "Roll 4d20 and tell me the final sum."}],
         "max_tokens": DEFAULT_MAX_TOKENS,
         "anthropic_version": DEFAULT_ANTHROPIC_VERSION,
+        "temperature": 0,
     }
 
 
@@ -59,6 +60,7 @@ def test_bedrock_with_llm_kwargs(mock_boto3_client):
         "messages": [{"role": "user", "content": "Roll 4d20 and tell me the final sum."}],
         "max_tokens": 100,
         "anthropic_version": "v1",
+        "temperature": 0,
     }
 
 
@@ -95,6 +97,7 @@ def test_bedrock_with_cache(mock_boto3_client):
             "messages": [{"role": "user", "content": "Roll 4d20 and tell me the final sum."}],
             "max_tokens": DEFAULT_MAX_TOKENS,
             "anthropic_version": DEFAULT_ANTHROPIC_VERSION,
+            "temperature": 0,
         }
 
         result = client.generate(

--- a/lib/sycamore/sycamore/tests/unit/llms/test_bedrock.py
+++ b/lib/sycamore/sycamore/tests/unit/llms/test_bedrock.py
@@ -2,7 +2,7 @@ import json
 from unittest.mock import patch
 import tempfile
 
-from sycamore.llms import Bedrock
+from sycamore.llms import Bedrock, BedrockModels
 from sycamore.llms.bedrock import DEFAULT_ANTHROPIC_VERSION, DEFAULT_MAX_TOKENS
 from sycamore.utils.cache import DiskCache
 
@@ -13,9 +13,9 @@ def test_bedrock(mock_boto3_client):
         '{"content": [{"text": "Here is your result: 56"}]}'
     )
 
-    client = Bedrock(model_name="anthropic.test-model")
+    client = Bedrock(BedrockModels.CLAUDE_3_5_SONNET)
     assert client.is_chat_mode()
-    assert client._model_name == "anthropic.test-model"
+    assert client._model_name == BedrockModels.CLAUDE_3_5_SONNET.value.name
 
     result = client.generate(
         prompt_kwargs={
@@ -40,9 +40,9 @@ def test_bedrock_with_llm_kwargs(mock_boto3_client):
         '{"content": [{"text": "Here is your result: 56"}]}'
     )
 
-    client = Bedrock(model_name="anthropic.test-model")
+    client = Bedrock(BedrockModels.CLAUDE_3_5_SONNET)
     assert client.is_chat_mode()
-    assert client._model_name == "anthropic.test-model"
+    assert client._model_name == BedrockModels.CLAUDE_3_5_SONNET.value.name
 
     result = client.generate(
         prompt_kwargs={
@@ -74,9 +74,9 @@ def test_bedrock_with_cache(mock_boto3_client):
         assert cache.cache_hits == 0
         assert cache.total_accesses == 0
 
-        client = Bedrock(model_name="anthropic.test-model", cache=cache)
+        client = Bedrock(BedrockModels.CLAUDE_3_5_SONNET, cache=cache)
         assert client.is_chat_mode()
-        assert client._model_name == "anthropic.test-model"
+        assert client._model_name == BedrockModels.CLAUDE_3_5_SONNET.value.name
 
         result = client.generate(
             prompt_kwargs={

--- a/lib/sycamore/sycamore/tests/unit/llms/test_bedrock.py
+++ b/lib/sycamore/sycamore/tests/unit/llms/test_bedrock.py
@@ -1,0 +1,110 @@
+import json
+from unittest.mock import patch
+import tempfile
+
+from sycamore.llms import Bedrock
+from sycamore.llms.bedrock import DEFAULT_ANTHROPIC_VERSION, DEFAULT_MAX_TOKENS
+from sycamore.utils.cache import DiskCache
+
+
+@patch("boto3.client")
+def test_bedrock(mock_boto3_client):
+    mock_boto3_client.return_value.invoke_model.return_value.get.return_value.read.return_value = (
+        '{"content": [{"text": "Here is your result: 56"}]}'
+    )
+
+    client = Bedrock(model_name="anthropic.test-model")
+    assert client.is_chat_mode()
+    assert client._model_name == "anthropic.test-model"
+
+    result = client.generate(
+        prompt_kwargs={
+            "messages": [
+                {"role": "user", "content": "Roll 4d20 and tell me the final sum."},
+            ]
+        }
+    )
+    assert result == "Here is your result: 56"
+
+    assert mock_boto3_client.call_args.kwargs["service_name"] == "bedrock-runtime"
+    assert json.loads(mock_boto3_client.return_value.invoke_model.call_args.kwargs["body"]) == {
+        "messages": [{"role": "user", "content": "Roll 4d20 and tell me the final sum."}],
+        "max_tokens": DEFAULT_MAX_TOKENS,
+        "anthropic_version": DEFAULT_ANTHROPIC_VERSION,
+    }
+
+
+@patch("boto3.client")
+def test_bedrock_with_llm_kwargs(mock_boto3_client):
+    mock_boto3_client.return_value.invoke_model.return_value.get.return_value.read.return_value = (
+        '{"content": [{"text": "Here is your result: 56"}]}'
+    )
+
+    client = Bedrock(model_name="anthropic.test-model")
+    assert client.is_chat_mode()
+    assert client._model_name == "anthropic.test-model"
+
+    result = client.generate(
+        prompt_kwargs={
+            "messages": [
+                {"role": "user", "content": "Roll 4d20 and tell me the final sum."},
+            ]
+        },
+        llm_kwargs={"max_tokens": 100, "anthropic_version": "v1"},
+    )
+    assert result == "Here is your result: 56"
+
+    assert mock_boto3_client.call_args.kwargs["service_name"] == "bedrock-runtime"
+    assert json.loads(mock_boto3_client.return_value.invoke_model.call_args.kwargs["body"]) == {
+        "messages": [{"role": "user", "content": "Roll 4d20 and tell me the final sum."}],
+        "max_tokens": 100,
+        "anthropic_version": "v1",
+    }
+
+
+@patch("boto3.client")
+def test_bedrock_with_cache(mock_boto3_client):
+    mock_boto3_client.return_value.invoke_model.return_value.get.return_value.read.return_value = (
+        '{"content": [{"text": "Here is your result: 56"}]}'
+    )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        cache = DiskCache(temp_dir)
+
+        assert cache.cache_hits == 0
+        assert cache.total_accesses == 0
+
+        client = Bedrock(model_name="anthropic.test-model", cache=cache)
+        assert client.is_chat_mode()
+        assert client._model_name == "anthropic.test-model"
+
+        result = client.generate(
+            prompt_kwargs={
+                "messages": [
+                    {"role": "user", "content": "Roll 4d20 and tell me the final sum."},
+                ]
+            }
+        )
+        assert result == "Here is your result: 56"
+
+        assert cache.cache_hits == 0
+        assert cache.total_accesses == 1
+
+        assert mock_boto3_client.call_args.kwargs["service_name"] == "bedrock-runtime"
+        assert json.loads(mock_boto3_client.return_value.invoke_model.call_args.kwargs["body"]) == {
+            "messages": [{"role": "user", "content": "Roll 4d20 and tell me the final sum."}],
+            "max_tokens": DEFAULT_MAX_TOKENS,
+            "anthropic_version": DEFAULT_ANTHROPIC_VERSION,
+        }
+
+        result = client.generate(
+            prompt_kwargs={
+                "messages": [
+                    {"role": "user", "content": "Roll 4d20 and tell me the final sum."},
+                ]
+            }
+        )
+        assert result == "Here is your result: 56"
+
+        assert cache.cache_hits == 1
+        assert cache.total_accesses == 2


### PR DESCRIPTION
This is a crude but serviceable LLM client that uses Bedrock. I have currently tested it only with Sonnet 3.5 and different models may have different requirements and parameters, but we can add those over time as needed.

Since there are so many different models with somewhat different formats, it's a little hard to test them all.

I lifted the cache logic into the `LLM` base class so it is reusable across subclasses, although the OpenAI variant needs to account for the response type in the cache key.

