### PR TITLE
Add support for tags and notes.

### DIFF
--- a/apps/query-eval/data/ntsb-mini.yaml
+++ b/apps/query-eval/data/ntsb-mini.yaml
@@ -9,7 +9,12 @@ config:
 queries:
   - query: "Were there any fire related incidents in CA in 2023?"
     expected: "Yes, there was a fire-related incident in California in 2023."
+    tags:
+      - easy
   - query: "How many Piper aircrafts were involved in accidents?"
     expected: "There were 21 Piper aircrafts involved in accidents."
   - query: "What fraction of incidents that resulted in substantial damage were due to engine problems?"
     expected: "0.338 of the incidents that resulted in substantial damage were due to engine problems."
+    tags:
+      - easy
+      - hard

--- a/apps/query-eval/queryeval/driver.py
+++ b/apps/query-eval/queryeval/driver.py
@@ -303,7 +303,7 @@ class QueryEvalDriver:
                     console.print(f"Actual node: [red]{diff.node_b!r}")
                     console.print()
                 metrics.plan_similarity = max(
-                    0.0, (len(_query.expected_plan.nodes) - len(plan_diff)) / len(_query.expected_plan.nodes)
+                    0.0, (len(query.expected_plan.nodes) - len(plan_diff)) / len(query.expected_plan.nodes)
                 )
                 metrics.plan_diff_count = len(plan_diff)
 

--- a/apps/query-eval/queryeval/main.py
+++ b/apps/query-eval/queryeval/main.py
@@ -11,7 +11,7 @@
 #      data/ntsb-queries.yaml \
 #      run
 
-from typing import Optional
+from typing import Optional, Tuple
 
 import click
 from rich.console import Console
@@ -52,7 +52,7 @@ def cli(
     doc_limit: Optional[int],
     overwrite: bool,
     llm: Optional[str],
-    tags: Optional[str],
+    tags: Optional[Tuple[str]],
     raw_output: bool,
 ):
     ctx.ensure_object(dict)
@@ -68,7 +68,7 @@ def cli(
         doc_limit=doc_limit,
         llm=llm,
         overwrite=overwrite,
-        tags=list(tags),
+        tags=list(tags) if tags else None,
     )
     ctx.obj["driver"] = driver
 

--- a/apps/query-eval/queryeval/main.py
+++ b/apps/query-eval/queryeval/main.py
@@ -35,6 +35,7 @@ console = Console()
 @click.option("--doc-limit", help="Limit number of docs in result set", type=int)
 @click.option("--overwrite", help="Overwrite existing results file", is_flag=True)
 @click.option("--llm", help="LLM model name", type=click.Choice(list(MODELS.keys())))
+@click.option("--tags", help="Filter queries by the given tags", multiple=True)
 @click.option(
     "--raw-output", help="Output should be a raw DocSet, rather than natural language", is_flag=True, default=False
 )
@@ -51,6 +52,7 @@ def cli(
     doc_limit: Optional[int],
     overwrite: bool,
     llm: Optional[str],
+    tags: Optional[str],
     raw_output: bool,
 ):
     ctx.ensure_object(dict)
@@ -66,6 +68,7 @@ def cli(
         doc_limit=doc_limit,
         llm=llm,
         overwrite=overwrite,
+        tags=list(tags),
     )
     ctx.obj["driver"] = driver
 

--- a/apps/query-eval/queryeval/types.py
+++ b/apps/query-eval/queryeval/types.py
@@ -24,6 +24,7 @@ class QueryEvalConfig(BaseModel):
     natural_language_response: Optional[bool] = True
     doc_limit: Optional[int] = None
     overwrite: Optional[bool] = False
+    tags: Optional[List[str]] = None
 
 
 class QueryEvalQuery(BaseModel):
@@ -33,6 +34,8 @@ class QueryEvalQuery(BaseModel):
     expected: Optional[Union[str, List[Dict[str, Any]]]] = None
     expected_plan: Optional[LogicalPlan] = None
     plan: Optional[LogicalPlan] = None
+    tags: Optional[List[str]] = None
+    notes: Optional[str] = None
 
 
 class QueryEvalInputFile(BaseModel):
@@ -63,6 +66,7 @@ class QueryEvalResult(BaseModel):
     result: Optional[Union[str, List[Dict[str, Any]]]] = None
     error: Optional[str] = None
     metrics: Optional[QueryEvalMetrics] = None
+    notes: Optional[str] = None
 
 
 class QueryEvalResultsFile(BaseModel):


### PR DESCRIPTION
This adds support for two new fields in the query type:
  * `tags` - A list of tags associated with the query, which can be used for filtering
  * `notes` - Human-readable and editable notes which we can add (but still parseable as opposed to using comments in the YAML).
 
This also adds the `notes` field to the result type.

Adds `--tags` option to `main.py` to pass tags to filter by.
