### PR TITLE
Union OCR / PDFMiner Tokens with Table Outputs

### DIFF
--- a/lib/sycamore/sycamore/transforms/detr_partitioner.py
+++ b/lib/sycamore/sycamore/transforms/detr_partitioner.py
@@ -21,7 +21,7 @@ from pypdf import PdfReader
 from sycamore.data import Element, BoundingBox, ImageElement, TableElement
 from sycamore.data.document import DocumentPropertyTypes
 from sycamore.data.element import create_element
-from sycamore.transforms.table_structure.extract import DEFAULT_TABLE_STRUCTURE_EXTRACTOR
+from sycamore.transforms.table_structure.extract import DEFAULT_TABLE_STRUCTURE_EXTRACTOR, TableStructureExtractor
 from sycamore.utils import choose_device
 from sycamore.utils.bbox_sort import bbox_sort_page
 from sycamore.utils.cache import Cache
@@ -153,6 +153,7 @@ class ArynPDFPartitioner:
         per_element_ocr=True,
         extract_table_structure=False,
         table_structure_extractor=None,
+        table_extractor_options: dict = {},
         extract_images=False,
         batch_size: int = 1,
         use_partitioning_service=True,
@@ -191,6 +192,7 @@ class ArynPDFPartitioner:
                 per_element_ocr=per_element_ocr,
                 extract_table_structure=extract_table_structure,
                 table_structure_extractor=table_structure_extractor,
+                table_extractor_options=table_extractor_options,
                 extract_images=extract_images,
                 batch_size=batch_size,
                 use_cache=use_cache,
@@ -376,6 +378,7 @@ class ArynPDFPartitioner:
         per_element_ocr: bool = True,
         extract_table_structure: bool = False,
         table_structure_extractor=None,
+        table_extractor_options: dict = {},
         extract_images: bool = False,
         batch_size: int = 1,
         use_cache=False,
@@ -405,6 +408,7 @@ class ArynPDFPartitioner:
                 per_element_ocr,
                 extract_table_structure,
                 table_structure_extractor,
+                table_extractor_options,
                 extract_images,
                 batch_size,
                 use_cache,
@@ -422,6 +426,7 @@ class ArynPDFPartitioner:
         per_element_ocr: bool = True,
         extract_table_structure=False,
         table_structure_extractor=None,
+        table_extractor_options: dict = {},
         extract_images=False,
         batch_size: int = 1,
         use_cache=False,
@@ -463,6 +468,7 @@ class ArynPDFPartitioner:
                 per_element_ocr=per_element_ocr,
                 extract_table_structure=extract_table_structure,
                 table_structure_extractor=table_structure_extractor,
+                table_extractor_options=table_extractor_options,
                 extract_images=extract_images,
                 use_cache=use_cache,
             )
@@ -488,13 +494,14 @@ class ArynPDFPartitioner:
         threshold: float,
         text_extractor: TextExtractor,
         extractor_inputs: Any,
-        use_ocr,
-        ocr_images,
-        ocr_model,
-        per_element_ocr,
-        extract_table_structure,
+        use_ocr: bool,
+        ocr_images: bool,
+        ocr_model: Union[str, OcrModel],
+        per_element_ocr: bool,
+        extract_table_structure: bool,
         table_structure_extractor,
-        extract_images,
+        table_extractor_options: dict,
+        extract_images: bool,
         use_cache,
     ) -> Any:
         with LogTime("infer"):
@@ -535,7 +542,7 @@ class ArynPDFPartitioner:
                     image = batch[i]
                     for element in page_elements:
                         if isinstance(element, TableElement):
-                            table_structure_extractor.extract(element, image)
+                            table_structure_extractor.extract(element, image, **table_extractor_options)
 
         if extract_images:
             with LogTime("extract_images_batch"):
@@ -599,9 +606,10 @@ class ArynPDFPartitioner:
         self,
         batch: list[Image.Image],
         deformable_layout: Any,
-        extract_table_structure,
+        extract_table_structure: bool,
         table_structure_extractor,
-        extract_images,
+        table_extractor_options: dict,
+        extract_images: bool,
     ) -> Any:
         if extract_table_structure:
             with LogTime("extract_table_structure_batch"):
@@ -611,7 +619,7 @@ class ArynPDFPartitioner:
                     image = batch[i]
                     for element in page_elements:
                         if isinstance(element, TableElement):
-                            table_structure_extractor.extract(element, image)
+                            table_structure_extractor.extract(element, image, **table_extractor_options)
 
         if extract_images:
             with LogTime("extract_images_batch"):

--- a/lib/sycamore/sycamore/transforms/detr_partitioner.py
+++ b/lib/sycamore/sycamore/transforms/detr_partitioner.py
@@ -21,7 +21,7 @@ from pypdf import PdfReader
 from sycamore.data import Element, BoundingBox, ImageElement, TableElement
 from sycamore.data.document import DocumentPropertyTypes
 from sycamore.data.element import create_element
-from sycamore.transforms.table_structure.extract import DEFAULT_TABLE_STRUCTURE_EXTRACTOR, TableStructureExtractor
+from sycamore.transforms.table_structure.extract import DEFAULT_TABLE_STRUCTURE_EXTRACTOR
 from sycamore.utils import choose_device
 from sycamore.utils.bbox_sort import bbox_sort_page
 from sycamore.utils.cache import Cache

--- a/lib/sycamore/sycamore/transforms/partition.py
+++ b/lib/sycamore/sycamore/transforms/partition.py
@@ -396,8 +396,9 @@ class ArynPartitioner(Partitioner):
              is True. The default is the TableTransformerStructureExtractor.
              Ignored when local mode is false.
         table_extractor_options: Dictionary of options that are sent to the TableExtractor implementation. Currently
-            supports union_tokens, which is a boolean that controls whether to union OCR / PDFMiner tokens in the table cells.
-            By default it is False.
+            supports union_tokens, which is a boolean that controls whether to union OCR / PDFMiner tokens 
+            in the table cells.
+            default: {"union_tokens": False}
         extract_images: If true, crops each region identified as an image and attaches it to the associated
              ImageElement. This can later be fed into the SummarizeImages transform.
             default: False

--- a/lib/sycamore/sycamore/transforms/partition.py
+++ b/lib/sycamore/sycamore/transforms/partition.py
@@ -395,6 +395,9 @@ class ArynPartitioner(Partitioner):
         table_structure_extractor: The table extraction implementaion to use when extract_table_structure
              is True. The default is the TableTransformerStructureExtractor.
              Ignored when local mode is false.
+        table_extractor_options: Dictionary of options that are sent to the TableExtractor implementation. Currently
+            supports union_tokens, which is a boolean that controls whether to union OCR / PDFMiner tokens in the table cells.
+            By default it is False.
         extract_images: If true, crops each region identified as an image and attaches it to the associated
              ImageElement. This can later be fed into the SummarizeImages transform.
             default: False
@@ -436,6 +439,7 @@ class ArynPartitioner(Partitioner):
         per_element_ocr: bool = True,
         extract_table_structure: bool = False,
         table_structure_extractor: Optional[TableStructureExtractor] = None,
+        table_extractor_options: dict[str, Any] = {},
         extract_images: bool = False,
         device=None,
         batch_size: int = 1,
@@ -476,6 +480,7 @@ class ArynPartitioner(Partitioner):
         self._per_element_ocr = per_element_ocr
         self._extract_table_structure = extract_table_structure
         self._table_structure_extractor = table_structure_extractor
+        self._table_extractor_options = table_extractor_options
         self._extract_images = extract_images
         self._output_format = output_format
         self._batch_size = batch_size
@@ -503,6 +508,7 @@ class ArynPartitioner(Partitioner):
                 ocr_model=self._ocr_model,
                 extract_table_structure=self._extract_table_structure,
                 table_structure_extractor=self._table_structure_extractor,
+                table_extractor_options=self._table_extractor_options,
                 extract_images=self._extract_images,
                 batch_size=self._batch_size,
                 use_partitioning_service=self._use_partitioning_service,

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -102,7 +102,7 @@ class TableTransformerStructureExtractor(TableStructureExtractor):
 
     @timetrace("tblExtr")
     @requires_modules(["torch", "torchvision"], extra="local-inference")
-    def extract(self, element: TableElement, doc_image: Image.Image) -> TableElement:
+    def extract(self, element: TableElement, doc_image: Image.Image, union_tokens=False) -> TableElement:
         """Extracts the table structure from the specified element using a TableTransformer model.
 
         Takes a TableElement containing a bounding box, for example from the SycamorePartitioner,
@@ -165,7 +165,7 @@ class TableTransformerStructureExtractor(TableStructureExtractor):
 
         # Convert the raw objects to our internal table representation. This involves multiple
         # phases of postprocessing.
-        table = table_transformers.objects_to_table(objects, tokens)
+        table = table_transformers.objects_to_table(objects, tokens, union_tokens=union_tokens)
 
         if table is None:
             element.table = None

--- a/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
@@ -104,7 +104,9 @@ DEFAULT_STRUCTURE_CLASS_THRESHOLDS = {
 }
 
 
-def objects_to_table(objects, tokens, structure_class_thresholds=DEFAULT_STRUCTURE_CLASS_THRESHOLDS) -> Optional[Table]:
+def objects_to_table(
+    objects, tokens, structure_class_thresholds=DEFAULT_STRUCTURE_CLASS_THRESHOLDS, union_tokens=False
+) -> Optional[Table]:
     structures = objects_to_structures(objects, tokens=tokens, class_thresholds=structure_class_thresholds)
 
     if len(structures) == 0:
@@ -123,7 +125,7 @@ def objects_to_table(objects, tokens, structure_class_thresholds=DEFAULT_STRUCTU
         )
         return Table(table_cells)
 
-    cells, _ = structure_to_cells(structures, tokens=tokens)
+    cells, _ = structure_to_cells(structures, tokens=tokens, union_tokens=union_tokens)
 
     table_cells = []
     for cell in cells:
@@ -880,7 +882,7 @@ def objects_to_structures(objects, tokens, class_thresholds):
     return structure
 
 
-def structure_to_cells(table_structure, tokens, union_tokens=True):
+def structure_to_cells(table_structure, tokens, union_tokens):
     """
     Assuming the row, column, spanning cell, and header bounding boxes have
     been refined into a set of consistent table structures, process these
@@ -1064,7 +1066,7 @@ def structure_to_cells(table_structure, tokens, union_tokens=True):
                 for row_idx, row in enumerate(rows):  # find or create the row for the token
                     row_rect = BoundingBox(*row["bbox"])
                     if row_rect.intersect(token_rect).area > 0:
-                        token_rows.append(row)
+                        token_rows.append(row_idx)
                     elif row_rect.y2 < token_rect.y1:
                         if row_idx < len(rows) - 1 and rows[row_idx + 1]["bbox"][1] > token_rect.y2:
                             new_row = BoundingBox(row_rect.x1, row_rect.y2, row_rect.x2, rows[row_idx + 1]["bbox"][1])
@@ -1078,7 +1080,7 @@ def structure_to_cells(table_structure, tokens, union_tokens=True):
                 for col_idx, col in enumerate(columns):  # find or create the row for the token
                     col_rect = BoundingBox(*col["bbox"])
                     if col_rect.intersect(token_rect).area > 0:
-                        token_columns.append(col)
+                        token_columns.append(col_idx)
                     elif col_rect.x2 < token_rect.x1:
                         if col_idx < len(columns) - 1 and columns[col_idx + 1]["bbox"][0] > token_rect.x2:
                             new_col = BoundingBox(
@@ -1092,11 +1094,11 @@ def structure_to_cells(table_structure, tokens, union_tokens=True):
                             token_columns.append(col_idx + 1)
                             break
                 if not token_rows:
-                    token_rows.append(max(rows) + 1)
+                    token_rows.append(len(rows) + 1)
                     prev_row = BoundingBox(*rows[-1]["bbox"])
                     rows.append({"bbox": [prev_row.x1, prev_row.y2, prev_row.x2, 2 * prev_row.y2 - prev_row.y1]})
                 if not token_columns:
-                    token_columns.append(max(columns) + 1)
+                    token_columns.append(len(columns) + 1)
                     prev_col = BoundingBox(*columns[-1]["bbox"])
                     columns.append({"bbox": [prev_col.x2, prev_col.y1, 2 * prev_col.x2 - prev_col.x1, prev_col.y2]})
                 row_rect = BoundingBox.from_union(BoundingBox(*rows[row_num]["bbox"]) for row_num in token_rows)

--- a/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
@@ -954,7 +954,10 @@ def objects_to_structures(objects, tokens, class_thresholds):
     # Process the rows and columns into a complete segmented table
     columns = align_columns(columns, table["row_column_bbox"])
     rows = align_rows(rows, table["row_column_bbox"])
-
+    if not rows:  # if no rows detected, create a single row comprising the whole table
+        rows = [{"bbox": table["row_column_bbox"]}]
+    if not columns:
+        columns = [{"bbox": table["row_column_bbox"]}]
     structure["rows"] = rows
     structure["columns"] = columns
     structure["column headers"] = column_headers

--- a/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
@@ -752,8 +752,8 @@ def align_supercells(supercells, rows, columns):
 def union_dropped_tokens_with_cells(cells, dropped_tokens, rows, columns):
     """
     For each token that was dropped, determine which cell it intersects with and add the text to that cell.
-    If the token does not intersect with any existing cell, create a new cell. Determine the new row and column by checking for
-    intersection with any previous one and creating a new one if necessary.
+    If the token does not intersect with any existing cell, create a new cell. Determine the new row and column by
+    checking for intersection with any previous one and creating a new one if necessary.
     """
     for token in dropped_tokens:
         token_rect = BoundingBox(*token["bbox"])


### PR DESCRIPTION
We currently drop all table outputs that are not matched to tokens, but this is not required since we anyways chop the image after the DETR model. With this we aim to union back in outputs that did not fit into the original table structure, either by matching to existing cells, or creating new rows and columns for them. This is hidden behind a feature flag `table_extractor_options` that by default does not enable this until we are sure of no regressions.