### PR TITLE
Update standardizer.py

### DIFF
--- a/lib/sycamore/sycamore/tests/unit/transforms/test_standardizer.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_standardizer.py
@@ -251,10 +251,10 @@ class TestIgnoreErrors(unittest.TestCase):
         key_path = ["event", "dateTime"]
         expected_output = {"event": {"dateTime": ""}}
         self.assertEqual(ignore_errors(doc, standardizer, key_path), expected_output)
-
- def test_ignore_errors_key_missing(self):
+        
+    def test_ignore_errors_key_missing(self):
         # Test with a document that has no key:value.
-
+    
         standardizer = DateTimeStandardizer()
         doc = {"event": {"coolKey": ""}}
         key_path = ["nonExistentKey"]

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_standardizer.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_standardizer.py
@@ -1,9 +1,9 @@
 from sycamore.data import Document
 from sycamore.transforms.standardizer import (
-    USStateStandardizer, 
-    StandardizeProperty, 
-    DateTimeStandardizer, 
-    ignore_errors
+    USStateStandardizer,
+    StandardizeProperty,
+    DateTimeStandardizer,
+    ignore_errors,
 )
 import unittest
 from datetime import date, datetime
@@ -246,6 +246,7 @@ class TestDateTimeStandardizer(unittest.TestCase):
         }
         self.assertEqual(self.standardizer.standardize(doc, key_path), expected_output)
 
+
 class TestIgnoreErrors(unittest.TestCase):
 
     def test_ignore_errors_value_missing(self):
@@ -256,14 +257,12 @@ class TestIgnoreErrors(unittest.TestCase):
         key_path = ["event", "dateTime"]
         expected_output = {"event": {"dateTime": ""}}
         self.assertEqual(ignore_errors(doc, standardizer, key_path), expected_output)
-        
+
     def test_ignore_errors_key_missing(self):
         # Test with a document that has no key:value.
-    
+
         standardizer = DateTimeStandardizer()
         doc = {"event": {"coolKey": ""}}
         key_path = ["nonExistentKey"]
         expected_output = {"event": {"coolKey": ""}}
         self.assertEqual(ignore_errors(doc, standardizer, key_path), expected_output)
-
-

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_standardizer.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_standardizer.py
@@ -1,5 +1,10 @@
 from sycamore.data import Document
-from sycamore.transforms.standardizer import USStateStandardizer, StandardizeProperty, DateTimeStandardizer, ignore_errors
+from sycamore.transforms.standardizer import (
+    USStateStandardizer, 
+    StandardizeProperty, 
+    DateTimeStandardizer, 
+    ignore_errors
+)
 import unittest
 from datetime import date, datetime
 

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_standardizer.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_standardizer.py
@@ -240,3 +240,25 @@ class TestDateTimeStandardizer(unittest.TestCase):
             "system": {"log": {"entry": {"dateTime": "July 15, 2023 10:30:00", "day": date(2023, 7, 15)}}}
         }
         self.assertEqual(self.standardizer.standardize(doc, key_path), expected_output)
+
+class TestIgnoreErrors(unittest.TestCase):
+
+    def test_ignore_errors_value_missing(self):
+        # Test with a document that has no key:value.
+
+        standardizer = DateTimeStandardizer()
+        doc = {"event": {"dateTime": ""}}
+        key_path = ["event", "dateTime"]
+        expected_output = {"event": {"dateTime": ""}}
+        self.assertEqual(ignore_errors(doc, standardizer, key_path), expected_output)
+
+ def test_ignore_errors_key_missing(self):
+        # Test with a document that has no key:value.
+
+        standardizer = DateTimeStandardizer()
+        doc = {"event": {"coolKey": ""}}
+        key_path = ["nonExistentKey"]
+        expected_output = {"event": {"coolKey": ""}}
+        self.assertEqual(ignore_errors(doc, standardizer, key_path), expected_output)
+
+

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_standardizer.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_standardizer.py
@@ -1,5 +1,5 @@
 from sycamore.data import Document
-from sycamore.transforms.standardizer import USStateStandardizer, StandardizeProperty, DateTimeStandardizer
+from sycamore.transforms.standardizer import USStateStandardizer, StandardizeProperty, DateTimeStandardizer, ignore_errors
 import unittest
 from datetime import date, datetime
 

--- a/lib/sycamore/sycamore/transforms/standardizer.py
+++ b/lib/sycamore/sycamore/transforms/standardizer.py
@@ -298,7 +298,7 @@ def ignore_errors(doc, standardizer, key_path: list[str]):
     Example:
         .. code-block:: python
 
-            docset.map(lambda doc: IgnoreErrors.ignore_errors(doc, DateTimeStandardizer, ["properties", "entity", "dateAndTime"])
+            docset.map(lambda doc: ignore_errors(doc, DateTimeStandardizer, ["properties", "entity", "dateAndTime"])
     """
     
     try:

--- a/lib/sycamore/sycamore/transforms/standardizer.py
+++ b/lib/sycamore/sycamore/transforms/standardizer.py
@@ -8,6 +8,9 @@ from sycamore.plan_nodes import Node
 from sycamore.data import Document
 from sycamore.transforms.map import Map
 
+import logging
+logger = logging.getLogger(__name__)
+
 
 class Standardizer(ABC):
     """
@@ -284,18 +287,27 @@ class StandardizeProperty(Map):
     ):
         super().__init__(child, f=standardizer.standardize, args=path, kwargs=kwargs)
 
-class IgnoreErrors(standardizer)
-
-   """
+def ignore_errors(doc, standardizer, key_path: list[str]):
+   
+    """
     A class for applying the behavior of a standardizer to log errors and continue when encountering null values.
 
     This class allows for the execution of standardization logic not to fail when encountering null key:value pairs. It will
     instead log a warning stating what key:value pairs in what documents were missing.
+
+    Example:
+        .. code-block:: python
+
+            docset.map(lambda doc: IgnoreErrors.ignore_errors(doc, DateTimeStandardizer, ["properties", "entity", "dateAndTime"])
     """
     
-    def ignore_errors(doc, standardizer, key_path: list[str]):
-        try:
-            doc = standardizer.standardize(doc, key_path=key_path)
-        except:
-            print(f"Key {key_path} not found in document: {doc}")
-        return doc
+    try:
+        doc = standardizer.standardize(doc, key_path=key_path)
+    except KeyError:
+        logger.warn(f"Key {key_path} not found in document: {doc}")
+    except Exception as e:
+        logger.error(e)
+    return doc
+
+
+

--- a/lib/sycamore/sycamore/transforms/standardizer.py
+++ b/lib/sycamore/sycamore/transforms/standardizer.py
@@ -283,3 +283,19 @@ class StandardizeProperty(Map):
         **kwargs,
     ):
         super().__init__(child, f=standardizer.standardize, args=path, kwargs=kwargs)
+
+class IgnoreErrors(standardizer)
+
+   """
+    A class for applying the behavior of a standardizer to log errors and continue when encountering null values.
+
+    This class allows for the execution of standardization logic not to fail when encountering null key:value pairs. It will
+    instead log a warning stating what key:value pairs in what documents were missing.
+    """
+    
+    def ignore_errors(doc, standardizer, key_path: list[str]):
+        try:
+            doc = standardizer.standardize(doc, key_path=key_path)
+        except:
+            print(f"Key {key_path} not found in document: {doc}")
+        return doc

--- a/lib/sycamore/sycamore/transforms/standardizer.py
+++ b/lib/sycamore/sycamore/transforms/standardizer.py
@@ -292,8 +292,8 @@ def ignore_errors(doc: Document, standardizer: Standardizer, key_path: list[str]
     """
     A class for applying the behavior of a standardizer to log errors and continue when encountering null values.
 
-    This class allows for the execution of standardization logic not to fail when encountering null key:value pairs. It will
-    instead log a warning stating what key:value pairs in what documents were missing.
+    This class allows for the execution of standardization logic not to fail when encountering null key:value pairs. 
+    It will instead log a warning stating what key:value pairs in what documents were missing.
 
     Example:
         .. code-block:: python

--- a/lib/sycamore/sycamore/transforms/standardizer.py
+++ b/lib/sycamore/sycamore/transforms/standardizer.py
@@ -9,6 +9,7 @@ from sycamore.data import Document
 from sycamore.transforms.map import Map
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -287,12 +288,12 @@ class StandardizeProperty(Map):
     ):
         super().__init__(child, f=standardizer.standardize, args=path, kwargs=kwargs)
 
+
 def ignore_errors(doc: Document, standardizer: Standardizer, key_path: list[str]) -> Document:
-   
     """
     A class for applying the behavior of a standardizer to log errors and continue when encountering null values.
 
-    This class allows for the execution of standardization logic not to fail when encountering null key:value pairs. 
+    This class allows for the execution of standardization logic not to fail when encountering null key:value pairs.
     It will instead log a warning stating what key:value pairs in what documents were missing.
 
     Example:
@@ -300,7 +301,7 @@ def ignore_errors(doc: Document, standardizer: Standardizer, key_path: list[str]
 
             docset.map(lambda doc: ignore_errors(doc, DateTimeStandardizer, ["properties", "entity", "dateAndTime"])
     """
-    
+
     try:
         doc = standardizer.standardize(doc, key_path=key_path)
     except KeyError:
@@ -308,6 +309,3 @@ def ignore_errors(doc: Document, standardizer: Standardizer, key_path: list[str]
     except Exception as e:
         logger.error(e)
     return doc
-
-
-

--- a/lib/sycamore/sycamore/transforms/standardizer.py
+++ b/lib/sycamore/sycamore/transforms/standardizer.py
@@ -287,7 +287,7 @@ class StandardizeProperty(Map):
     ):
         super().__init__(child, f=standardizer.standardize, args=path, kwargs=kwargs)
 
-def ignore_errors(doc, standardizer, key_path: list[str]):
+def ignore_errors(doc: Document, standardizer: Standardizer, key_path: list[str]) -> Document:
    
     """
     A class for applying the behavior of a standardizer to log errors and continue when encountering null values.


### PR DESCRIPTION
Adding a new class called ignore_errors to enable the standardizers to gracefully continue when encountering null key:value pairs