### PR TITLE
Support SummarizeImages with non-OpenAI LLMs.

### DIFF
--- a/lib/sycamore/sycamore/llms/bedrock.py
+++ b/lib/sycamore/sycamore/llms/bedrock.py
@@ -2,11 +2,13 @@ from dataclasses import dataclass
 from enum import Enum
 import boto3
 import json
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
+from PIL import Image
 
 from sycamore.llms.llms import LLM
 from sycamore.utils.cache import Cache
+from sycamore.utils.image_utils import base64_data
 
 DEFAULT_MAX_TOKENS = 1000
 DEFAULT_ANTHROPIC_VERSION = "bedrock-2023-05-31"
@@ -48,6 +50,8 @@ class Bedrock(LLM):
         model_name: Union[BedrockModels, str],
         cache: Optional[Cache] = None,
     ):
+        self.model_name = model_name
+
         if isinstance(model_name, BedrockModels):
             self.model = model_name.value
         elif isinstance(model_name, str):
@@ -56,9 +60,19 @@ class Bedrock(LLM):
         self._client = boto3.client(service_name="bedrock-runtime")
         super().__init__(self.model.name, cache)
 
+    def __reduce__(self):
+        def deserializer(kwargs):
+            return Bedrock(**kwargs)
+
+        kwargs = {"model_name": self.model_name, "cache": self._cache}
+        return deserializer, (kwargs,)
+
     def is_chat_mode(self) -> bool:
         """Returns True if the LLM is in chat mode, False otherwise."""
         return True
+
+    def format_image(self, image: Image.Image) -> dict[str, Any]:
+        return {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": base64_data(image)}}
 
     def _rewrite_system_messages(self, messages: Optional[List[Dict]]) -> Optional[List[Dict]]:
         # Anthropic models don't accept messages with "role" set to "system", and

--- a/lib/sycamore/sycamore/llms/bedrock.py
+++ b/lib/sycamore/sycamore/llms/bedrock.py
@@ -72,7 +72,12 @@ class Bedrock(LLM):
         return True
 
     def format_image(self, image: Image.Image) -> dict[str, Any]:
-        return {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": base64_data(image)}}
+        if self.model.name.startswith("anthropic."):
+            return {
+                "type": "image",
+                "source": {"type": "base64", "media_type": "image/png", "data": base64_data(image)},
+            }
+        raise NotImplementedError("Images not supported for non-Anthropic Bedrock models.")
 
     def _rewrite_system_messages(self, messages: Optional[List[Dict]]) -> Optional[List[Dict]]:
         # Anthropic models don't accept messages with "role" set to "system", and

--- a/lib/sycamore/sycamore/llms/llms.py
+++ b/lib/sycamore/sycamore/llms/llms.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 import pickle
-from typing import Optional, Tuple
-
+from PIL import Image
+from typing import Any, Optional, Tuple
 from sycamore.utils.cache import Cache
 
 
@@ -21,6 +21,10 @@ class LLM(ABC):
     def is_chat_mode(self) -> bool:
         """Returns True if the LLM is in chat mode, False otherwise."""
         pass
+
+    def format_image(self, image: Image.Image) -> dict[str, Any]:
+        """Returns a dictionary containing the specified image suitable for use in an LLM message."""
+        raise NotImplementedError("This LLM does not support images.")
 
     async def generate_async(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> str:
         """Generates a response from the LLM for the given prompt and LLM parameters asynchronously."""

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -4,6 +4,7 @@ import logging
 import os
 from dataclasses import dataclass
 from enum import Enum
+from PIL import Image
 from typing import Any, Dict, Optional, TypedDict, Union, cast, TYPE_CHECKING
 
 from openai import AzureOpenAI as AzureOpenAIClient
@@ -21,6 +22,7 @@ from sycamore.llms.guidance import execute_with_guidance
 from sycamore.llms.llms import LLM
 from sycamore.llms.prompts import SimplePrompt
 from sycamore.utils.cache import Cache
+from sycamore.utils.image_utils import base64_data_url
 
 if TYPE_CHECKING:
     from guidance.models import Model
@@ -362,6 +364,9 @@ class OpenAI(LLM):
 
     def is_chat_mode(self):
         return self.model.is_chat
+
+    def format_image(self, image: Image.Image) -> dict[str, Any]:
+        return {"type": "image_url", "image_url": {"url": base64_data_url(image)}}
 
     def _convert_response_format(self, llm_kwargs: Optional[Dict]) -> Optional[Dict]:
         """Convert the response_format parameter to the appropriate OpenAI format."""

--- a/lib/sycamore/sycamore/tests/integration/transforms/test_summarize_images.py
+++ b/lib/sycamore/sycamore/tests/integration/transforms/test_summarize_images.py
@@ -1,24 +1,22 @@
 import sycamore
 from sycamore.transforms.partition import ArynPartitioner
-from sycamore.transforms.summarize_images import LLMImageSummarizer, SummarizeImages
+from sycamore.transforms.summarize_images import LLMImageSummarizer, OpenAIImageSummarizer, SummarizeImages
 from sycamore.tests.config import TEST_DIR
 from sycamore.llms.bedrock import BedrockModels, Bedrock
 
 
-def test_summarize_images():
+def test_summarize_images_openai():
     path = TEST_DIR / "resources/data/pdfs/Ray_page11.pdf"
 
     context = sycamore.init()
     image_docs = (
         context.read.binary(paths=[str(path)], binary_format="pdf")
         .partition(ArynPartitioner(extract_images=True, use_partitioning_service=False, use_cache=False))
-        .transform(SummarizeImages)
+        .transform(SummarizeImages, summarizer=OpenAIImageSummarizer())
         .explode()
         .filter(lambda d: d.type == "Image")
         .take_all()
     )
-
-    print(f"result: {image_docs[0].properties['summary']}")
 
     assert len(image_docs) == 1
     assert image_docs[0].properties["summary"]["is_graph"]
@@ -38,8 +36,6 @@ def test_summarize_images_claude():
         .filter(lambda d: d.type == "Image")
         .take_all()
     )
-
-    print(f"result: {image_docs[0].properties['summary']}")
 
     assert len(image_docs) == 1
     assert image_docs[0].properties["summary"]["is_graph"]

--- a/lib/sycamore/sycamore/tests/integration/transforms/test_summarize_images.py
+++ b/lib/sycamore/sycamore/tests/integration/transforms/test_summarize_images.py
@@ -1,7 +1,8 @@
 import sycamore
 from sycamore.transforms.partition import ArynPartitioner
-from sycamore.transforms.summarize_images import SummarizeImages
+from sycamore.transforms.summarize_images import LLMImageSummarizer, SummarizeImages
 from sycamore.tests.config import TEST_DIR
+from sycamore.llms.bedrock import BedrockModels, Bedrock
 
 
 def test_summarize_images():
@@ -16,6 +17,29 @@ def test_summarize_images():
         .filter(lambda d: d.type == "Image")
         .take_all()
     )
+
+    print(f"result: {image_docs[0].properties['summary']}")
+
+    assert len(image_docs) == 1
+    assert image_docs[0].properties["summary"]["is_graph"]
+
+
+def test_summarize_images_claude():
+    llm = Bedrock(BedrockModels.CLAUDE_3_5_SONNET)
+
+    path = TEST_DIR / "resources/data/pdfs/Ray_page11.pdf"
+
+    context = sycamore.init()
+    image_docs = (
+        context.read.binary(paths=[str(path)], binary_format="pdf")
+        .partition(ArynPartitioner(extract_images=True, use_partitioning_service=False, use_cache=False))
+        .transform(SummarizeImages, summarizer=LLMImageSummarizer(llm=llm))
+        .explode()
+        .filter(lambda d: d.type == "Image")
+        .take_all()
+    )
+
+    print(f"result: {image_docs[0].properties['summary']}")
 
     assert len(image_docs) == 1
     assert image_docs[0].properties["summary"]["is_graph"]

--- a/lib/sycamore/sycamore/transforms/summarize_images.py
+++ b/lib/sycamore/sycamore/transforms/summarize_images.py
@@ -3,41 +3,37 @@ from typing import Any, Optional
 from PIL import Image
 
 from sycamore.data import Document, ImageElement
-from sycamore.llms.openai import OpenAI, OpenAIClientWrapper, OpenAIModels
+from sycamore.llms.openai import LLM, OpenAI, OpenAIClientWrapper, OpenAIModels
 from sycamore.plan_nodes import Node
 from sycamore.transforms.map import Map
-from sycamore.utils.image_utils import base64_data_url
 from sycamore.utils.extract_json import extract_json
 from sycamore.utils.time_trace import timetrace
 
 
-class OpenAIImageSummarizer:
-    """Image Summarizer that uses OpenAI GPT-4 Turbo to summarize the specified image.
+class LLMImageSummarizer:
+    """Image Summarizer that uses an LLM to summarize the specified image.
 
-    The image is passed to OpenAI along with a text prompt and optionally the text elements
+    The image is passed to the LLM along with a text prompt and optionally the text elements
     immediately preceding and following the image.
 
     Args:
-       openai_model: The OpenAI instance to use. If not set, one will be created.
-       client_wrapper: The OpenAIClientWrapper to use when creating an OpenAI instance.
-           Not used if openai_model is set.
+       llm: The LLM to use.
        prompt: The prompt to use to pass to the model, as a string.
        include_context: Whether to include the immediately preceding and following text elements as context.
 
     Example:
          The following code demonstrates how to partition a pdf DocSet and summarize the images it contains.
-         This version uses the default prompt and disables passing additional text context.
+         This version uses a Claude model via Bedrock. 
 
          .. code-block:: python
-
+            llm = Bedrock(BedrockModels.CLAUDE_3_5_SONNET)
+    
             context = sycamore.init()
             doc = context.read.binary(paths=paths, binary_format="pdf")\
                               .partition(partitioner=SycamorePartitioner(extract_images=True))\
-                              .transform(SummarizeImages(summarizer=OpenAIImageSummarizer(include_context=False)))\
+                              .transform(SummarizeImages(summarizer=LLMImageSummarizer(llm=llm)))\
                               .show()
     """
-
-    model = OpenAIModels.GPT_4O
 
     DEFAULT_PROMPT = """You are given an image from a PDF document along with with some snippets of text preceding
             and following the image on the page. Based on this context, please decide whether the image is a
@@ -65,18 +61,8 @@ class OpenAIImageSummarizer:
             In all cases return only JSON and check your work.
             """
 
-    def __init__(
-        self,
-        openai_model: Optional[OpenAI] = None,
-        client_wrapper: Optional[OpenAIClientWrapper] = None,
-        prompt: Optional[str] = None,
-        include_context: bool = True,
-    ):
-        if openai_model is not None:
-            self.openai = openai_model
-        else:
-            self.openai = OpenAI(model_name=self.model, client_wrapper=client_wrapper)
-
+    def __init__(self, llm: LLM, prompt: Optional[str] = None, include_context: bool = True):
+        self.llm = llm
         if prompt is None:
             prompt = self.DEFAULT_PROMPT
         self.prompt = prompt
@@ -86,23 +72,26 @@ class OpenAIImageSummarizer:
     def summarize_image(
         self, image: Image.Image, preceding_context: Optional[str] = None, following_context: Optional[str] = None
     ):
-        messages: list[dict[str, Any]] = [
-            {"role": "user", "content": self.prompt},
-        ]
+        text = self.prompt
 
         if self.include_context and preceding_context is not None:
-            messages.append({"role": "user", "content": "The text preceding the image is {}".format(preceding_context)})
-
-        messages.append(
-            {"role": "user", "content": [{"type": "image_url", "image_url": {"url": base64_data_url(image)}}]}
-        )
+            text += f"\n The text preceding the image is {preceding_context}"
 
         if self.include_context and following_context is not None:
-            messages.append({"role": "user", "content": "The text preceding the image is {}".format(following_context)})
+            text += f"\nThe text following the image is {following_context}"
+
+        content = [
+            {"type": "text", "text": text},
+            self.llm.format_image(image),
+        ]
+
+        messages: list[dict[str, Any]] = [
+            {"role": "user", "content": content},
+        ]
 
         prompt_kwargs = {"messages": messages}
 
-        raw_answer = self.openai.generate(prompt_kwargs=prompt_kwargs, llm_kwargs={})
+        raw_answer = self.llm.generate(prompt_kwargs=prompt_kwargs, llm_kwargs={})
         return extract_json(raw_answer)
 
     def summarize_all_images(self, doc: Document) -> Document:
@@ -132,6 +121,34 @@ class OpenAIImageSummarizer:
             element.properties["summary"] = json_summary
             element.text_representation = json_summary["summary"]
         return doc
+
+
+class OpenAIImageSummarizer(LLMImageSummarizer):
+    """Implementation of the LLMImageSummarizer for OpenAI models.
+
+    Args:
+       openai_model: The OpenAI instance to use. If not set, one will be created.
+       client_wrapper: The OpenAIClientWrapper to use when creating an OpenAI instance.
+           Not used if openai_model is set.
+       prompt: The prompt to use to pass to the model, as a string.
+       include_context: Whether to include the immediately preceding and following text elements as context.
+    """
+
+    model = OpenAIModels.GPT_4O
+
+    def __init__(
+        self,
+        openai_model: Optional[OpenAI] = None,
+        client_wrapper: Optional[OpenAIClientWrapper] = None,
+        prompt: Optional[str] = None,
+        include_context: bool = True,
+    ):
+        if openai_model is not None:
+            openai = openai_model
+        else:
+            openai = OpenAI(model_name=self.model, client_wrapper=client_wrapper)
+
+        super().__init__(llm=openai, prompt=prompt, include_context=include_context)
 
 
 class SummarizeImages(Map):

--- a/lib/sycamore/sycamore/utils/image_utils.py
+++ b/lib/sycamore/sycamore/utils/image_utils.py
@@ -50,7 +50,17 @@ def image_to_bytes(image: Image.Image, format: Optional[str] = None) -> bytes:
     return iobuf.getvalue()
 
 
-def base64_data_url(image: Image.Image) -> str:
+def base64_data(image: Image.Image, format="PNG") -> str:
+    """Returns the image encoded as a base64 string.
+
+    Args:
+       image: A PIL image.
+    """
+
+    return base64.b64encode(image_to_bytes(image, format)).decode("utf-8")
+
+
+def base64_data_url(image: Image.Image, format="PNG") -> str:
     """Returns the image encoded as a png data url
 
     More info on data urls can be found at https://en.wikipedia.org/wiki/Data_URI_scheme
@@ -58,9 +68,7 @@ def base64_data_url(image: Image.Image) -> str:
     Args:
        image: A PIL image.
     """
-
-    encoded_image = image_to_bytes(image, "PNG")
-    return f"data:image/png/;base64,{base64.b64encode(encoded_image).decode('utf-8')}"
+    return f"data:image/png/;base64,{base64_data(image, format)}"
 
 
 def image_page_filename_fn(doc: Document) -> str:


### PR DESCRIPTION
This commit adds a generic LLMImageSummarizer that takes an LLM instance. In order to account for differences in image formats accepted by the LLMs, I also added a `format_image` method to the LLM interface. Finally, I fixed a serialization issue in the Bedrock class by not serializing the boto client.