### PR TITLE
Fix source_directory path in conf.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,5 +42,5 @@ html_favicon = "images/favicon.ico"
 html_theme_options = {
     "source_repository": "https://github.com/aryn-ai/sycamore",
     "source_branch": "main",
-    "source_directory": "docs/",
+    "source_directory": "docs/source",
 }


### PR DESCRIPTION
The `edit this page` button in docs redirect to wrong path
![image](https://github.com/user-attachments/assets/505c3896-036e-4157-bc2d-29c383bd9734)
