### PR TITLE
Move tokenized data to device

### DIFF
--- a/lib/sycamore/sycamore/transforms/similarity.py
+++ b/lib/sycamore/sycamore/transforms/similarity.py
@@ -173,7 +173,7 @@ class HuggingFaceTransformersSimilarityScorer(SimilarityScorer):
 
                 tokenized = self._tokenizer(
                     input_batch, padding=True, truncation=True, return_tensors="pt", max_length=self.max_tokens
-                )
+                ).to(self.device)
                 scores.extend(
                     (
                         self._model(**tokenized, return_dict=True)


### PR DESCRIPTION
The tokenized data was living in the CPU (since tokenizer is only on the cpu), needed to move it to the gpu for scoring