### PR TITLE
Sort retrieval docs by score properties if they exist

### DIFF
--- a/apps/query-eval/queryeval/driver.py
+++ b/apps/query-eval/queryeval/driver.py
@@ -336,15 +336,15 @@ class QueryEvalDriver:
         elif not result.retrieved_docs:
             console.print("[yellow]:construction: No computed document list found, skipping.. ")
         else:
-            if query.expected_docs.issubset(result.retrieved_docs):
-                console.print("[green]✔ Documents retrieved match")
+            expected_doc_set = set(query.expected_docs)
+            retrieved_doc_set = set(result.retrieved_docs)
+            if expected_doc_set.issubset(retrieved_doc_set):
+                console.print("[green]✔ Documents retrieved include expected docs")
             else:
-                console.print("[red]:x: Document retrieval mismatch")
-                console.print(f"Missing docs: {query.expected_docs - result.retrieved_docs})")
-            metrics.doc_retrieval_recall = len(result.retrieved_docs & query.expected_docs) / len(query.expected_docs)
-            metrics.doc_retrieval_precision = len(result.retrieved_docs & query.expected_docs) / len(
-                result.retrieved_docs
-            )
+                console.print("[red]:x: Documents retrieved don't include all expected docs")
+                console.print(f"Missing docs: {expected_doc_set - retrieved_doc_set})")
+            metrics.doc_retrieval_recall = len(retrieved_doc_set & expected_doc_set) / len(expected_doc_set)
+            metrics.doc_retrieval_precision = len(retrieved_doc_set & expected_doc_set) / len(result.retrieved_docs)
 
         # Evaluate result
         if not result.result:

--- a/apps/query-eval/queryeval/test-results.yaml
+++ b/apps/query-eval/queryeval/test-results.yaml
@@ -1,5 +1,5 @@
 config:
-  config_file: /private/var/folders/rd/5lfl86jj2yb3gn2zwwgqjgrc0000gn/T/pytest-of-vinayakthapliyal/pytest-108/test_driver_do_query0/test_input.yaml
+  config_file: /private/var/folders/rd/5lfl86jj2yb3gn2zwwgqjgrc0000gn/T/pytest-of-vinayakthapliyal/pytest-110/test_driver_do_query0/test_input.yaml
   doc_limit: null
   dry_run: false
   index: test-index

--- a/apps/query-eval/queryeval/test_driver.py
+++ b/apps/query-eval/queryeval/test_driver.py
@@ -58,7 +58,7 @@ def test_driver_init(test_input_file, mock_client):
         assert driver.config.config.doc_limit == 10
         assert driver.config.queries[0].tags == ["test"]
         assert driver.config.queries[1].tags is None
-        assert driver.config.queries[0].expected_docs == {"doc1.pdf", "doc2.pdf"}
+        assert driver.config.queries[0].expected_docs == ["doc1.pdf", "doc2.pdf"]
         assert driver.config.queries[1].expected_docs is None
 
 

--- a/apps/query-eval/queryeval/types.py
+++ b/apps/query-eval/queryeval/types.py
@@ -1,7 +1,7 @@
 # This module defines types used for the config, input, and output
 # files for the Sycamore Query evaluator.
 
-from typing import Any, Dict, List, Optional, Union, Set
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel
 
@@ -33,7 +33,7 @@ class QueryEvalQuery(BaseModel):
     query: str
     expected: Optional[Union[str, List[Dict[str, Any]]]] = None
     expected_plan: Optional[LogicalPlan] = None
-    expected_docs: Optional[Set[str]] = None
+    expected_docs: Optional[list[str]] = None
     plan: Optional[LogicalPlan] = None
     tags: Optional[List[str]] = None
     notes: Optional[str] = None
@@ -78,7 +78,7 @@ class QueryEvalResult(BaseModel):
     error: Optional[str] = None
     metrics: Optional[QueryEvalMetrics] = None
     notes: Optional[str] = None
-    retrieved_docs: Optional[Set[str]] = None
+    retrieved_docs: Optional[list[str]] = None
 
 
 class QueryEvalResultsFile(BaseModel):

--- a/apps/query-server/queryserver/main.py
+++ b/apps/query-server/queryserver/main.py
@@ -46,7 +46,7 @@ class QueryResult(BaseModel):
 
     plan: LogicalPlan
     result: Any
-    retrieved_docs: Set[str]
+    retrieved_docs: list[str]
 
 
 @app.get("/v1/indices")

--- a/apps/query-server/queryserver/main.py
+++ b/apps/query-server/queryserver/main.py
@@ -5,7 +5,7 @@
 
 import os
 import tempfile
-from typing import Annotated, Any, List, Optional, Set
+from typing import Annotated, Any, List, Optional
 
 from fastapi import FastAPI, Path
 from pydantic import BaseModel

--- a/lib/sycamore/sycamore/query/result.py
+++ b/lib/sycamore/sycamore/query/result.py
@@ -102,7 +102,7 @@ class SycamoreQueryResult(BaseModel):
 
             # Walk up the tree.
             node = self.plan.nodes[node_id]
-            retval = OrderedDict()
+            retval: OrderedDict = OrderedDict()
             for input_node_id in node.inputs:
                 for path in get_source_docs(context, input_node_id):
                     retval[path] = None  # Using None as a placeholder value

--- a/lib/sycamore/sycamore/query/result.py
+++ b/lib/sycamore/sycamore/query/result.py
@@ -87,8 +87,8 @@ class SycamoreQueryResult(BaseModel):
                     try:
                         mds = context.read.materialize(node_trace_dir)
                         keep = mds.filter(lambda doc: doc.properties.get("path") is not None)
-                        if keep.count() > 0:
-                            results = keep.take_all()
+                        results = keep.take_all()
+                        if len(results) > 0:
                             for prop in sort_by_properties:
                                 results = sorted(
                                     results, key=lambda doc: doc.properties.get(prop, float("-inf")), reverse=True

--- a/lib/sycamore/sycamore/query/result.py
+++ b/lib/sycamore/sycamore/query/result.py
@@ -1,5 +1,6 @@
 import io
-from typing import Any, Dict, Optional, Set
+from collections import OrderedDict
+from typing import Any, Dict, Optional
 
 from pydantic import BaseModel
 
@@ -54,7 +55,7 @@ class SycamoreQueryResult(BaseModel):
         else:
             return str(self.result)
 
-    def retrieved_docs(self) -> Set[str]:
+    def retrieved_docs(self) -> list[str]:
         """Return a set of Document paths for the documents retrieved by the query."""
 
         context = sycamore.init()
@@ -67,8 +68,19 @@ class SycamoreQueryResult(BaseModel):
         # plan tree, collecting the set of documents from each node that has a trace directory
         # and which contain documents with "path" properties.
 
-        def get_source_docs(context: sycamore.Context, node_id: int) -> Set[str]:
-            """Helper function to recursively retrieve the source document paths for a given node."""
+        def get_source_docs(context: sycamore.Context, node_id: int, sort_by_properties=None) -> list[str]:
+            """Helper function to recursively retrieve the source document paths for a given node.
+
+            Args:
+                context: The Sycamore context used to read and materialize documents.
+                node_id: The ID of the node in the query plan, typically the result node if you want docs for the query.
+                sort_by_properties: A list of properties to sort the documents by. defaults: ["score", "_rerank_score"].
+
+            Returns:
+                A list of unique document paths sorted by the specified properties.
+            """
+            if sort_by_properties is None:
+                sort_by_properties = ["score", "_rerank_score"]
             if self.execution is not None and node_id in self.execution:
                 node_trace_dir = self.execution[node_id].trace_dir
                 if node_trace_dir:
@@ -76,7 +88,13 @@ class SycamoreQueryResult(BaseModel):
                         mds = context.read.materialize(node_trace_dir)
                         keep = mds.filter(lambda doc: doc.properties.get("path") is not None)
                         if keep.count() > 0:
-                            return {doc.properties.get("path") for doc in keep.take_all()}
+                            results = keep.take_all()
+                            for prop in sort_by_properties:
+                                results = sorted(
+                                    results, key=lambda doc: doc.properties.get(prop, float("-inf")), reverse=True
+                                )
+                            unique_paths = OrderedDict((doc.properties.get("path"), None) for doc in results)
+                            return list(unique_paths.keys())
                     except ValueError:
                         # This can happen if the materialize directory is empty.
                         # Ignore and move onto the next node.
@@ -84,9 +102,10 @@ class SycamoreQueryResult(BaseModel):
 
             # Walk up the tree.
             node = self.plan.nodes[node_id]
-            retval: Set[str] = set()
+            retval = OrderedDict()
             for input_node_id in node.inputs:
-                retval = retval.union(get_source_docs(context, input_node_id))
-            return retval
+                for path in get_source_docs(context, input_node_id):
+                    retval[path] = None  # Using None as a placeholder value
+            return list(retval.keys())
 
         return get_source_docs(context, self.plan.result_node)

--- a/lib/sycamore/sycamore/tests/unit/query/test_result.py
+++ b/lib/sycamore/sycamore/tests/unit/query/test_result.py
@@ -12,13 +12,14 @@ from sycamore.query.operators.math import Math
 
 
 @pytest.fixture
-def fake_docset():
-    """Return a docset with some fake documents."""
+def fake_docset_with_scores():
+    """Return a docset with some fake documents with ranking scores."""
     doc_dicts = [
-        {"doc_id": 1, "properties": {"path": "path1.txt"}},
-        {"doc_id": 2, "properties": {"path": "path2.txt"}},
-        {"doc_id": 3, "properties": {"path": "path3.txt"}},
-        {"doc_id": 4, "properties": {}},
+        {"doc_id": 1, "properties": {"path": "path1.txt", "_rerank_score": 1, "score": 10}},
+        {"doc_id": 2, "properties": {"path": "path2.txt", "_rerank_score": 5}},
+        {"doc_id": 3, "properties": {"path": "path3.txt", "score": 3}},
+        {"doc_id": 4, "properties": {"path": "path4.txt", "score": 9}},
+        {"doc_id": 5, "properties": {"score": 4}},
     ]
     context = sycamore.init()
     docset = context.read.document([Document(d) for d in doc_dicts])
@@ -39,7 +40,7 @@ def fake_docset_2():
     return docset
 
 
-def test_get_source_docs(fake_docset):
+def test_get_source_docs(fake_docset_with_scores):
     """Test that get_source_docs returns the correct set of documents."""
 
     plan = LogicalPlan(
@@ -68,7 +69,7 @@ def test_get_source_docs(fake_docset):
 
     def mock_materialize_result(trace_dir):
         if trace_dir == "test_trace_dir_1":
-            return fake_docset
+            return fake_docset_with_scores
         else:
             return None
 
@@ -82,10 +83,10 @@ def test_get_source_docs(fake_docset):
         )
         retrieved_docs = result.retrieved_docs()
 
-    assert retrieved_docs == {"path1.txt", "path2.txt", "path3.txt"}
+    assert ["path2.txt", "path1.txt", "path4.txt", "path3.txt"] == retrieved_docs
 
 
-def test_get_source_docs_complex(fake_docset, fake_docset_2):
+def test_get_source_docs_complex(fake_docset_with_scores, fake_docset_2):
     """Test that get_source_docs returns the correct set of documents for a complex query plan."""
 
     plan = LogicalPlan(
@@ -129,7 +130,7 @@ def test_get_source_docs_complex(fake_docset, fake_docset_2):
 
     def mock_materialize_result(trace_dir):
         if trace_dir == "test_trace_dir_1":
-            return fake_docset
+            return fake_docset_with_scores
         elif trace_dir == "test_trace_dir_3":
             return fake_docset_2
         else:
@@ -148,4 +149,4 @@ def test_get_source_docs_complex(fake_docset, fake_docset_2):
     print(f"\nMDW: retrieved_docs is {retrieved_docs}")
 
     assert mock_context.read.materialize.call_count == 2
-    assert retrieved_docs == {"path1.txt", "path2.txt", "path3.txt", "path5.txt", "path6.txt"}
+    assert retrieved_docs == ["path2.txt", "path1.txt", "path4.txt", "path3.txt", "path5.txt", "path6.txt"]


### PR DESCRIPTION
When trying to retrieve docs for a query, we return them in a descending sorted order by a list of properties you can specify. It defaults to using "score" (from opensearch results), and "_rerank_score" (if a rerank operation was run)