### PR TITLE
Fix `mark_bbox_preset`'s `MarkDropHeaderFooter` parameter

### DIFF
--- a/lib/sycamore/sycamore/transforms/bbox_merge.py
+++ b/lib/sycamore/sycamore/transforms/bbox_merge.py
@@ -152,7 +152,7 @@ class MarkDropHeaderFooter(SingleThreadUser, NonGPUUser, Map):
     """
 
     def __init__(self, child: Node, top: float = 0.05, bottom: Optional[float] = None, **resource_args):
-        super().__init__(child, f=MarkDropHeaderFooter.mark_drop_header_and_footer, args=[bottom, top], **resource_args)
+        super().__init__(child, f=MarkDropHeaderFooter.mark_drop_header_and_footer, args=[top, bottom], **resource_args)
 
     @staticmethod
     @timetrace("markHeadFoot")

--- a/lib/sycamore/sycamore/transforms/bbox_merge.py
+++ b/lib/sycamore/sycamore/transforms/bbox_merge.py
@@ -152,15 +152,17 @@ class MarkDropHeaderFooter(SingleThreadUser, NonGPUUser, Map):
     """
 
     def __init__(self, child: Node, top: float = 0.05, bottom: Optional[float] = None, **resource_args):
-        if bottom is None:
-            bottom = top
-        lo = top
-        hi = 1.0 - bottom
-        super().__init__(child, f=MarkDropHeaderFooter.mark_drop_header_and_footer, args=[lo, hi], **resource_args)
+        super().__init__(child, f=MarkDropHeaderFooter.mark_drop_header_and_footer, args=[bottom, top], **resource_args)
 
     @staticmethod
     @timetrace("markHeadFoot")
-    def mark_drop_header_and_footer(parent: Document, lo: float, hi: float) -> Document:
+    def mark_drop_header_and_footer(parent: Document, top: float = 0.05, bottom: Optional[float] = None) -> Document:
+        if bottom is None:
+            bottom = top
+
+        lo = top
+        hi = 1.0 - bottom
+
         for elem in parent.elements:
             bbox = elem.data.get("bbox")
             if (bbox is not None) and ((bbox[1] > hi) or (bbox[3] < lo)):

--- a/lib/sycamore/sycamore/transforms/mark_misc.py
+++ b/lib/sycamore/sycamore/transforms/mark_misc.py
@@ -141,7 +141,7 @@ class MarkBboxPreset(SingleThreadUser, NonGPUUser, Map):
 
         SortByPageBbox.sort_by_page_bbox(parent)
         MarkDropTiny.mark_drop_tiny(parent, 2)
-        MarkDropHeaderFooter.mark_drop_header_and_footer(parent, 0.05, 0.05)
+        MarkDropHeaderFooter.mark_drop_header_and_footer(parent, 0.05, 0.95)
         MarkBreakPage.mark_break_page(parent)
         MarkBreakByColumn.mark_break_by_column(parent)
         MarkBreakByTokens.mark_break_by_tokens(parent, tokenizer, token_limit)

--- a/lib/sycamore/sycamore/transforms/mark_misc.py
+++ b/lib/sycamore/sycamore/transforms/mark_misc.py
@@ -141,7 +141,7 @@ class MarkBboxPreset(SingleThreadUser, NonGPUUser, Map):
 
         SortByPageBbox.sort_by_page_bbox(parent)
         MarkDropTiny.mark_drop_tiny(parent, 2)
-        MarkDropHeaderFooter.mark_drop_header_and_footer(parent, 0.05, 0.95)
+        MarkDropHeaderFooter.mark_drop_header_and_footer(parent, 0.05, 0.05)
         MarkBreakPage.mark_break_page(parent)
         MarkBreakByColumn.mark_break_by_column(parent)
         MarkBreakByTokens.mark_break_by_tokens(parent, tokenizer, token_limit)


### PR DESCRIPTION
Fixes bug that where `MarkDropHeaderFooter` always adds `_drop` to all elements, causing all elements to be dropped. This is because the parameters for `MarkDropHeaderFooter.__init__` are different from `MarkDropHeaderFootermark_drop_header_footer`:

```python
  def __init__(self, child: Node, top: float = 0.05, bottom: Optional[float] = None, **resource_args):
      if bottom is None:
          bottom = top
      lo = top
      hi = 1.0 - bottom
      super().__init__(child, f=MarkDropHeaderFooter.mark_drop_header_and_footer, args=[lo, hi], **resource_args)
  
  @staticmethod
  @timetrace("markHeadFoot")
  def mark_drop_header_and_footer(parent: Document, lo: float, hi: float) -> Document:
      for elem in parent.elements:
          bbox = elem.data.get("bbox")
          if (bbox is not None) and ((bbox[1] > hi) or (bbox[3] < lo)):
              elem.data["_drop"] = True  # mark for removal
      return parent
```

