### PR TITLE
Remove seed from rewrite prompt

### DIFF
--- a/lib/sycamore/sycamore/query/strategy.py
+++ b/lib/sycamore/sycamore/query/strategy.py
@@ -133,7 +133,7 @@ class RemoveVectorSearchForAnalytics(LogicalPlanProcessor):
         ]
 
         prompt_kwargs = {"messages": messages}
-        chat_completion = self.llm.generate(prompt_kwargs=prompt_kwargs, llm_kwargs={"temperature": 0, "seed": 42})
+        chat_completion = self.llm.generate(prompt_kwargs=prompt_kwargs, llm_kwargs={"temperature": 0})
         return chat_completion
 
 


### PR DESCRIPTION
Not all LLMs support seed, and we're seeing validation errors from the unsupported LLMs for this. The param should be moved to the LLM implementation if someone wants to use it.