### PR TITLE
Couple of minor fixes and tweaks to the table merger.

### DIFF
--- a/lib/sycamore/sycamore/transforms/llm_query.py
+++ b/lib/sycamore/sycamore/transforms/llm_query.py
@@ -104,8 +104,17 @@ class LLMTextQueryAgent:
                     .render(doc=object)
                 )
             else:
+                object_name = "ELEMENT" if isinstance(object, Element) else "DOCUMENT"
                 if objectPrev and objectPrev.text_representation:
-                    prompt = self._prompt + "\n" + objectPrev.text_representation + "\n\n" + object.text_representation
+                    prompt = (
+                        self._prompt
+                        + "\n"
+                        + f"{object_name} 1: \n\n"
+                        + objectPrev.text_representation
+                        + "\n\n"
+                        + f"{object_name} 2: \n"
+                        + object.text_representation
+                    )
                 else:
                     prompt = self._prompt + "\n" + object.text_representation
             prompt_kwargs = {"prompt": prompt}

--- a/lib/sycamore/sycamore/transforms/merge_elements.py
+++ b/lib/sycamore/sycamore/transforms/merge_elements.py
@@ -24,13 +24,11 @@ class ElementMerger(ABC):
     def merge(self, element1: Element, element2: Element) -> Element:
         pass
 
-    @abstractmethod
     def preprocess_element(self, element: Element) -> Element:
-        pass
+        return element
 
-    @abstractmethod
     def postprocess_element(self, element: Element) -> Element:
-        pass
+        return element
 
     @timetrace("mergeElem")
     def merge_elements(self, document: Document) -> Document:
@@ -443,7 +441,7 @@ class TableMerger(ElementMerger):
             Respond with only 'true' or 'false' based on your certainty that the second table is a continuation. \
             Certainty is determined if either of the two conditions is true."
 
-            regex_pattern = r"table \d+"
+            regex_pattern = r"table \\d+"
 
             merger = TableMerger(llm_prompt = prompt, llm=llm)
 
@@ -481,8 +479,10 @@ class TableMerger(ElementMerger):
         for element in table_elements[1:]:
             if self.should_merge(new_table_elements[-1], element):
                 new_table_elements[-1] = self.merge(new_table_elements[-1], element)
+                new_table_elements[-1]["properties"]["table_continuation"] = True
             else:
                 new_table_elements.append(element)
+                new_table_elements[-1]["properties"]["table_continuation"] = False
         other_elements.extend(new_table_elements)
         document.elements = other_elements
         bbox_sort_document(document)
@@ -606,12 +606,6 @@ class TableMerger(ElementMerger):
         llm_query_agent = LLMTextQueryAgent(prompt=self.llm_prompt, element_type="table", llm=self.llm, table_cont=True)
         llm_results = llm_query_agent.execute_query(document)
         return llm_results
-
-    def preprocess_element(self, elem: Element) -> Element:
-        return elem
-
-    def postprocess_element(self, elem: Element) -> Element:
-        return elem
 
 
 class Merge(SingleThreadUser, NonGPUUser, Map):


### PR DESCRIPTION
1. I observed the LLM sometimes having issues distinguishing where one table ended and the next started, so I added headers - either ELEMENT 1/ELEMENT 2 or DOCUMENT 1/DOCUMENT 2 in the llm_query transform.

2. Added a default implementation for preprocess_element and postprocess_element in the ElementMerger base class. This just reduces code in some simple sub-classes.

3. Added code to update the table_continuation to be True or False. This is because I ended up getting better results when asking the LLM to explain its reasoning in some cases, but I didn't want all of the output carried along in the element.

4. Minor fix to address an invalid escape character warning in a comment.