### PR TITLE
Update vectorsearch query test

### DIFF
--- a/lib/sycamore/sycamore/tests/integration/query/execution/test_sycamore_query.py
+++ b/lib/sycamore/sycamore/tests/integration/query/execution/test_sycamore_query.py
@@ -1,5 +1,8 @@
 import pytest
 
+from sycamore import DocSet
+from sycamore.query.strategy import QueryPlanStrategy
+
 from sycamore.query.client import SycamoreQueryClient
 from sycamore.query.operators.query_database import QueryVectorDatabase
 
@@ -71,16 +74,15 @@ class TestSycamoreQuery:
     def test_vector_search(self, query_integration_test_index: str, codegen_mode: bool):
         """ """
 
-        client = SycamoreQueryClient()
+        client = SycamoreQueryClient(query_plan_strategy=QueryPlanStrategy())
         schema = client.get_opensearch_schema(query_integration_test_index)
         plan = client.generate_plan(
-            "were there any environmentally caused incidents?",
+            "give me some wind related incidents",
             query_integration_test_index,
             schema,
-            natural_language_response=True,
+            natural_language_response=False,
         )
-        assert len(plan.nodes) == 2
+        assert len(plan.nodes) == 1
         assert isinstance(plan.nodes[0], QueryVectorDatabase)
         result = client.run_plan(plan, codegen_mode=codegen_mode)
-        assert isinstance(result.result, str)
-        assert len(result.result) > 0
+        assert isinstance(result.result, DocSet)


### PR DESCRIPTION
The default planner would execute a rewrite rule that would prevent QueryVectorDatabase from ever being used in the test question's prompt. Updated the test to get more reliable usage. Obviously, still depends on the llms mood