### PR TITLE
Add Lots of Connector Unit Tests

### DIFF
--- a/lib/sycamore/sycamore/connectors/common.py
+++ b/lib/sycamore/sycamore/connectors/common.py
@@ -40,7 +40,7 @@ def filter_doc(doc: Document, include):
 
 def check_dictionary_compatibility(dict1: dict[Any, Any], dict2: dict[Any, Any], ignore: list[str] = []):
     for k in dict1:
-        if not dict1.get(k) or (ignore and any(val in k for val in ignore)):
+        if not dict1.get(k) or (ignore and any(k in ignore_value for ignore_value in ignore)):
             continue
         if k not in dict2:
             return False

--- a/lib/sycamore/sycamore/connectors/common.py
+++ b/lib/sycamore/sycamore/connectors/common.py
@@ -38,9 +38,14 @@ def filter_doc(doc: Document, include):
     return {k: v for k, v in doc.items() if k in include}
 
 
-def check_dictionary_compatibility(dict1: dict[Any, Any], dict2: dict[Any, Any], ignore: list[str] = []):
+def check_dictionary_compatibility(dict1: dict[Any, Any], dict2: dict[Any, Any], ignore_list: list[str] = []):
     for k in dict1:
-        if not dict1.get(k) or (ignore and any(k in ignore_value for ignore_value in ignore)):
+        if not dict1.get(k) or (
+            ignore_list
+            and any(
+                (ignore_value in k and any(k in dict2_k for dict2_k in dict2.keys())) for ignore_value in ignore_list
+            )
+        ):  # skip if ignored key and if it exists in dict2
             continue
         if k not in dict2:
             return False

--- a/lib/sycamore/sycamore/connectors/duckdb/duckdb_writer.py
+++ b/lib/sycamore/sycamore/connectors/duckdb/duckdb_writer.py
@@ -1,14 +1,15 @@
 from dataclasses import dataclass, asdict, field
-from typing import Optional, Any, Dict
+from typing import Optional, Any
 from typing_extensions import TypeGuard
+
+import pyarrow as pa
+import logging
+import duckdb
 
 from sycamore.data.document import Document
 from sycamore.connectors.base_writer import BaseDBWriter
-from sycamore.connectors.common import convert_to_str_dict
 from sycamore.utils.import_utils import requires_modules
-
-import pyarrow as pa
-import os
+from sycamore.connectors.common import convert_to_str_dict, _get_pyarrow_type
 
 
 @dataclass
@@ -22,7 +23,7 @@ class DuckDBWriterTargetParams(BaseDBWriter.TargetParams):
     db_url: Optional[str] = "tmp.db"
     table_name: Optional[str] = "default_table"
     batch_size: int = 1000
-    schema: Dict[str, str] = field(
+    schema: dict[str, str] = field(
         default_factory=lambda: {
             "doc_id": "VARCHAR",
             "parent_id": "VARCHAR",
@@ -74,23 +75,21 @@ class DuckDBClient(BaseDBWriter.Client):
         ), f"Wrong kind of target parameters found: {target_params}"
         dict_params = asdict(target_params)
         N = target_params.batch_size * 1024  # Around 1 MB
-        headers = ["doc_id", "parent_id", "embedding", "properties", "text_representation", "bbox", "shingles", "type"]
-        schema = pa.schema(
-            [
-                ("doc_id", pa.string()),
-                ("parent_id", pa.string()),
-                ("embedding", pa.list_(pa.float32())),
-                ("properties", pa.map_(pa.string(), pa.string())),
-                ("text_representation", pa.string()),
-                ("bbox", pa.list_(pa.float32())),
-                ("shingles", pa.list_(pa.int64())),
-                ("type", pa.string()),
-            ]
-        )
+
+        # Validate schema and create pyarrow schema
+        headers = []
+        pa_fields = []
+        for key, dtype in target_params.schema.items():
+            headers.append(key)
+            try:
+                pa_dtype = _get_pyarrow_type(key, dtype)
+                pa_fields.append((key, pa_dtype))
+            except Exception as e:
+                raise ValueError(f"Invalid schema attribute or datatype for {key}: {e}")
+
+        schema = pa.schema(pa_fields)
 
         def write_batch(batch_data: dict):
-            import duckdb
-
             pa_table = pa.Table.from_pydict(batch_data, schema=schema)  # noqa
             client = duckdb.connect(str(dict_params.get("db_url")))
             client.sql(f"INSERT INTO {dict_params.get('table_name')} SELECT * FROM pa_table")
@@ -100,42 +99,37 @@ class DuckDBClient(BaseDBWriter.Client):
         batch_data: dict[str, list[Any]] = {key: [] for key in headers}
 
         for r in records:
-            # Append the new data to the batch
-            batch_data["doc_id"].append(r.doc_id)
-            batch_data["parent_id"].append(r.parent_id)
-            batch_data["embedding"].append(r.embedding)
-            batch_data["properties"].append(convert_to_str_dict(r.properties) if r.properties else {})
-            batch_data["text_representation"].append(r.text_representation)
-            batch_data["bbox"].append(r.bbox)
-            batch_data["shingles"].append(r.shingles)
-            batch_data["type"].append(r.type)
+            for key in headers:
+                value = getattr(r, key, None)
+                if isinstance(value, dict) and value:
+                    value = convert_to_str_dict(value)
+                batch_data[key].append(value)
 
             # If we've reached the batch size, write to the database
             if batch_data.__sizeof__() >= N:
                 write_batch(batch_data)
         # Write any remaining records
-        if len(batch_data["doc_id"]) > 0:
+        if len(batch_data[headers[0]]) > 0:
             write_batch(batch_data)
 
     def create_target_idempotent(self, target_params: BaseDBWriter.TargetParams):
-        import duckdb
-
         assert isinstance(target_params, DuckDBWriterTargetParams)
         dict_params = asdict(target_params)
         schema = dict_params.get("schema")
+        if not target_params.db_url:
+            raise ValueError(f"Must provide valid disk location. Location Specified: {target_params.db_url}")
         client = duckdb.connect(str(dict_params.get("db_url")))
         try:
             if schema:
-                embedding_size = schema.get("embedding") + "[" + str(dict_params.get("dimensions")) + "]"
-                client.sql(
-                    f"""CREATE TABLE {dict_params.get('table_name')} (doc_id {schema.get('doc_id')},
-                     parent_id {schema.get('parent_id')},
-                      embedding {embedding_size}, properties {schema.get('properties')},
-                      text_representation {schema.get('text_representation')}, bbox {schema.get('bbox')},
-                      shingles {schema.get('shingles')}, type {schema.get('type')})"""
-                )
+                columns = []
+                for key, dtype in schema.items():
+                    if key == "embedding":
+                        dtype += f"[{dict_params.get('dimensions')}]"
+                    columns.append(f"{key} {dtype}")
+                columns_str = ", ".join(columns)
+                client.sql(f"CREATE TABLE {dict_params.get('table_name')} ({columns_str})")
             else:
-                print(
+                logging.warning(
                     f"""Error creating table {dict_params.get('table_name')}
                     in database {dict_params.get('db_url')}: no schema provided"""
                 )
@@ -143,20 +137,16 @@ class DuckDBClient(BaseDBWriter.Client):
             return
 
     def get_existing_target_params(self, target_params: BaseDBWriter.TargetParams) -> "DuckDBWriterTargetParams":
-        import duckdb
-
         assert isinstance(target_params, DuckDBWriterTargetParams)
         dict_params = asdict(target_params)
         schema = target_params.schema
-        if not target_params.db_url or not os.path.exists(target_params.db_url):
-            raise ValueError(f"Must provide valid disk location. Location Specified: {target_params.db_url}")
         if target_params.db_url and target_params.table_name:
             client = duckdb.connect(str(dict_params.get("db_url")))
             try:
                 table = client.sql(f"SELECT * FROM {target_params.table_name}")
-                schema = dict(zip(table.columns, [repr(i) for i in table.dtypes]))
+                schema = dict(zip(table.columns, [str(i) for i in table.dtypes]))
             except Exception as e:
-                print(
+                logging.warning(
                     f"""Table {dict_params.get('table_name')}
                     does not exist in database {dict_params.get('table_name')}: {e}"""
                 )

--- a/lib/sycamore/sycamore/connectors/duckdb/duckdb_writer.py
+++ b/lib/sycamore/sycamore/connectors/duckdb/duckdb_writer.py
@@ -45,8 +45,6 @@ class DuckDBWriterTargetParams(BaseDBWriter.TargetParams):
             return False
         if self.table_name != other.table_name:
             return False
-        if self.batch_size != other.batch_size:
-            return False
         if other.schema and self.schema:
             if (
                 "embedding" in other.schema

--- a/lib/sycamore/sycamore/connectors/elasticsearch/elasticsearch_writer.py
+++ b/lib/sycamore/sycamore/connectors/elasticsearch/elasticsearch_writer.py
@@ -81,6 +81,8 @@ class ElasticsearchWriterClient(BaseDBWriter.Client):
 
         assert isinstance(target_params, ElasticsearchWriterTargetParams)
         assert _narrow_list_of_doc_records(records), f"Found a bad record in {records}"
+        if not records:
+            return
         with self._client:
 
             def bulk_action_generator():

--- a/lib/sycamore/sycamore/tests/unit/connectors/duckdb/test_duckdb_reader.py
+++ b/lib/sycamore/sycamore/tests/unit/connectors/duckdb/test_duckdb_reader.py
@@ -1,0 +1,104 @@
+import pytest
+from unittest import mock
+from sycamore.data import Document
+from sycamore.data.document import DocumentPropertyTypes, DocumentSource
+
+from sycamore.connectors.duckdb.duckdb_reader import (
+    DuckDBReaderClient,
+    DuckDBReaderClientParams,
+    DuckDBReaderQueryParams,
+    DuckDBReaderQueryResponse,
+    DuckDBReader,
+)
+
+
+@pytest.fixture
+def mock_duckdb_connection():
+    with mock.patch("duckdb.connect") as mock_connect:
+        mock_conn = mock.Mock()
+        mock_connect.return_value = mock_conn
+        yield mock_conn
+
+
+def test_duckdb_reader_client_from_client_params(mock_duckdb_connection):
+    params = DuckDBReaderClientParams(db_url="test_db")
+    client = DuckDBReaderClient.from_client_params(params)
+    assert isinstance(client, DuckDBReaderClient)
+    mock_duckdb_connection.connect.assert_called_once_with(database="test_db", read_only=True)
+
+
+def test_duckdb_reader_client_read_records(mock_duckdb_connection):
+    client = DuckDBReaderClient(mock_duckdb_connection)
+    query_params = DuckDBReaderQueryParams(table_name="test_table", query=None, create_hnsw_table=None)
+    mock_duckdb_connection.execute.return_value = mock.Mock()
+    response = client.read_records(query_params)
+    assert isinstance(response, DuckDBReaderQueryResponse)
+    mock_duckdb_connection.execute.assert_called_once_with("SELECT * from test_table")
+
+
+def test_duckdb_reader_client_read_records_with_query(mock_duckdb_connection):
+    client = DuckDBReaderClient(mock_duckdb_connection)
+    query_params = DuckDBReaderQueryParams(
+        table_name="test_table", query="SELECT * FROM test_table", create_hnsw_table=None
+    )
+    mock_duckdb_connection.execute.return_value = mock.Mock()
+    response = client.read_records(query_params)
+    assert isinstance(response, DuckDBReaderQueryResponse)
+    mock_duckdb_connection.execute.assert_called_once_with("SELECT * FROM test_table")
+
+
+def test_duckdb_reader_client_read_records_with_create_hnsw_table(mock_duckdb_connection):
+    client = DuckDBReaderClient(mock_duckdb_connection)
+    query_params = DuckDBReaderQueryParams(
+        table_name="test_table", query=None, create_hnsw_table="CREATE TABLE hnsw AS SELECT * FROM test_table"
+    )
+    mock_duckdb_connection.execute.return_value = mock.Mock()
+    response = client.read_records(query_params)
+    assert isinstance(response, DuckDBReaderQueryResponse)
+    mock_duckdb_connection.execute.assert_any_call("CREATE TABLE hnsw AS SELECT * FROM test_table")
+    mock_duckdb_connection.execute.assert_any_call("SELECT * from test_table")
+
+
+def test_duckdb_reader_client_check_target_presence(mock_duckdb_connection):
+    client = DuckDBReaderClient(mock_duckdb_connection)
+    query_params = DuckDBReaderQueryParams(table_name="test_table", query=None, create_hnsw_table=None)
+    mock_duckdb_connection.sql.return_value = mock.Mock()
+    assert client.check_target_presence(query_params) is True
+    mock_duckdb_connection.sql.assert_called_once_with("SELECT * FROM test_table")
+
+
+def test_duckdb_reader_client_check_target_presence_not_found(mock_duckdb_connection):
+    client = DuckDBReaderClient(mock_duckdb_connection)
+    query_params = DuckDBReaderQueryParams(table_name="non_existent_table", query=None, create_hnsw_table=None)
+    mock_duckdb_connection.sql.side_effect = Exception("Table not found")
+    assert client.check_target_presence(query_params) is False
+    mock_duckdb_connection.sql.assert_called_once_with("SELECT * FROM non_existent_table")
+
+
+def test_duckdb_reader_query_response_to_docs():
+    mock_output = mock.Mock()
+    mock_output.df.return_value.to_dict.return_value = [{"properties": '{"key": "value"}', "embedding": 0.0}]
+    response = DuckDBReaderQueryResponse(output=mock_output)
+    query_params = DuckDBReaderQueryParams(table_name="test_table", query=None, create_hnsw_table=None)
+    docs = response.to_docs(query_params)
+    assert len(docs) == 1
+    assert isinstance(docs[0], Document)
+    assert docs[0].properties[DocumentPropertyTypes.SOURCE] == DocumentSource.DB_QUERY
+    assert docs[0].properties["key"] == "value"
+    assert docs[0].embedding == []
+
+
+def test_duckdb_reader_query_response_to_docs_empty():
+    mock_output = mock.Mock()
+    mock_output.df.return_value.to_dict.return_value = []
+    response = DuckDBReaderQueryResponse(output=mock_output)
+    query_params = DuckDBReaderQueryParams(table_name="test_table", query=None, create_hnsw_table=None)
+    docs = response.to_docs(query_params)
+    assert len(docs) == 0
+
+
+def test_duckdb_reader():
+    assert DuckDBReader.Client == DuckDBReaderClient
+    assert DuckDBReader.Record == DuckDBReaderQueryResponse
+    assert DuckDBReader.ClientParams == DuckDBReaderClientParams
+    assert DuckDBReader.QueryParams == DuckDBReaderQueryParams

--- a/lib/sycamore/sycamore/tests/unit/connectors/duckdb/test_duckdb_writer.py
+++ b/lib/sycamore/sycamore/tests/unit/connectors/duckdb/test_duckdb_writer.py
@@ -109,11 +109,11 @@ def test_duckdb_writer_target_params_compatible_with():
     params5 = DuckDBWriterTargetParams(dimensions=128, table_name="different_table")
     assert not params1.compatible_with(params5)
 
-    params6 = DuckDBWriterTargetParams(dimensions=128, batch_size=2000)
-    assert not params1.compatible_with(params6)
-
     params7 = DuckDBWriterTargetParams(dimensions=128, schema={"doc_id": "VARCHAR", "embedding": "FLOAT[128]"})
     assert not params1.compatible_with(params7)
+
+    params8 = DuckDBWriterTargetParams(dimensions=128, schema={"doc_id": "VARCHAR", "embedding": "FLOAT"})
+    assert params8.compatible_with(params7)
 
 
 def test_duckdb_writer_get_existing_target_params_table_not_exist(mock_duckdb, target_params):

--- a/lib/sycamore/sycamore/tests/unit/connectors/duckdb/test_duckdb_writer.py
+++ b/lib/sycamore/sycamore/tests/unit/connectors/duckdb/test_duckdb_writer.py
@@ -116,12 +116,6 @@ def test_duckdb_writer_target_params_compatible_with():
     assert not params1.compatible_with(params7)
 
 
-def test_duckdb_writer_get_existing_target_params_no_db(mock_duckdb, target_params):
-    client = DuckDBClient(DuckDBWriterClientParams())
-    with pytest.raises(ValueError):
-        client.get_existing_target_params(target_params)
-
-
 def test_duckdb_writer_get_existing_target_params_table_not_exist(mock_duckdb, target_params):
     client = DuckDBClient(DuckDBWriterClientParams())
     mock_duckdb.sql.side_effect = Exception("Table does not exist")

--- a/lib/sycamore/sycamore/tests/unit/connectors/duckdb/test_duckdb_writer.py
+++ b/lib/sycamore/sycamore/tests/unit/connectors/duckdb/test_duckdb_writer.py
@@ -1,0 +1,164 @@
+import pytest
+from unittest import mock
+from sycamore.connectors.duckdb.duckdb_writer import (
+    DuckDBWriterClientParams,
+    DuckDBWriterTargetParams,
+    DuckDBClient,
+    DuckDBDocumentRecord,
+)
+from sycamore.data.document import Document
+from sycamore.connectors.duckdb.duckdb_writer import _narrow_list_of_doc_records
+from sycamore.connectors.base_writer import BaseDBWriter
+
+
+@pytest.fixture
+def mock_duckdb(mocker):
+    mock_duckdb = mocker.patch("duckdb.connect")
+    mock_conn = mocker.Mock()
+    mock_duckdb.return_value = mock_conn
+    return mock_conn
+
+
+@pytest.fixture
+def target_params():
+    return DuckDBWriterTargetParams(dimensions=128)
+
+
+@pytest.fixture
+def client_params():
+    return DuckDBWriterClientParams()
+
+
+@pytest.fixture
+def duckdb_client(client_params):
+    return DuckDBClient(client_params)
+
+
+@pytest.fixture
+def document():
+    return Document(
+        doc_id="doc1",
+        parent_id="parent1",
+        properties={"key": "value"},
+        type="type1",
+        text_representation="text",
+        bbox=(0.0, 0.0, 1.0, 1.0),
+        shingles=[1, 2, 3],
+        embedding=[0.1, 0.2, 0.3, 0.4],
+    )
+
+
+def test_duckdb_client_init(client_params):
+    client = DuckDBClient(client_params)
+    assert isinstance(client, DuckDBClient)
+
+
+def test_duckdb_client_from_client_params(client_params):
+    client = DuckDBClient.from_client_params(client_params)
+    assert isinstance(client, DuckDBClient)
+
+
+def test_duckdb_writer_create_target_idempotent(mock_duckdb, target_params):
+    client = DuckDBClient(DuckDBWriterClientParams())
+    client.create_target_idempotent(target_params)
+    mock_duckdb.sql.assert_called_once()
+
+
+def test_duckdb_writer_write_many_records(mock_duckdb, target_params, document):
+    client = DuckDBClient(DuckDBWriterClientParams())
+    records = [DuckDBDocumentRecord.from_doc(document, target_params)]
+    client.write_many_records(records, target_params)
+    assert mock_duckdb.sql.call_count > 0
+
+
+def test_duckdb_writer_get_existing_target_params(mock_duckdb, target_params):
+    client = DuckDBClient(DuckDBWriterClientParams())
+    mock_duckdb.sql.return_value = mock.Mock(columns=["doc_id"], dtypes=["VARCHAR"])
+    params = client.get_existing_target_params(target_params)
+    assert params.schema == {"doc_id": "VARCHAR"}
+
+
+def test_duckdb_document_record_from_doc(document, target_params):
+    record = DuckDBDocumentRecord.from_doc(document, target_params)
+    assert record.doc_id == document.doc_id
+    assert record.parent_id == document.parent_id
+    assert record.properties == document.properties
+    assert record.type == document.type
+    assert record.text_representation == document.text_representation
+    assert record.bbox == document.bbox.coordinates
+    assert record.shingles == document.shingles
+    assert record.embedding == document.embedding
+
+
+def test_narrow_list_of_doc_records(document, target_params):
+    records = [DuckDBDocumentRecord.from_doc(document, target_params)]
+    assert _narrow_list_of_doc_records(records)
+
+
+def test_duckdb_writer_target_params_compatible_with():
+    params1 = DuckDBWriterTargetParams(dimensions=128)
+    params2 = DuckDBWriterTargetParams(dimensions=128)
+    assert params1.compatible_with(params2)
+
+    params3 = DuckDBWriterTargetParams(dimensions=64)
+    assert not params1.compatible_with(params3)
+
+    params4 = DuckDBWriterTargetParams(dimensions=128, db_url="different.db")
+    assert not params1.compatible_with(params4)
+
+    params5 = DuckDBWriterTargetParams(dimensions=128, table_name="different_table")
+    assert not params1.compatible_with(params5)
+
+    params6 = DuckDBWriterTargetParams(dimensions=128, batch_size=2000)
+    assert not params1.compatible_with(params6)
+
+    params7 = DuckDBWriterTargetParams(dimensions=128, schema={"doc_id": "VARCHAR", "embedding": "FLOAT[128]"})
+    assert not params1.compatible_with(params7)
+
+
+def test_duckdb_writer_get_existing_target_params_no_db(mock_duckdb, target_params):
+    client = DuckDBClient(DuckDBWriterClientParams())
+    with pytest.raises(ValueError):
+        client.get_existing_target_params(target_params)
+
+
+def test_duckdb_writer_get_existing_target_params_table_not_exist(mock_duckdb, target_params):
+    client = DuckDBClient(DuckDBWriterClientParams())
+    mock_duckdb.sql.side_effect = Exception("Table does not exist")
+    params = client.get_existing_target_params(target_params)
+    assert params.schema == target_params.schema
+
+
+def test_duckdb_writer_write_many_records_empty(mock_duckdb, target_params):
+    client = DuckDBClient(DuckDBWriterClientParams())
+    client.write_many_records([], target_params)
+    assert mock_duckdb.sql.call_count == 0
+
+
+def test_duckdb_writer_write_many_records_invalid_record(mock_duckdb, target_params, document):
+    client = DuckDBClient(DuckDBWriterClientParams())
+    invalid_record = mock.Mock(spec=BaseDBWriter.Record)
+    with pytest.raises(AssertionError):
+        client.write_many_records([invalid_record], target_params)
+
+
+def test_duckdb_document_record_from_doc_no_doc_id(target_params):
+    document = Document(
+        doc_id=None,
+        parent_id="parent1",
+        properties={"key": "value"},
+        type="type1",
+        text_representation="text",
+        bbox=(0.0, 0.0, 1.0, 1.0),
+        shingles=[1, 2, 3],
+        embedding=[0.1, 0.2, 0.3, 0.4],
+    )
+    with pytest.raises(ValueError):
+        DuckDBDocumentRecord.from_doc(document, target_params)
+
+
+def test_duckdb_writer_create_target_idempotent_no_schema(mock_duckdb, target_params):
+    client = DuckDBClient(DuckDBWriterClientParams())
+    target_params.schema = None
+    client.create_target_idempotent(target_params)
+    assert mock_duckdb.sql.call_count == 0

--- a/lib/sycamore/sycamore/tests/unit/connectors/elasticsearch/test_elasticsearch_reader.py
+++ b/lib/sycamore/sycamore/tests/unit/connectors/elasticsearch/test_elasticsearch_reader.py
@@ -1,0 +1,106 @@
+import pytest
+from unittest import mock
+from sycamore.data import Document
+from sycamore.data.document import DocumentPropertyTypes, DocumentSource
+
+from sycamore.connectors.elasticsearch.elasticsearch_reader import (
+    ElasticsearchReaderClient,
+    ElasticsearchReaderClientParams,
+    ElasticsearchReaderQueryParams,
+    ElasticsearchReaderQueryResponse,
+)
+
+
+@pytest.fixture
+def mock_elasticsearch_client():
+    return mock.Mock()
+
+
+@pytest.fixture
+def client_params():
+    return ElasticsearchReaderClientParams(url="http://localhost:9200")
+
+
+@pytest.fixture
+def query_params():
+    return ElasticsearchReaderQueryParams(index_name="test_index")
+
+
+def test_elasticsearch_reader_client_initialization(mock_elasticsearch_client):
+    client = ElasticsearchReaderClient(mock_elasticsearch_client)
+    assert client._client == mock_elasticsearch_client
+
+
+def test_elasticsearch_reader_client_from_client_params(client_params):
+    with mock.patch("elasticsearch.Elasticsearch") as MockElasticsearch:
+        client = ElasticsearchReaderClient.from_client_params(client_params)
+        MockElasticsearch.assert_called_once_with(client_params.url, **client_params.es_client_args)
+        assert isinstance(client, ElasticsearchReaderClient)
+
+
+def test_elasticsearch_reader_client_read_records(mock_elasticsearch_client, query_params):
+    mock_elasticsearch_client.open_point_in_time.return_value = {"id": "test_pit_id"}
+    mock_elasticsearch_client.search.side_effect = [
+        {"hits": {"hits": [{"_id": "1", "_source": {"properties": {}}}], "pit_id": "test_pit_id"}},
+        {"hits": {"hits": []}, "pit_id": "test_pit_id"},
+    ]
+
+    client = ElasticsearchReaderClient(mock_elasticsearch_client)
+    response = client.read_records(query_params)
+
+    assert isinstance(response, ElasticsearchReaderQueryResponse)
+    assert len(response.output) == 1
+    assert response.output[0]["_id"] == "1"
+    mock_elasticsearch_client.close_point_in_time.assert_called_once_with(id="test_pit_id")
+
+
+def test_elasticsearch_reader_client_read_records_no_hits(mock_elasticsearch_client, query_params):
+    mock_elasticsearch_client.open_point_in_time.return_value = {"id": "test_pit_id"}
+    mock_elasticsearch_client.search.side_effect = [
+        {"hits": {"hits": [], "pit_id": "test_pit_id"}},
+    ]
+
+    client = ElasticsearchReaderClient(mock_elasticsearch_client)
+    response = client.read_records(query_params)
+
+    assert isinstance(response, ElasticsearchReaderQueryResponse)
+    assert len(response.output) == 0
+    mock_elasticsearch_client.close_point_in_time.assert_called_once_with(id="test_pit_id")
+
+
+def test_elasticsearch_reader_client_check_target_presence(mock_elasticsearch_client, query_params):
+    mock_elasticsearch_client.indices.exists.return_value = True
+
+    client = ElasticsearchReaderClient(mock_elasticsearch_client)
+    result = client.check_target_presence(query_params)
+
+    assert result is True
+    mock_elasticsearch_client.indices.exists.assert_called_once_with(index=query_params.index_name)
+
+
+def test_elasticsearch_reader_client_check_target_absence(mock_elasticsearch_client, query_params):
+    mock_elasticsearch_client.indices.exists.return_value = False
+
+    client = ElasticsearchReaderClient(mock_elasticsearch_client)
+    result = client.check_target_presence(query_params)
+
+    assert result is False
+    mock_elasticsearch_client.indices.exists.assert_called_once_with(index=query_params.index_name)
+
+
+def test_elasticsearch_reader_query_response_to_docs():
+    response = ElasticsearchReaderQueryResponse(output=[{"_id": "1", "_source": {"properties": {}}}])
+    query_params = ElasticsearchReaderQueryParams(index_name="test_index")
+    docs = response.to_docs(query_params)
+
+    assert len(docs) == 1
+    assert isinstance(docs[0], Document)
+    assert docs[0].properties[DocumentPropertyTypes.SOURCE] == DocumentSource.DB_QUERY
+
+
+def test_elasticsearch_reader_query_response_to_docs_empty():
+    response = ElasticsearchReaderQueryResponse(output=[])
+    query_params = ElasticsearchReaderQueryParams(index_name="test_index")
+    docs = response.to_docs(query_params)
+
+    assert len(docs) == 0

--- a/lib/sycamore/sycamore/tests/unit/connectors/elasticsearch/test_elasticsearch_reader.py
+++ b/lib/sycamore/sycamore/tests/unit/connectors/elasticsearch/test_elasticsearch_reader.py
@@ -41,7 +41,10 @@ def test_elasticsearch_reader_client_from_client_params(client_params):
 def test_elasticsearch_reader_client_read_records(mock_elasticsearch_client, query_params):
     mock_elasticsearch_client.open_point_in_time.return_value = {"id": "test_pit_id"}
     mock_elasticsearch_client.search.side_effect = [
-        {"hits": {"hits": [{"_id": "1", "_source": {"properties": {}}}], "pit_id": "test_pit_id"}},
+        {
+            "hits": {"hits": [{"_id": "1", "_source": {"properties": {}}, "sort": {"_shard_doc": "desc"}}]},
+            "pit_id": "test_pit_id",
+        },
         {"hits": {"hits": []}, "pit_id": "test_pit_id"},
     ]
 

--- a/lib/sycamore/sycamore/tests/unit/connectors/elasticsearch/test_elasticsearch_writer.py
+++ b/lib/sycamore/sycamore/tests/unit/connectors/elasticsearch/test_elasticsearch_writer.py
@@ -52,7 +52,7 @@ def test_elasticsearch_writer_client_init(mock_elasticsearch_client):
 def test_elasticsearch_writer_client_from_client_params(client_params, mock_elasticsearch_client):
     client = ElasticsearchWriterClient.from_client_params(client_params)
     assert isinstance(client, ElasticsearchWriterClient)
-    assert client._client == mock_elasticsearch_client.return_value
+    assert client._client == mock_elasticsearch_client
 
 
 def test_elasticsearch_writer_client_write_many_records(mock_elasticsearch_client, target_params):
@@ -87,7 +87,7 @@ def test_elasticsearch_writer_client_create_target_idempotent(mock_elasticsearch
 def test_elasticsearch_writer_client_create_target_idempotent_existing(mock_elasticsearch_client, target_params):
     from elasticsearch import ApiError
 
-    mock_elasticsearch_client.indices.create.side_effect = ApiError("index_already_exists_exception")
+    mock_elasticsearch_client.indices.create.side_effect = ApiError(400, "index_already_exists_exception", "body")
     client = ElasticsearchWriterClient(mock_elasticsearch_client)
     client.create_target_idempotent(target_params)
     assert mock_elasticsearch_client.indices.create.called
@@ -128,21 +128,6 @@ def test_elasticsearch_writer_document_record_from_doc_no_doc_id(target_params):
     )
     with pytest.raises(ValueError):
         ElasticsearchWriterDocumentRecord.from_doc(document, target_params)
-
-
-def test_narrow_list_of_doc_records():
-    records = [
-        ElasticsearchWriterDocumentRecord(
-            doc_id="1",
-            properties={"key": "value"},
-            parent_id="parent1",
-            embedding=[0.1, 0.2, 0.3],
-        )
-    ]
-    assert _narrow_list_of_doc_records(records) is True
-
-    records.append(BaseDBWriter.Record())
-    assert _narrow_list_of_doc_records(records) is False
 
 
 def test_elasticsearch_writer_target_params_compatible_with():

--- a/lib/sycamore/sycamore/tests/unit/connectors/elasticsearch/test_elasticsearch_writer.py
+++ b/lib/sycamore/sycamore/tests/unit/connectors/elasticsearch/test_elasticsearch_writer.py
@@ -1,0 +1,170 @@
+import pytest
+from unittest import mock
+from elasticsearch import Elasticsearch
+from sycamore.data.document import Document
+from sycamore.connectors.base_writer import BaseDBWriter
+
+from sycamore.connectors.elasticsearch.elasticsearch_writer import (
+    ElasticsearchWriterClient,
+    ElasticsearchWriterClientParams,
+    ElasticsearchWriterTargetParams,
+    ElasticsearchWriterDocumentRecord,
+    ElasticsearchDocumentWriter,
+    _narrow_list_of_doc_records,
+)
+
+
+@pytest.fixture
+def mock_elasticsearch_client():
+    with mock.patch("elasticsearch.Elasticsearch") as MockElasticsearch:
+        yield MockElasticsearch()
+
+
+@pytest.fixture
+def client_params():
+    return ElasticsearchWriterClientParams(url="http://localhost:9200")
+
+
+@pytest.fixture
+def target_params():
+    return ElasticsearchWriterTargetParams(index_name="test_index")
+
+
+@pytest.fixture
+def document():
+    return Document(
+        doc_id="1",
+        properties={"key": "value"},
+        type="test_type",
+        text_representation="test_text",
+        bbox=None,
+        shingles=["shingle1", "shingle2"],
+        parent_id="parent1",
+        embedding=[0.1, 0.2, 0.3],
+    )
+
+
+def test_elasticsearch_writer_client_init(mock_elasticsearch_client):
+    client = ElasticsearchWriterClient(mock_elasticsearch_client)
+    assert client._client == mock_elasticsearch_client
+
+
+def test_elasticsearch_writer_client_from_client_params(client_params, mock_elasticsearch_client):
+    client = ElasticsearchWriterClient.from_client_params(client_params)
+    assert isinstance(client, ElasticsearchWriterClient)
+    assert client._client == mock_elasticsearch_client.return_value
+
+
+def test_elasticsearch_writer_client_write_many_records(mock_elasticsearch_client, target_params):
+    client = ElasticsearchWriterClient(mock_elasticsearch_client)
+    records = [
+        ElasticsearchWriterDocumentRecord(
+            doc_id="1",
+            properties={"key": "value"},
+            parent_id="parent1",
+            embedding=[0.1, 0.2, 0.3],
+        )
+    ]
+    with mock.patch("elasticsearch.helpers.parallel_bulk") as mock_parallel_bulk:
+        client.write_many_records(records, target_params)
+        assert mock_parallel_bulk.called
+
+
+def test_elasticsearch_writer_client_write_many_records_empty(mock_elasticsearch_client, target_params):
+    client = ElasticsearchWriterClient(mock_elasticsearch_client)
+    records = []
+    with mock.patch("elasticsearch.helpers.parallel_bulk") as mock_parallel_bulk:
+        client.write_many_records(records, target_params)
+        assert not mock_parallel_bulk.called
+
+
+def test_elasticsearch_writer_client_create_target_idempotent(mock_elasticsearch_client, target_params):
+    client = ElasticsearchWriterClient(mock_elasticsearch_client)
+    client.create_target_idempotent(target_params)
+    assert mock_elasticsearch_client.indices.create.called
+
+
+def test_elasticsearch_writer_client_create_target_idempotent_existing(mock_elasticsearch_client, target_params):
+    from elasticsearch import ApiError
+
+    mock_elasticsearch_client.indices.create.side_effect = ApiError("index_already_exists_exception")
+    client = ElasticsearchWriterClient(mock_elasticsearch_client)
+    client.create_target_idempotent(target_params)
+    assert mock_elasticsearch_client.indices.create.called
+
+
+def test_elasticsearch_writer_client_get_existing_target_params(mock_elasticsearch_client, target_params):
+    mock_elasticsearch_client.indices.get_mapping.return_value = {
+        target_params.index_name: {"mappings": target_params.mappings}
+    }
+    mock_elasticsearch_client.indices.get_settings.return_value = {
+        target_params.index_name: {"settings": target_params.settings}
+    }
+    client = ElasticsearchWriterClient(mock_elasticsearch_client)
+    existing_params = client.get_existing_target_params(target_params)
+    assert existing_params.index_name == target_params.index_name
+    assert existing_params.mappings == target_params.mappings
+    assert existing_params.settings == target_params.settings
+
+
+def test_elasticsearch_writer_document_record_from_doc(document, target_params):
+    record = ElasticsearchWriterDocumentRecord.from_doc(document, target_params)
+    assert record.doc_id == document.doc_id
+    assert record.properties["properties"] == document.properties
+    assert record.parent_id == document.parent_id
+    assert record.embedding == document.embedding
+
+
+def test_elasticsearch_writer_document_record_from_doc_no_doc_id(target_params):
+    document = Document(
+        doc_id=None,
+        properties={"key": "value"},
+        type="test_type",
+        text_representation="test_text",
+        bbox=None,
+        shingles=["shingle1", "shingle2"],
+        parent_id="parent1",
+        embedding=[0.1, 0.2, 0.3],
+    )
+    with pytest.raises(ValueError):
+        ElasticsearchWriterDocumentRecord.from_doc(document, target_params)
+
+
+def test_narrow_list_of_doc_records():
+    records = [
+        ElasticsearchWriterDocumentRecord(
+            doc_id="1",
+            properties={"key": "value"},
+            parent_id="parent1",
+            embedding=[0.1, 0.2, 0.3],
+        )
+    ]
+    assert _narrow_list_of_doc_records(records) is True
+
+    records.append(BaseDBWriter.Record())
+    assert _narrow_list_of_doc_records(records) is False
+
+
+def test_elasticsearch_writer_target_params_compatible_with():
+    params1 = ElasticsearchWriterTargetParams(index_name="test_index")
+    params2 = ElasticsearchWriterTargetParams(index_name="test_index")
+    assert params1.compatible_with(params2) is True
+
+    params3 = ElasticsearchWriterTargetParams(index_name="different_index")
+    assert params1.compatible_with(params3) is False
+
+
+def test_elasticsearch_writer_target_params_compatible_with_different_settings():
+    params1 = ElasticsearchWriterTargetParams(index_name="test_index", settings={"number_of_shards": 1})
+    params2 = ElasticsearchWriterTargetParams(index_name="test_index", settings={"number_of_shards": 2})
+    assert params1.compatible_with(params2) is False
+
+
+def test_elasticsearch_writer_target_params_compatible_with_different_mappings():
+    params1 = ElasticsearchWriterTargetParams(
+        index_name="test_index", mappings={"properties": {"field1": {"type": "text"}}}
+    )
+    params2 = ElasticsearchWriterTargetParams(
+        index_name="test_index", mappings={"properties": {"field2": {"type": "text"}}}
+    )
+    assert params1.compatible_with(params2) is False

--- a/lib/sycamore/sycamore/tests/unit/connectors/elasticsearch/test_elasticsearch_writer.py
+++ b/lib/sycamore/sycamore/tests/unit/connectors/elasticsearch/test_elasticsearch_writer.py
@@ -1,16 +1,12 @@
 import pytest
 from unittest import mock
-from elasticsearch import Elasticsearch
 from sycamore.data.document import Document
-from sycamore.connectors.base_writer import BaseDBWriter
 
 from sycamore.connectors.elasticsearch.elasticsearch_writer import (
     ElasticsearchWriterClient,
     ElasticsearchWriterClientParams,
     ElasticsearchWriterTargetParams,
     ElasticsearchWriterDocumentRecord,
-    ElasticsearchDocumentWriter,
-    _narrow_list_of_doc_records,
 )
 
 

--- a/lib/sycamore/sycamore/tests/unit/connectors/pinecone/test_pinecone_reader.py
+++ b/lib/sycamore/sycamore/tests/unit/connectors/pinecone/test_pinecone_reader.py
@@ -120,4 +120,4 @@ def test_pinecone_reader_query_response_to_docs_with_sparse_vector():
     assert len(docs) == 1
     assert isinstance(docs[0], Document)
     assert docs[0].doc_id == "doc1"
-    assert docs[0].properties["properties.term_frequency"] == {0: 0.5, 1: 0.5}
+    assert docs[0].properties["term_frequency"] == {0: 0.5, 1: 0.5}

--- a/lib/sycamore/sycamore/tests/unit/connectors/pinecone/test_pinecone_reader.py
+++ b/lib/sycamore/sycamore/tests/unit/connectors/pinecone/test_pinecone_reader.py
@@ -1,13 +1,11 @@
 import pytest
 from unittest import mock
 from sycamore.data import Document
-from sycamore.connectors.base_reader import BaseDBReader
 from sycamore.connectors.pinecone.pinecone_reader import (
     PineconeReaderClient,
     PineconeReaderClientParams,
     PineconeReaderQueryParams,
     PineconeReaderQueryResponse,
-    PineconeReader,
 )
 
 

--- a/lib/sycamore/sycamore/tests/unit/connectors/pinecone/test_pinecone_reader.py
+++ b/lib/sycamore/sycamore/tests/unit/connectors/pinecone/test_pinecone_reader.py
@@ -1,0 +1,123 @@
+import pytest
+from unittest import mock
+from sycamore.data import Document
+from sycamore.connectors.base_reader import BaseDBReader
+from sycamore.connectors.pinecone.pinecone_reader import (
+    PineconeReaderClient,
+    PineconeReaderClientParams,
+    PineconeReaderQueryParams,
+    PineconeReaderQueryResponse,
+    PineconeReader,
+)
+
+
+@pytest.fixture
+def client_params():
+    return PineconeReaderClientParams(api_key="test_api_key")
+
+
+@pytest.fixture
+def query_params():
+    return PineconeReaderQueryParams(index_name="test_index", namespace="test_namespace", query=None)
+
+
+@pytest.fixture
+def mock_pinecone_grpc():
+    with mock.patch("pinecone.grpc.PineconeGRPC") as MockPineconeGRPC:
+        yield MockPineconeGRPC
+
+
+def test_pinecone_reader_client_init(client_params, mock_pinecone_grpc):
+    client = PineconeReaderClient(client_params)
+    mock_pinecone_grpc.assert_called_once_with(api_key="test_api_key", source_tag="Aryn")
+    assert client._client is not None
+
+
+def test_pinecone_reader_client_from_client_params(client_params):
+    client = PineconeReaderClient.from_client_params(client_params)
+    assert isinstance(client, PineconeReaderClient)
+
+
+def test_pinecone_reader_client_read_records(query_params, mock_pinecone_grpc):
+    mock_index = mock.Mock()
+    mock_pinecone_grpc.return_value.Index.return_value = mock_index
+    mock_index.list.return_value = [["id1", "id2"]]
+    mock_index.fetch.return_value = {
+        "vectors": {"id1": {"id": "id1", "values": [0.1, 0.2]}, "id2": {"id": "id2", "values": [0.3, 0.4]}}
+    }
+
+    client = PineconeReaderClient(PineconeReaderClientParams(api_key="test_api_key"))
+    response = client.read_records(query_params)
+
+    assert isinstance(response, PineconeReaderQueryResponse)
+    assert len(response.output) == 2
+
+
+def test_pinecone_reader_client_read_records_with_query(query_params, mock_pinecone_grpc):
+    query_params.query = {"top_k": 2, "include_values": True}
+    mock_index = mock.Mock()
+    mock_pinecone_grpc.return_value.Index.return_value = mock_index
+    mock_index.query.return_value = {
+        "matches": [{"id": "id1", "values": [0.1, 0.2]}, {"id": "id2", "values": [0.3, 0.4]}]
+    }
+
+    client = PineconeReaderClient(PineconeReaderClientParams(api_key="test_api_key"))
+    response = client.read_records(query_params)
+
+    assert isinstance(response, PineconeReaderQueryResponse)
+    assert len(response.output) == 2
+
+
+def test_pinecone_reader_client_check_target_presence(query_params, mock_pinecone_grpc):
+    mock_index = mock.Mock()
+    mock_pinecone_grpc.return_value.Index.return_value = mock_index
+    mock_index.describe_index_stats.return_value = {"namespaces": {"test_namespace": {}}}
+
+    client = PineconeReaderClient(PineconeReaderClientParams(api_key="test_api_key"))
+    presence = client.check_target_presence(query_params)
+
+    assert presence is True
+
+
+def test_pinecone_reader_client_check_target_presence_not_found(query_params, mock_pinecone_grpc):
+    mock_index = mock.Mock()
+    mock_pinecone_grpc.return_value.Index.return_value = mock_index
+    mock_index.describe_index_stats.return_value = {"namespaces": {}}
+
+    client = PineconeReaderClient(PineconeReaderClientParams(api_key="test_api_key"))
+    presence = client.check_target_presence(query_params)
+
+    assert presence is False
+
+
+def test_pinecone_reader_query_response_to_docs():
+    data = [
+        mock.Mock(id="doc1", values=[0.1, 0.2], metadata={"key": "value"}, sparse_vector=None),
+        mock.Mock(id="doc2#parent", values=[0.3, 0.4], metadata={}, sparse_vector=None),
+    ]
+    response = PineconeReaderQueryResponse(output=data)
+    docs = response.to_docs(PineconeReaderQueryParams(index_name="test_index", namespace="test_namespace", query=None))
+
+    assert len(docs) == 2
+    assert isinstance(docs[0], Document)
+    assert docs[0].doc_id == "doc1"
+    assert docs[1].parent_id == "doc2"
+    assert docs[1].doc_id == "parent"
+
+
+def test_pinecone_reader_query_response_to_docs_with_sparse_vector():
+    data = [
+        mock.Mock(
+            id="doc1",
+            values=[0.1, 0.2],
+            metadata={"key": "value"},
+            sparse_vector=mock.Mock(indices=[0, 1], values=[0.5, 0.5]),
+        ),
+    ]
+    response = PineconeReaderQueryResponse(output=data)
+    docs = response.to_docs(PineconeReaderQueryParams(index_name="test_index", namespace="test_namespace", query=None))
+
+    assert len(docs) == 1
+    assert isinstance(docs[0], Document)
+    assert docs[0].doc_id == "doc1"
+    assert docs[0].properties["properties.term_frequency"] == {0: 0.5, 1: 0.5}

--- a/lib/sycamore/sycamore/tests/unit/connectors/pinecone/test_pinecone_writer.py
+++ b/lib/sycamore/sycamore/tests/unit/connectors/pinecone/test_pinecone_writer.py
@@ -1,0 +1,189 @@
+import pytest
+from unittest import mock
+from sycamore.data.document import Document
+from sycamore.connectors.base_writer import BaseDBWriter
+
+from sycamore.connectors.pinecone.pinecone_writer import (
+    PineconeWriter,
+    PineconeWriterClient,
+    PineconeWriterRecord,
+    PineconeWriterTargetParams,
+    PineconeWriterClientParams,
+    _narrow_list_of_pinecone_records,
+    wait_on_index,
+)
+
+
+@pytest.fixture
+def mock_pinecone_grpc():
+    with mock.patch("sycamore.connectors.pinecone.pinecone_writer.PineconeGRPC") as mock_grpc:
+        yield mock_grpc
+
+
+@pytest.fixture
+def mock_pinecone_api_exception():
+    with mock.patch("sycamore.connectors.pinecone.pinecone_writer.PineconeApiException") as mock_exception:
+        yield mock_exception
+
+
+@pytest.fixture
+def mock_pinecone_exception():
+    with mock.patch("sycamore.connectors.pinecone.pinecone_writer.PineconeException") as mock_exception:
+        yield mock_exception
+
+
+def test_pinecone_writer_target_params_compatible_with():
+    params1 = PineconeWriterTargetParams(index_name="index1", dimensions=128)
+    params2 = PineconeWriterTargetParams(index_name="index1", dimensions=128)
+    assert params1.compatible_with(params2)
+
+    params3 = PineconeWriterTargetParams(index_name="index2", dimensions=128)
+    assert not params1.compatible_with(params3)
+
+    params4 = PineconeWriterTargetParams(index_name="index1", dimensions=64)
+    assert not params1.compatible_with(params4)
+
+
+def test_pinecone_writer_client_init(mock_pinecone_grpc):
+    client = PineconeWriterClient(api_key="test_key", batch_size=100)
+    mock_pinecone_grpc.assert_called_once_with(api_key="test_key", source_tag="Aryn")
+    assert client._batch_size == 100
+
+
+def test_pinecone_writer_client_from_client_params():
+    params = PineconeWriterClientParams(api_key="test_key", batch_size=100)
+    client = PineconeWriterClient.from_client_params(params)
+    assert isinstance(client, PineconeWriterClient)
+    assert client._batch_size == 100
+
+
+def test_pinecone_writer_client_write_many_records(mock_pinecone_grpc):
+    client = PineconeWriterClient(api_key="test_key", batch_size=2)
+    target_params = PineconeWriterTargetParams(index_name="index1", dimensions=128)
+    records = [
+        PineconeWriterRecord(id="1", values=[0.1, 0.2], metadata={}, sparse_values=None),
+        PineconeWriterRecord(id="2", values=[0.3, 0.4], metadata={}, sparse_values=None),
+    ]
+    client.write_many_records(records, target_params)
+    assert mock_pinecone_grpc.return_value.Index.return_value.upsert.call_count == 1
+
+
+def test_pinecone_writer_client_write_many_records_empty(mock_pinecone_grpc):
+    client = PineconeWriterClient(api_key="test_key", batch_size=2)
+    target_params = PineconeWriterTargetParams(index_name="index1", dimensions=128)
+    records = []
+    client.write_many_records(records, target_params)
+    assert mock_pinecone_grpc.return_value.Index.return_value.upsert.call_count == 0
+
+
+def test_pinecone_writer_client_create_target_idempotent(mock_pinecone_grpc, mock_pinecone_api_exception):
+    client = PineconeWriterClient(api_key="test_key", batch_size=100)
+    target_params = PineconeWriterTargetParams(index_name="index1", dimensions=128, index_spec={"spec": "value"})
+    client.create_target_idempotent(target_params)
+    mock_pinecone_grpc.return_value.create_index.assert_called_once_with(
+        name="index1", dimension=128, spec={"spec": "value"}, metric="cosine"
+    )
+
+
+def test_pinecone_writer_client_create_target_idempotent_existing(mock_pinecone_grpc, mock_pinecone_api_exception):
+    client = PineconeWriterClient(api_key="test_key", batch_size=100)
+    target_params = PineconeWriterTargetParams(index_name="index1", dimensions=128, index_spec={"spec": "value"})
+    mock_pinecone_grpc.return_value.create_index.side_effect = mock_pinecone_api_exception
+    client.create_target_idempotent(target_params)
+    mock_pinecone_grpc.return_value.create_index.assert_called_once()
+
+
+def test_pinecone_writer_client_get_existing_target_params(mock_pinecone_grpc):
+    client = PineconeWriterClient(api_key="test_key", batch_size=100)
+    target_params = PineconeWriterTargetParams(index_name="index1", dimensions=128)
+    mock_pinecone_grpc.return_value.describe_index.return_value.to_dict.return_value = {
+        "name": "index1",
+        "dimension": 128,
+        "spec": {"spec": "value"},
+        "metric": "cosine",
+    }
+    result = client.get_existing_target_params(target_params)
+    assert result.index_name == "index1"
+    assert result.dimensions == 128
+    assert result.index_spec == {"spec": "value"}
+    assert result.distance_metric == "cosine"
+
+
+def test_pinecone_writer_record_from_doc():
+    document = Document(
+        doc_id="doc1",
+        embedding=[0.1, 0.2],
+        type="type1",
+        text_representation="text",
+        bbox=None,
+        shingles=None,
+        properties={},
+    )
+    target_params = PineconeWriterTargetParams(index_name="index1", dimensions=128)
+    record = PineconeWriterRecord.from_doc(document, target_params)
+    assert record.id == "doc1"
+    assert record.values == [0.1, 0.2]
+    assert record.metadata["type"] == "type1"
+
+
+def test_pinecone_writer_record_from_doc_with_parent_id():
+    document = Document(
+        doc_id="doc1",
+        parent_id="parent1",
+        embedding=[0.1, 0.2],
+        type="type1",
+        text_representation="text",
+        bbox=None,
+        shingles=None,
+        properties={},
+    )
+    target_params = PineconeWriterTargetParams(index_name="index1", dimensions=128)
+    record = PineconeWriterRecord.from_doc(document, target_params)
+    assert record.id == "parent1#doc1"
+
+
+def test_pinecone_writer_record_from_doc_with_sparse_vector():
+    document = Document(
+        doc_id="doc1",
+        embedding=[0.1, 0.2],
+        type="type1",
+        text_representation="text",
+        bbox=None,
+        shingles=None,
+        properties={"term_frequency": {1: 0.5, 2: 0.3}},
+    )
+    target_params = PineconeWriterTargetParams(index_name="index1", dimensions=128)
+    record = PineconeWriterRecord.from_doc(document, target_params)
+    assert record.sparse_values is not None
+    assert record.sparse_values["indices"] == [1, 2]
+    assert record.sparse_values["values"] == [0.5, 0.3]
+
+
+def test_narrow_list_of_pinecone_records():
+    records = [
+        PineconeWriterRecord(id="1", values=[0.1, 0.2], metadata={}, sparse_values=None),
+        PineconeWriterRecord(id="2", values=[0.3, 0.4], metadata={}, sparse_values=None),
+    ]
+    assert _narrow_list_of_pinecone_records(records)
+
+
+def test_narrow_list_of_pinecone_records_invalid():
+    records = [
+        PineconeWriterRecord(id="1", values=[0.1, 0.2], metadata={}, sparse_values=None),
+        BaseDBWriter.Record(id="2", values=[0.3, 0.4], metadata={}, sparse_values=None),
+    ]
+    assert not _narrow_list_of_pinecone_records(records)
+
+
+def test_wait_on_index(mock_pinecone_grpc, mock_pinecone_exception):
+    client = mock_pinecone_grpc.return_value
+    client.describe_index.return_value.get.return_value = {"status": {"ready": True}}
+    wait_on_index(client, "index1")
+    client.describe_index.assert_called_with("index1")
+
+
+def test_wait_on_index_timeout(mock_pinecone_grpc, mock_pinecone_exception):
+    client = mock_pinecone_grpc.return_value
+    client.describe_index.return_value.get.return_value = {"status": {"ready": False}}
+    with pytest.raises(RuntimeError, match="Pinecone failed to create index in 30 seconds"):
+        wait_on_index(client, "index1")

--- a/lib/sycamore/sycamore/tests/unit/connectors/pinecone/test_pinecone_writer.py
+++ b/lib/sycamore/sycamore/tests/unit/connectors/pinecone/test_pinecone_writer.py
@@ -1,7 +1,6 @@
 import pytest
 from unittest import mock
 from sycamore.data.document import Document
-from sycamore.connectors.base_writer import BaseDBWriter
 
 from sycamore.connectors.pinecone.pinecone_writer import (
     PineconeWriterClient,


### PR DESCRIPTION
Adds unit tests for the Pinecone, Elasticsearch, and DuckDB readers and writers, fixes bugs, and refactors DuckDB to not hardcode the schema.