### PR TITLE
Fix OpenAI __reduce__ methods to handle Azure deployment names.

### DIFF
--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -358,7 +358,7 @@ class OpenAI(LLM):
     # recreate the client on the other end.
     def __reduce__(self):
 
-        kwargs = {"client_wrapper": self.client_wrapper, "model_name": self._model_name, "cache": self._cache}
+        kwargs = {"client_wrapper": self.client_wrapper, "model_name": self.model, "cache": self._cache}
 
         return openai_deserializer, (kwargs,)
 

--- a/lib/sycamore/sycamore/tests/integration/llms/test_openai.py
+++ b/lib/sycamore/sycamore/tests/integration/llms/test_openai.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+import pickle
+import pytest
 
 from sycamore.llms import OpenAI, OpenAIModels, OpenAIClientWrapper
 from sycamore.llms.openai import OpenAIModel, OpenAIClientType
@@ -190,9 +192,11 @@ def test_openai_defaults_guidance_instruct():
     assert len(res) > 0
 
 
-def test_azure_defaults_guidance_chat():
-    llm = OpenAI(
-        # Note this deployment name is different from the official model name, which has a '.'
+@pytest.fixture(scope="module")
+def azure_llm():
+    # Note this deployment name is different from the official model name, which has a '.'
+
+    return OpenAI(
         OpenAIModel("gpt-35-turbo", is_chat=True),
         client_wrapper=OpenAIClientWrapper(
             client_type=OpenAIClientType.AZURE,
@@ -201,22 +205,20 @@ def test_azure_defaults_guidance_chat():
         ),
     )
 
+
+def test_azure_defaults_guidance_chat(azure_llm):
     prompt_kwargs = {"prompt": TestPrompt()}
-    res = llm.generate(prompt_kwargs=prompt_kwargs)
+    res = azure_llm.generate(prompt_kwargs=prompt_kwargs)
     assert len(res) > 0
 
 
-def test_azure_defaults_guidance_instruct():
-    llm = OpenAI(
-        # Note this deployment name is different from the official model name, which has a '.'
-        OpenAIModel("gpt-35-turbo-instruct", is_chat=False),
-        client_wrapper=OpenAIClientWrapper(
-            client_type=OpenAIClientType.AZURE,
-            azure_endpoint="https://aryn.openai.azure.com",
-            api_version="2024-02-15-preview",
-        ),
-    )
-
+def test_azure_defaults_guidance_instruct(azure_llm):
     prompt_kwargs = {"prompt": TestPrompt()}
-    res = llm.generate(prompt_kwargs=prompt_kwargs)
+    res = azure_llm.generate(prompt_kwargs=prompt_kwargs)
     assert len(res) > 0
+
+
+def test_azure_pickle(azure_llm):
+    pickled = pickle.dumps(azure_llm)
+    _ = pickle.loads(pickled)
+    assert True


### PR DESCRIPTION
There was a bug in how we pickled OpenAI class instances specifically with Azure. Azure OpenAI is a bit weird in that the "deployment name" of a model can be different than the normal OpenAI name. This makes it impossible to use the standard models from the OpenAIModels Enum. Instead, we typically created separate OpenAIModel instances. The problem was that when we pickled the OpenAI object, it saved just the model name, and then tried to recreate the model option by using the Enum. This change pickles the entire OpenAIModel class instead of just the name. Also adds a test that demonstrates the bug (and fix). The other tests were passing because they called the OpenAI methods directly and didn't pickle the object. The object will be pickled in basically any Sycamore job using ray.