### PR TITLE
Handle Drawing Missing Tables and Cells

### DIFF
--- a/lib/aryn-sdk/aryn_sdk/partition/art.py
+++ b/lib/aryn-sdk/aryn_sdk/partition/art.py
@@ -79,20 +79,21 @@ def draw_with_boxes(
         if "page_number" in element["properties"]:
             im = images[element["properties"]["page_number"] - 1]
             _draw_box_on_image(im, element)
-            if draw_table_cells and element.get("type") == "table":
-                for cell in element.get("table", {}).get("cells", []):
-                    _draw_box_on_image(
-                        im,
-                        element={
-                            "type": "",
-                            "bbox": (
-                                cell["bbox"]["x1"],
-                                cell["bbox"]["y1"],
-                                cell["bbox"]["x2"],
-                                cell["bbox"]["y2"],
-                            ),
-                        },
-                    )
+            if draw_table_cells and element.get("type") == "table" and (table_object := element.get("table")):
+                for cell in table_object.get("cells", []):
+                    if cell and (bbox := cell.get("bbox")):
+                        _draw_box_on_image(
+                            im,
+                            element={
+                                "type": "",
+                                "bbox": (
+                                    bbox["x1"],
+                                    bbox["y1"],
+                                    bbox["x2"],
+                                    bbox["y2"],
+                                ),
+                            },
+                        )
     return images
 
 


### PR DESCRIPTION
We sometimes have missing tables and empty bboxes, this ensures the drawing code does not break over that.