### PR TITLE
Improve suggested install command

### DIFF
--- a/lib/sycamore/sycamore/utils/import_utils.py
+++ b/lib/sycamore/sycamore/utils/import_utils.py
@@ -26,7 +26,7 @@ def import_modules(modules: Union[str, list[str]], extra: Optional[str] = None):
     if len(missing) > 0:
         msg = f"Unable to locate modules: {missing}."
         if extra is not None:
-            msg += f" Please install using `pip install sycamore-ai[{extra}]`"
+            msg += f' Please install using `pip install "sycamore-ai[{extra}]"`'
         else:
             msg += f" Please install using `pip install {','.join(missing)}`"
 


### PR DESCRIPTION
people see, copy, and paste `pip install sycamore-ai[extra]` in the requires_module error message and then get zsh errors bc they need to quote it.