### PR TITLE
Fix mixed samples for schema extraction.

### DIFF
--- a/lib/sycamore/sycamore/query/schema.py
+++ b/lib/sycamore/sycamore/query/schema.py
@@ -81,6 +81,7 @@ class OpenSearchSchemaFetcher:
                 logger.debug(f"  Attempting to get samples for key {key}")
                 samples: set[str] = set()
                 sample_type: Optional[type] = None
+                warnings: Dict[str, bool] = {}
                 for sample in random_sample:
                     if len(samples) >= self.NUM_EXAMPLE_VALUES:
                         break
@@ -108,10 +109,12 @@ class OpenSearchSchemaFetcher:
                                 samples = {str([x]) for x in samples}
                             elif sample_type != t:
                                 # We have an incompatible type, so promote it to string.
-                                logger.warning(
-                                    "Got multiple sample types for schema field"
-                                    + f" {key}: {sample_type} and {t}. Promoting to str."
-                                )
+                                if key not in warnings:
+                                    logger.warning(
+                                        "Got multiple sample types for schema field"
+                                        + f" {key}: {sample_type} and {t}. Promoting to str."
+                                    )
+                                    warnings[key] = True
                                 sample_type = str
                                 samples = {str(x) for x in samples}
 

--- a/lib/sycamore/sycamore/tests/unit/query/test_schema.py
+++ b/lib/sycamore/sycamore/tests/unit/query/test_schema.py
@@ -131,6 +131,17 @@ def test_opensearch_schema():
                             }
                         }
                     },
+                    {
+                        "_source": {
+                            "properties": {
+                                "entity": {
+                                    "day": "2021-01-02",
+                                    "aircraft": "Flight b741",
+                                    "airspeed": 74.1,
+                                }
+                            }
+                        }
+                    },
                 ]
             }
         }
@@ -150,7 +161,7 @@ def test_opensearch_schema():
     assert got.fields["properties.entity.day"].field_type == "<class 'str'>"
     assert set(got.fields["properties.entity.day"].examples) == {"2021-01-01", "2021-01-02"}
     assert got.fields["properties.entity.aircraft"].field_type == "<class 'str'>"
-    assert set(got.fields["properties.entity.aircraft"].examples) == {"Boeing 747", "Airbus A380"}
+    assert set(got.fields["properties.entity.aircraft"].examples) == {"Boeing 747", "Airbus A380", "Flight b741"}
     assert got.fields["properties.entity.weather"] == OpenSearchSchemaField(
         field_type="<class 'str'>", examples=["Sunny"]
     )
@@ -166,7 +177,7 @@ def test_opensearch_schema():
 
     # Ints get promoted to floats when there is a mix of sample values.
     assert got.fields["properties.entity.airspeed"].field_type == "<class 'float'>"
-    assert set(got.fields["properties.entity.airspeed"].examples) == {"41.5", "42", "48"}
+    assert set(got.fields["properties.entity.airspeed"].examples) == {"41.5", "42", "48", "74.1"}
 
     # Ints stay ints when there is no mix.
     assert got.fields["properties.entity.count"].field_type == "<class 'int'>"

--- a/lib/sycamore/sycamore/tests/unit/query/test_schema.py
+++ b/lib/sycamore/sycamore/tests/unit/query/test_schema.py
@@ -43,10 +43,22 @@ def test_opensearch_schema():
                         "colors": {"type": "array", "fields": {"keyword": {"type": "keyword", "ignore_above": 256}}}
                     },
                 },
+                "properties.entity.flavors": {
+                    "full_name": "properties.entity.flavors",
+                    "mapping": {
+                        "flavors": {"type": "array", "fields": {"keyword": {"type": "keyword", "ignore_above": 256}}}
+                    },
+                },
                 "properties.entity.airspeed": {
                     "full_name": "properties.entity.airspeed",
                     "mapping": {
                         "airspeed": {"type": "array", "fields": {"keyword": {"type": "keyword", "ignore_above": 256}}}
+                    },
+                },
+                "properties.entity.count": {
+                    "full_name": "properties.entity.count",
+                    "mapping": {
+                        "count": {"type": "array", "fields": {"keyword": {"type": "keyword", "ignore_above": 256}}}
                     },
                 },
                 "properties.entity.weird": {
@@ -74,7 +86,15 @@ def test_opensearch_schema():
                     {
                         "_source": {
                             "properties": {
-                                "entity": {"day": "2021-01-01", "aircraft": "Boeing 747", "colors": ["red", "blue"]},
+                                "entity": {
+                                    "day": "2021-01-01",
+                                    "aircraft": "Boeing 747",
+                                    "colors": ["red", "blue"],
+                                    "flavors": "vanilla",
+                                    "airspeed": 42,
+                                    "count": 3,
+                                    "weird": True,
+                                },
                                 "happiness": "yes",
                             }
                         }
@@ -87,6 +107,26 @@ def test_opensearch_schema():
                                     "aircraft": "Airbus A380",
                                     "weather": "Sunny",
                                     "colors": [],
+                                    "flavors": ["chocolate", "strawberry"],
+                                    "airspeed": 41.5,
+                                    "count": 0,
+                                    "weird": 500,
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "_source": {
+                            "properties": {
+                                "entity": {
+                                    "day": "2021-01-02",
+                                    "aircraft": "Airbus A380",
+                                    "weather": "Sunny",
+                                    "colors": "yellow",
+                                    "flavors": "banana",
+                                    "airspeed": 48,
+                                    "count": 67,
+                                    "weird": "alphabetical",
                                 }
                             }
                         }
@@ -95,16 +135,6 @@ def test_opensearch_schema():
             }
         }
     }
-
-    # Verify we can handle schemas where int and float are both used
-    airspeeds = [500, 37.5, 300, 217.11]
-    for i in airspeeds:
-        mock_random_sample["result"]["hits"]["hits"].append({"_source": {"properties": {"entity": {"airspeed": i}}}})
-
-    # Verify we tolerate schemas where the types are incompatible
-    weird = [True, 500, "alphabetical"]
-    for i in weird:
-        mock_random_sample["result"]["hits"]["hits"].append({"_source": {"properties": {"entity": {"weird": i}}}})
 
     # this is asserting we only take OpenSearchSchemaFetcher.NUM_EXAMPLE_VALUES examples
     for i in range(0, OpenSearchSchemaFetcher.NUM_EXAMPLE_VALUES + 5):
@@ -124,15 +154,30 @@ def test_opensearch_schema():
     assert got.fields["properties.entity.weather"] == OpenSearchSchemaField(
         field_type="<class 'str'>", examples=["Sunny"]
     )
+
+    # A mix of lists and singletons gets promoted to a list.
     assert got.fields["properties.entity.colors"].field_type == "<class 'list'>"
-    assert set(got.fields["properties.entity.colors"].examples) == {"['red', 'blue']", "[]"}
+    assert set(got.fields["properties.entity.colors"].examples) == {"['red', 'blue']", "[]", "['yellow']"}
+
     assert got.fields["properties.entity.test_prop"].field_type == "<class 'str'>"
     assert set(got.fields["properties.entity.test_prop"].examples) == {
         str(i) for i in range(OpenSearchSchemaFetcher.NUM_EXAMPLE_VALUES)
     }
+
+    # Ints get promoted to floats when there is a mix of sample values.
     assert got.fields["properties.entity.airspeed"].field_type == "<class 'float'>"
-    assert set(got.fields["properties.entity.airspeed"].examples) == {str(a) for a in airspeeds}
-    assert got.fields["properties.entity.weird"].field_type == "<class 'bool'>"
-    assert set(got.fields["properties.entity.weird"].examples) == {str(w) for w in weird}
+    assert set(got.fields["properties.entity.airspeed"].examples) == {"41.5", "42", "48"}
+
+    # Ints stay ints when there is no mix.
+    assert got.fields["properties.entity.count"].field_type == "<class 'int'>"
+    assert set(got.fields["properties.entity.count"].examples) == {"3", "0", "67"}
+
+    # Mixed type gets promoted to string.
+    assert got.fields["properties.entity.weird"].field_type == "<class 'str'>"
+    assert set(got.fields["properties.entity.weird"].examples) == {"500", "True", "alphabetical"}
+
+    # Check that fields with a single sample are retained.
     assert got.fields["properties.happiness"] == OpenSearchSchemaField(field_type="<class 'str'>", examples=["yes"])
+
+    # Check that fields with no samples are ignored.
     assert "properties.entity.location" not in got.fields


### PR DESCRIPTION
This PR fixes issues where the samples retrieved from OpenSearch are mixed in terms of their types. It addresses two cases:

* In cases where there is a mix of singleton and list types, we promote to a list.
* In cases where there is a mix of singleton types (e.g., bools and ints), we promote to string.

