### PR TITLE
Enable use_elements in query.summarize_data

### DIFF
--- a/apps/query-eval/queryeval/driver.py
+++ b/apps/query-eval/queryeval/driver.py
@@ -188,13 +188,16 @@ class QueryEvalDriver:
         self.results_map[query.query] = result
         return result
 
+    def _check_tags_match(self, query):
+        return set(self.config.config.tags or []) != set(query.tags or [])
+
     def do_plan(self, query: QueryEvalQuery, result: QueryEvalResult) -> QueryEvalResult:
         """Generate or return an existing query plan."""
         if self.config.config:
             if self.config.config.dry_run:
                 console.print("[yellow]:point_right: Dry run: skipping plan generation")
                 return result
-            elif self.config.config.tags and not (set(self.config.config.tags or []) & set(query.tags or [])):
+            elif not self._check_tags_match(query):
                 console.print("[yellow]:point_right: Skipping query due to tag mismatch")
                 return result
 
@@ -238,7 +241,7 @@ class QueryEvalDriver:
             if self.config.config.dry_run:
                 console.print("[yellow]:point_right: Dry run: skipping query execution")
                 return result
-            elif not (set(self.config.config.tags or []) & set(query.tags or [])):
+            elif not self._check_tags_match(query):
                 console.print("[yellow]:point_right: Skipping query due to tag mismatch")
                 return result
 

--- a/lib/sycamore/sycamore/query/execution/operations.py
+++ b/lib/sycamore/sycamore/query/execution/operations.py
@@ -1,4 +1,3 @@
-import json
 import math
 from typing import Any, List, Union, Optional
 
@@ -60,6 +59,8 @@ def summarize_data(
     question: str,
     result_description: str,
     result_data: List[Any],
+    use_elements: bool = False,
+    num_elements: int = 5,
     context: Optional[Context] = None,
     **kwargs,
 ) -> str:
@@ -67,36 +68,25 @@ def summarize_data(
     Provides an English response to a question given relevant information.
 
     Args:
-        client: LLM client.
+        llm: LLM ti use for summarization.
         question: Question to answer.
         result_description: Description of each of the inputs in result_data.
         result_data: List of inputs.
+        use_elements: use text contents from document.elements instead of document.text_representation.
+        num_elements: number of elements whose text to use from each document.
+        context: Optional Context object to get default parameters from.
         **kwargs
 
     Returns:
         Conversational response to question.
     """
-    text = f"Description: {result_description}\n"
-
-    for i, result in enumerate(result_data):
-        text += f"Input {i + 1}:\n"
-
-        # consolidates relevant properties to give to LLM
-        if isinstance(result, DocSet):
-            for doc in result.take(NUM_DOCS_GENERATE, **kwargs):
-                if isinstance(doc, MetadataDocument):
-                    continue
-                props_dict = doc.properties.get("entity", {})
-                props_dict.update({p: doc.properties[p] for p in set(doc.properties) - set(BASE_PROPS)})
-                props_dict["text_representation"] = (
-                    doc.text_representation[:NUM_TEXT_CHARS_GENERATE] if doc.text_representation is not None else None
-                )
-
-                text += json.dumps(props_dict, indent=2) + "\n"
-
-        else:
-            text += str(result_data) + "\n"
-
+    text = _get_text_for_summarize_data(
+        result_description=result_description,
+        result_data=result_data,
+        use_elements=use_elements,
+        num_elements=num_elements,
+        **kwargs,
+    )
     messages = SummarizeDataMessagesPrompt(question=question, text=text).as_messages()
     prompt_kwargs = {"messages": messages}
 
@@ -105,3 +95,41 @@ def summarize_data(
 
     # LLM response
     return completion
+
+
+def _get_text_for_summarize_data(
+    result_description: str, result_data: List[Any], use_elements: bool, num_elements: int, **kwargs
+) -> str:
+    text = f"Data description: {result_description}\n"
+
+    for i, result in enumerate(result_data):
+        text += f"Input {i + 1}:\n"
+
+        # consolidates relevant properties to give to LLM
+        if isinstance(result, DocSet):
+            for i, doc in enumerate(result.take(NUM_DOCS_GENERATE, **kwargs)):
+                if isinstance(doc, MetadataDocument):
+                    continue
+                props_dict = doc.properties.get("entity", {})
+                props_dict.update({p: doc.properties[p] for p in set(doc.properties) - set(BASE_PROPS)})
+                doc_text = f"Document {i}:\n"
+                for k, v in props_dict.items():
+                    doc_text += f"{k}: {v}\n"
+
+                doc_text_representation = ""
+                if not use_elements:
+                    if doc.text_representation is not None:
+                        doc_text_representation += doc.text_representation[:NUM_TEXT_CHARS_GENERATE]
+                else:
+                    for element in doc.elements[:num_elements]:
+                        # Greedy fill doc level text length
+                        if len(doc_text_representation) >= NUM_TEXT_CHARS_GENERATE:
+                            break
+                        doc_text_representation += (element.text_representation or "") + "\n"
+                doc_text += f"Text contents:\n{doc_text_representation}\n"
+
+                text += doc_text + "\n"
+        else:
+            text += str(result_data) + "\n"
+
+    return text

--- a/lib/sycamore/sycamore/query/execution/sycamore_operator.py
+++ b/lib/sycamore/sycamore/query/execution/sycamore_operator.py
@@ -195,6 +195,7 @@ class SycamoreSummarizeData(SycamoreOperator):
             result_description=description,
             result_data=self.inputs,
             context=self.context,
+            use_elements=True,
             **self.get_execute_args(),
         )
         return result
@@ -217,6 +218,7 @@ class SycamoreSummarizeData(SycamoreOperator):
     result_description='{description}',
     result_data=[{logical_deps_str}],
     context=context,
+    use_elements=True,
     **{get_str_for_dict(self.get_execute_args())},
 )
 """

--- a/lib/sycamore/sycamore/tests/unit/query/execution/test_sycamore_operator.py
+++ b/lib/sycamore/sycamore/tests/unit/query/execution/test_sycamore_operator.py
@@ -164,6 +164,7 @@ def test_summarize_data():
             question=logical_node.question,
             result_description=logical_node.description,
             result_data=[load_node],
+            use_elements=True,
             **sycamore_operator.get_execute_args(),
         )
 


### PR DESCRIPTION
Verified we're using element's text_representations when asking queries through the query-ui (question: "Summarize incident <>")