### PR TITLE
Crop To Bbox Error

### DIFF
--- a/lib/sycamore/sycamore/transforms/detr_partitioner.py
+++ b/lib/sycamore/sycamore/transforms/detr_partitioner.py
@@ -788,7 +788,7 @@ def extract_ocr(
                 continue
             if elem.type == "Picture" and not ocr_images:
                 continue
-            cropped_image = crop_to_bbox(image, elem.bbox)
+            cropped_image = crop_to_bbox(image, elem.bbox, padding=0)
             if 0 in cropped_image.size:
                 elem.text_representation = ""
                 continue


### PR DESCRIPTION
Previously cropping to bounding box had no padding, the `crop_to_bbox` function has a default padding of 10 (done since the DETR model often chops very small) which might have caused issues in the table merging code.