### PR TITLE
fix materialize bug with s3 filesystem

### DIFF
--- a/lib/sycamore/sycamore/materialize.py
+++ b/lib/sycamore/sycamore/materialize.py
@@ -70,11 +70,11 @@ class Materialize(UnaryNode):
             self._clean_root = True
         elif isinstance(path, dict):
             assert "root" in path, "Need to specify root in materialize(path={})"
-            self._root = Path(path["root"])
             if "fs" in path:
                 self._fs = path["fs"]
+                self._root = Path(path["root"])
             else:
-                (self._fs, self._root) = self.infer_fs(str(self._root))
+                (self._fs, self._root) = self.infer_fs(str(path["root"]))
             self._fshelper = _PyArrowFsHelper(self._fs)
             self._doc_to_name = path.get("name", self.doc_to_name)
             self._doc_to_binary = path.get("tobin", Document.serialize)

--- a/lib/sycamore/sycamore/tests/unit/test_materialize.py
+++ b/lib/sycamore/sycamore/tests/unit/test_materialize.py
@@ -516,3 +516,15 @@ class TestErrorChecking(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             with pytest.raises(ValueError):
                 ds.materialize(path=tmpdir).materialize(path=tmpdir).execute()
+
+
+def test_s3_infer_filesystem():
+    from sycamore.materialize import Materialize
+    from pyarrow.fs import S3FileSystem
+    from pathlib import Path
+
+    ctx = sycamore.init()
+    m = Materialize(None, ctx, path={"root": "s3://test-example/a/path"})
+    assert isinstance(m._fs, S3FileSystem)
+    assert isinstance(m._root, Path)
+    assert str(m._root) == "test-example/a/path"


### PR DESCRIPTION
if you specified the advanced path={"root": "s3://soemthing"} it would incorrectly translate the root to a Path which would remove one of the /'s and then the filesystem inference would interpret it as a local file.