### PR TITLE
Return the list of documents referenced in a Luna query.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For processing PDFs, Sycamore leverages the [Aryn Partitioning Service](https://
 
 The Aryn Partitioning Service takes PDFs and returns the partitioned output in JSON, and you can use Sycamore for additional data extraction, enrichment, transforms, cleaning, and loading into downstream databases. You can choose the LLMs to use with these transforms.
 
-Sycamore reliably loads your vector databases and hybrid search engines, including as OpenSearch, ElasticSearch, Pinecone, DuckDB and Weaviate, with higher quality data. 
+Sycamore reliably loads your vector databases and hybrid search engines, including as OpenSearch, ElasticSearch, Pinecone, DuckDB, Qdrant and Weaviate, with higher quality data. 
 
 The Sycamore framework is built around a scalable and robust abstraction for document processing called a DocSet, and includes powerful high-level transformations in Python for data processing, enrichment, and cleaning. DocSets also encapsulate scalable data processing techniques removing the undifferentiated heavy lifting of reliably loading chunks. DocSets' functional programming approach allows you to rapidly customize and experiment with your chunking for better quality RAG results.
 
@@ -41,7 +41,7 @@ Sycamore provides connectors to vector databases via Python extras. To install a
 
 ```pip install sycamore-ai[duckdb]```
 
-Supported connectors include `duckdb`, `elasticsearch`, `opensearch`, `pinecone`, and `weaviate`.
+Supported connectors include `duckdb`, `elasticsearch`, `opensearch`, `pinecone`, `qdrant`, and `weaviate`.
 
 To use the Aryn Partitioning Service, [sign-up for free here](https://www.aryn.ai/get-started) and use the API key.
 

--- a/apps/query-eval/queryeval/driver.py
+++ b/apps/query-eval/queryeval/driver.py
@@ -264,12 +264,13 @@ class QueryEvalDriver:
             else:
                 query_result.result = query_result.result.take_all()
             t2 = time.time()
-            result.result = self.format_docset(query_result.result)
+            result.result = [doc.data for doc in query_result.result]
         else:
             result.result = str(query_result.result)
             t2 = time.time()
         assert result.metrics
         result.metrics.query_time = t2 - t1
+        result.retrieved_docs = query_result.retrieved_docs()
 
         console.print(f"[green]:clock9: Executed query in {result.metrics.query_time:.2f} seconds")
         console.print(f":white_check_mark: Result: {result.result}")

--- a/apps/query-eval/queryeval/main.py
+++ b/apps/query-eval/queryeval/main.py
@@ -11,6 +11,7 @@
 #      data/ntsb-queries.yaml \
 #      run
 
+import tempfile
 from typing import Optional, Tuple
 
 import click
@@ -56,6 +57,11 @@ def cli(
     raw_output: bool,
 ):
     ctx.ensure_object(dict)
+
+    if not query_cache_path:
+        query_cache_path = tempfile.mkdtemp()
+    console.print(f"[yellow]Using query cache path: {query_cache_path}")
+
     driver = QueryEvalDriver(
         input_file_path=config_file,
         index=index,

--- a/apps/query-eval/queryeval/test_driver.py
+++ b/apps/query-eval/queryeval/test_driver.py
@@ -1,0 +1,89 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from queryeval.driver import QueryEvalDriver
+from queryeval.types import (
+    QueryEvalQuery,
+    QueryEvalResult,
+    QueryEvalMetrics,
+)
+from sycamore.query.result import SycamoreQueryResult
+from sycamore.query.logical_plan import LogicalPlan, Node
+
+
+@pytest.fixture
+def mock_client():
+    client = MagicMock()
+    client.get_opensearch_schema.return_value = {"field1": "text", "field2": "keyword"}
+    return client
+
+
+@pytest.fixture
+def mock_plan():
+    return LogicalPlan(query="test query", nodes={0: Node(node_id=0, node_type="test_op")}, result_node=0)
+
+
+@pytest.fixture
+def test_input_file(tmp_path):
+    input_file = tmp_path / "test_input.yaml"
+    input_file.write_text(
+        """
+config:
+  index: test-index
+  results_file: test-results.yaml
+queries:
+  - query: "test query 1"
+    tags: ["test"]
+  - query: "test query 2"
+"""
+    )
+    return str(input_file)
+
+
+def test_driver_init(test_input_file, mock_client):
+    with patch("queryeval.driver.SycamoreQueryClient", return_value=mock_client):
+        driver = QueryEvalDriver(input_file_path=test_input_file, index="test-index", doc_limit=10, tags=["test"])
+
+        assert driver.config.config.index == "test-index"
+        assert driver.config.config.doc_limit == 10
+        assert driver.config.config.tags == ["test"]
+        assert len(driver.config.queries) == 2
+
+
+def test_driver_do_plan(test_input_file, mock_client, mock_plan):
+    with patch("queryeval.driver.SycamoreQueryClient", return_value=mock_client):
+        driver = QueryEvalDriver(input_file_path=test_input_file)
+
+        query = QueryEvalQuery(query="test query")
+        result = QueryEvalResult(query=query, metrics=QueryEvalMetrics())
+
+        mock_client.generate_plan.return_value = mock_plan
+
+        result = driver.do_plan(query, result)
+        assert result.plan is not None
+        mock_client.generate_plan.assert_called_once()
+
+
+def test_driver_do_query(test_input_file, mock_client, mock_plan):
+    with patch("queryeval.driver.SycamoreQueryClient", return_value=mock_client):
+        driver = QueryEvalDriver(input_file_path=test_input_file)
+
+        query = QueryEvalQuery(query="test query")
+        result = QueryEvalResult(query=query, plan=mock_plan, metrics=QueryEvalMetrics())
+
+        mock_query_result = SycamoreQueryResult(query_id="test", plan=result.plan, result="test result")
+        mock_client.run_plan.return_value = mock_query_result
+
+        result = driver.do_query(query, result)
+        assert result.result == "test result"
+
+
+def test_driver_do_eval(test_input_file, mock_client, mock_plan):
+    with patch("queryeval.driver.SycamoreQueryClient", return_value=mock_client):
+        driver = QueryEvalDriver(input_file_path=test_input_file)
+
+        query = QueryEvalQuery(query="test query", expected_plan=mock_plan)
+        result = QueryEvalResult(query=query, plan=mock_plan)
+
+        result = driver.do_eval(query, result)
+        assert result.metrics.plan_similarity == 1.0

--- a/apps/query-eval/queryeval/types.py
+++ b/apps/query-eval/queryeval/types.py
@@ -1,7 +1,7 @@
 # This module defines types used for the config, input, and output
 # files for the Sycamore Query evaluator.
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, Set
 
 from pydantic import BaseModel
 
@@ -68,6 +68,7 @@ class QueryEvalResult(BaseModel):
     error: Optional[str] = None
     metrics: Optional[QueryEvalMetrics] = None
     notes: Optional[str] = None
+    retrieved_docs: Optional[Set[str]] = None
 
 
 class QueryEvalResultsFile(BaseModel):

--- a/lib/sycamore/sycamore/executor.py
+++ b/lib/sycamore/sycamore/executor.py
@@ -109,7 +109,7 @@ class Execution:
             for d in self.recursive_execute(plan):
                 yield d
         else:
-            assert False
+            raise ValueError(f"Unknown execution mode {self._exec_mode}")
 
         plan.traverse(visit=lambda n: n.finalize())
 

--- a/lib/sycamore/sycamore/query/client.py
+++ b/lib/sycamore/sycamore/query/client.py
@@ -225,7 +225,7 @@ class SycamoreQueryClient:
         index: str,
         dry_run: bool = False,
         codegen_mode: bool = False,
-    ) -> Any:
+    ) -> SycamoreQueryResult:
         """Run a query against the given index."""
         schema = self.get_opensearch_schema(index)
         plan = self.generate_plan(query, index, schema)

--- a/lib/sycamore/sycamore/query/client.py
+++ b/lib/sycamore/sycamore/query/client.py
@@ -13,7 +13,7 @@ import argparse
 import logging
 import os
 import uuid
-from typing import Any, List, Optional, Union
+from typing import List, Optional, Union
 
 import structlog
 import yaml

--- a/lib/sycamore/sycamore/query/result.py
+++ b/lib/sycamore/sycamore/query/result.py
@@ -1,10 +1,12 @@
 import io
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Set
 
 from pydantic import BaseModel
 
+import sycamore
 from sycamore.query.logical_plan import LogicalPlan
 from sycamore import DocSet
+from sycamore.transforms.dataset_scan import DatasetScan
 
 
 class NodeExecution(BaseModel):
@@ -52,3 +54,37 @@ class SycamoreQueryResult(BaseModel):
             return out.getvalue()
         else:
             return str(self.result)
+
+    def retrieved_docs(self) -> Set[str]:
+        """Return a set of Document paths for the documents retrieved by the query."""
+
+        context = sycamore.init()
+
+        if self.execution is None:
+            raise ValueError("No execution data available.")
+
+        # We want to return the set of documents from the deepest node in the query plan
+        # that yields "true" documents from the data source. To do this, we recurse up the query
+        # plan tree, collecting the set of documents from each node that has a trace directory
+        # and which contain documents with "path" properties.
+
+        def get_source_docs(context: sycamore.Context, node_id: int) -> Set[str]:
+            """Helper function to recursively retrieve the source document paths for a given node."""
+            if self.execution is not None and node_id in self.execution:
+                node_trace_dir = self.execution[node_id].trace_dir
+                if node_trace_dir:
+                    mds = context.read.materialize(node_trace_dir).filter(
+                        lambda doc: doc.properties.get("path") is not None
+                    )
+                    keep = mds.filter(lambda doc: doc.properties.get("path") is not None)
+                    if keep.count() > 0:
+                        return {doc.properties.get("path") for doc in keep.take_all()}
+
+            # Walk up the tree.
+            node = self.plan.nodes[node_id]
+            retval: Set[str] = set()
+            for input_node_id in node.inputs:
+                retval = retval.union(get_source_docs(context, input_node_id))
+            return retval
+
+        return get_source_docs(context, self.plan.result_node)

--- a/lib/sycamore/sycamore/query/result.py
+++ b/lib/sycamore/sycamore/query/result.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel
 import sycamore
 from sycamore.query.logical_plan import LogicalPlan
 from sycamore import DocSet
-from sycamore.transforms.dataset_scan import DatasetScan
 
 
 class NodeExecution(BaseModel):

--- a/lib/sycamore/sycamore/tests/unit/query/test_result.py
+++ b/lib/sycamore/sycamore/tests/unit/query/test_result.py
@@ -1,0 +1,151 @@
+from unittest.mock import patch, MagicMock
+import pytest
+
+import sycamore
+from sycamore.data import Document
+from sycamore.query.result import SycamoreQueryResult, NodeExecution
+from sycamore.query.logical_plan import LogicalPlan
+from sycamore.query.operators.query_database import QueryDatabase
+from sycamore.query.operators.count import Count
+from sycamore.query.operators.llm_filter import LlmFilter
+from sycamore.query.operators.math import Math
+
+
+@pytest.fixture
+def fake_docset():
+    """Return a docset with some fake documents."""
+    doc_dicts = [
+        {"doc_id": 1, "properties": {"path": "path1.txt"}},
+        {"doc_id": 2, "properties": {"path": "path2.txt"}},
+        {"doc_id": 3, "properties": {"path": "path3.txt"}},
+        {"doc_id": 4, "properties": {}},
+    ]
+    context = sycamore.init()
+    docset = context.read.document([Document(d) for d in doc_dicts])
+    return docset
+
+
+@pytest.fixture
+def fake_docset_2():
+    """Return a second docset with some fake documents."""
+    doc_dicts = [
+        {"doc_id": 5, "properties": {"path": "path5.txt"}},
+        {"doc_id": 6, "properties": {"path": "path6.txt"}},
+        {"doc_id": 3, "properties": {"path": "path3.txt"}},  # Intentional Duplicate.
+        {"doc_id": 8, "properties": {}},
+    ]
+    context = sycamore.init()
+    docset = context.read.document([Document(d) for d in doc_dicts])
+    return docset
+
+
+def test_get_source_docs(fake_docset):
+    """Test that get_source_docs returns the correct set of documents."""
+
+    plan = LogicalPlan(
+        query="Dummy query",
+        result_node=1,
+        nodes={
+            0: QueryDatabase(
+                node_id=0,
+                description="Get all the airplane incidents",
+                index="ntsb",
+                query={"match_all": {}},
+            ),
+            1: Count(
+                node_id=1,
+                description="Count the number of incidents",
+                field=None,
+                inputs=[0],
+            ),
+        },
+    )
+
+    execution = {
+        0: NodeExecution(node_id=0, trace_dir="test_trace_dir_0"),
+        1: NodeExecution(node_id=1, trace_dir="test_trace_dir_1"),
+    }
+
+    def mock_materialize_result(trace_dir):
+        if trace_dir == "test_trace_dir_1":
+            return fake_docset
+        else:
+            return None
+
+    context = sycamore.init()
+    mock_context = MagicMock(wraps=context)
+    mock_context.exec_mode = sycamore.ExecMode.RAY
+    mock_context.read.materialize.side_effect = mock_materialize_result
+    with patch("sycamore.init", return_value=mock_context):
+        result = SycamoreQueryResult(
+            query_id="test_query_id", plan=plan, result="Test query result", execution=execution
+        )
+        retrieved_docs = result.retrieved_docs()
+
+    assert retrieved_docs == {"path1.txt", "path2.txt", "path3.txt"}
+
+
+def test_get_source_docs_complex(fake_docset, fake_docset_2):
+    """Test that get_source_docs returns the correct set of documents for a complex query plan."""
+
+    plan = LogicalPlan(
+        query="Dummy query",
+        result_node=5,
+        nodes={
+            0: QueryDatabase(
+                node_id=0,
+                description="Get all the airplane incidents",
+                index="ntsb",
+                query={"match_all": {}},
+            ),
+            1: LlmFilter(
+                node_id=1,
+                description="Filter by test_field_1",
+                inputs=[0],
+                field="test_field_1",
+                question="test_question",
+            ),
+            2: Count(node_id=2, description="Test count 1", field=None, inputs=[1]),
+            3: LlmFilter(
+                node_id=3,
+                description="Filter by test_field_2",
+                inputs=[0],
+                field="test_field_2",
+                question="test_question",
+            ),
+            4: Count(node_id=4, description="Test count 2", field=None, inputs=[3]),
+            5: Math(node_id=5, description="Sum counts", operation="add", inputs=[2, 4]),
+        },
+    )
+
+    execution = {
+        0: NodeExecution(node_id=0, trace_dir="test_trace_dir_0"),
+        1: NodeExecution(node_id=1, trace_dir="test_trace_dir_1"),
+        2: NodeExecution(node_id=2, trace_dir=None),
+        3: NodeExecution(node_id=3, trace_dir="test_trace_dir_3"),
+        4: NodeExecution(node_id=4, trace_dir=None),
+        5: NodeExecution(node_id=5, trace_dir=None),
+    }
+
+    def mock_materialize_result(trace_dir):
+        if trace_dir == "test_trace_dir_1":
+            return fake_docset
+        elif trace_dir == "test_trace_dir_3":
+            return fake_docset_2
+        else:
+            return None
+
+    context = sycamore.init()
+    mock_context = MagicMock(wraps=context)
+    mock_context.exec_mode = sycamore.ExecMode.RAY
+    mock_context.read.materialize.side_effect = mock_materialize_result
+    with patch("sycamore.init", return_value=mock_context):
+        result = SycamoreQueryResult(
+            query_id="test_query_id", plan=plan, result="Test query result", execution=execution
+        )
+        retrieved_docs = result.retrieved_docs()
+
+    print(f"\nMDW: retrieved_docs is {retrieved_docs}")
+
+    assert mock_context.read.materialize.call_count == 2
+    assert retrieved_docs == {"path1.txt", "path2.txt", "path3.txt", "path5.txt", "path6.txt"}


### PR DESCRIPTION
This PR adds logic to `SycamoreQueryResult` to return the list of Document paths referenced by the query.

The idea here is to provide a "reasonably selective" set of documents that a query is using in generating its final response. To this end we walk the query tree from the result node up and return the set of docs from the first node (or set of nodes) that return docs, rather than those that return non-doc values (like text chunks or singleton values).

This PR also adds the resulting set to the response returned in `query-server`.

I ended up changing how this worked a bit from @baitsguy's previous implementation (in a private repo).