### PR TITLE
Queryeval docset write fix

### DIFF
--- a/apps/query-eval/queryeval/driver.py
+++ b/apps/query-eval/queryeval/driver.py
@@ -187,8 +187,14 @@ class QueryEvalDriver:
                 if hasattr(doc.data, "model_dump"):
                     results.append(doc.data.model_dump())
                 else:
-                    results.append(DocumentSummary(doc_id=doc.doc_id, path=doc.properties.get("path")))
-        return DocSetSummary(documents=results)
+                    results.append(
+                        DocumentSummary(
+                            doc_id=doc.doc_id,
+                            path=doc.properties.get("path"),
+                            text_representation=doc.text_representation,
+                        )
+                    )
+        return DocSetSummary(docs=results)
 
     def get_result(self, query: QueryEvalQuery) -> Optional[QueryEvalResult]:
         """Get the existing result for the query, or return a new result object."""

--- a/apps/query-eval/queryeval/types.py
+++ b/apps/query-eval/queryeval/types.py
@@ -69,7 +69,7 @@ class QueryEvalMetrics(BaseModel):
 
 
 class DocumentSummary(BaseModel):
-    """Represents a writeable Document for serialization."""
+    """Represents a serializable Document summary."""
 
     doc_id: Optional[str] = None
     text_representation: Optional[str] = None
@@ -77,7 +77,7 @@ class DocumentSummary(BaseModel):
 
 
 class DocSetSummary(BaseModel):
-    """Represents a writeable DocSet for serialization."""
+    """Represents a serializable DocSet."""
 
     docs: list[Any] = []
 

--- a/apps/query-eval/queryeval/types.py
+++ b/apps/query-eval/queryeval/types.py
@@ -68,6 +68,19 @@ class QueryEvalMetrics(BaseModel):
     similarity_score: Optional[float] = None
 
 
+class DocumentSummary(BaseModel):
+    """Represents a writeable Document for serialization."""
+
+    doc_id: Optional[str] = None
+    path: Optional[str] = None
+
+
+class DocSetSummary(BaseModel):
+    """Represents a writeable DocSet for serialization."""
+
+    docs: list[Any] = []
+
+
 class QueryEvalResult(BaseModel):
     """Represents a single result for running a query."""
 

--- a/apps/query-eval/queryeval/types.py
+++ b/apps/query-eval/queryeval/types.py
@@ -72,6 +72,7 @@ class DocumentSummary(BaseModel):
     """Represents a writeable Document for serialization."""
 
     doc_id: Optional[str] = None
+    text_representation: Optional[str] = None
     path: Optional[str] = None
 
 
@@ -87,7 +88,7 @@ class QueryEvalResult(BaseModel):
     timestamp: Optional[str] = None
     query: QueryEvalQuery
     plan: Optional[LogicalPlan] = None
-    result: Optional[Union[str, List[Dict[str, Any]]]] = None
+    result: Optional[Union[str, DocSetSummary]] = None
     error: Optional[str] = None
     metrics: Optional[QueryEvalMetrics] = None
     notes: Optional[str] = None


### PR DESCRIPTION
When we started returning raw results as part of QueryResult writing to yaml was broken because it could only handle pydantic types. Added some types with simple doc level fields 