### PR TITLE
Bug fixes: remove kwargs in docset.rerank, sycamore query codegen

### DIFF
--- a/lib/sycamore/sycamore/docset.py
+++ b/lib/sycamore/sycamore/docset.py
@@ -1140,7 +1140,6 @@ class DocSet:
         query: str,
         score_property_name: str = "_rerank_score",
         limit: Optional[int] = None,
-        **kwargs,
     ) -> "DocSet":
         """
         Sort a DocSet given a scoring class.
@@ -1158,7 +1157,7 @@ class DocSet:
         else:
             plan = self.plan
         similarity_scored = ScoreSimilarity(
-            plan, similarity_scorer=similarity_scorer, query=query, score_property_name=score_property_name, **kwargs
+            plan, similarity_scorer=similarity_scorer, query=query, score_property_name=score_property_name
         )
         return DocSet(
             self.context,

--- a/lib/sycamore/sycamore/query/execution/sycamore_executor.py
+++ b/lib/sycamore/sycamore/query/execution/sycamore_executor.py
@@ -204,7 +204,7 @@ class SycamoreExecutor:
         else:
             raise ValueError(f"Unsupported node type: {str(logical_node)}")
 
-        code, imports = operation.script(output_var=(self.OUTPUT_VAR_NAME if not is_result_node else None))
+        code, imports = operation.script(output_var=(self.OUTPUT_VAR_NAME if is_result_node else None))
         self.imports += imports
         self.node_id_to_code[logical_node.node_id] = code
         self.node_id_to_node[logical_node.node_id] = logical_node

--- a/lib/sycamore/sycamore/tests/unit/test_docset.py
+++ b/lib/sycamore/sycamore/tests/unit/test_docset.py
@@ -9,6 +9,7 @@ import sycamore
 from sycamore import DocSet, Context
 from sycamore.context import OperationTypes, ExecMode
 from sycamore.data import Document, Element
+from sycamore.llms import LLM
 from sycamore.llms.prompts.default_prompts import (
     LlmClusterEntityAssignGroupsMessagesPrompt,
     LlmClusterEntityFormGroupsMessagesPrompt,
@@ -28,16 +29,14 @@ from sycamore.transforms import (
     ExtractProperties,
     Query,
 )
-
-from sycamore.llms import LLM
+from sycamore.transforms import Filter
 from sycamore.transforms.base import get_name_from_callable
 from sycamore.transforms.extract_entity import OpenAIEntityExtractor
 from sycamore.transforms.extract_schema import SchemaExtractor
-from sycamore.transforms import Filter
+from sycamore.transforms.query import QueryExecutor
 from sycamore.transforms.similarity import SimilarityScorer
 from sycamore.transforms.sort import Sort
 from sycamore.transforms.summarize import LLMElementTextSummarizer
-from sycamore.transforms.query import QueryExecutor
 
 
 class MockLLM(LLM):


### PR DESCRIPTION
kwargs were being populated by @context_params but unused in the function. They were being passed as is to the underlying ray dataset execution which would complain about unknown additional args. Removed kwargs since it isn't needed here. This was breaking on a vector search query plan but undetected because the integ tests are broken.

Fixed result node naming in sycamore query codegen. Undetected because integ tests broken
