### PR TITLE
Updated NTSB queries and ground truth for CIDR-25 paper.

### DIFF
--- a/apps/query-eval/data/ntsb-full.yaml
+++ b/apps/query-eval/data/ntsb-full.yaml
@@ -389,12 +389,14 @@ queries:
       Tennessee: 1
     tags:
       - verified_ground_truth
+      - need_to_check
 
   - query: "How many incidents involved student pilots?"
     # Need ground truth answer.
     expected: "XXX"
     tags:
       - need_ground_truth
+      - need_to_check
 
   - query: "How many incidents involved a wind speed over 10 knots?"
     expected: "16"
@@ -413,6 +415,7 @@ queries:
       AIR TRACTOR INC AT-402
     tags:
       - verified_ground_truth
+      - need_to_check
 
   - query: "What was the breakdown of incidents by month?"
     expected: |
@@ -487,6 +490,7 @@ queries:
       Zenith Aircraft Company: 2
     tags:
       - verified_ground_truth
+      - need_to_check
 
   - query: "Which incidents occurred in July involving birds?"
     expected: |

--- a/apps/query-eval/data/ntsb-full.yaml
+++ b/apps/query-eval/data/ntsb-full.yaml
@@ -389,14 +389,12 @@ queries:
       Tennessee: 1
     tags:
       - verified_ground_truth
-      - need_to_check
 
   - query: "How many incidents involved student pilots?"
     # Need ground truth answer.
     expected: "XXX"
     tags:
       - need_ground_truth
-      - need_to_check
 
   - query: "How many incidents involved a wind speed over 10 knots?"
     expected: "16"
@@ -415,7 +413,6 @@ queries:
       AIR TRACTOR INC AT-402
     tags:
       - verified_ground_truth
-      - need_to_check
 
   - query: "What was the breakdown of incidents by month?"
     expected: |
@@ -423,15 +420,6 @@ queries:
       July 2024: 36
       August 2024: 17
       September 2024: 5
-    tags:
-      - verified_ground_truth
-
-  - query: "What was the breakdown of incidents by month, expressed as MM/YY?"
-    expected: |
-      06/24: 42
-      07/24: 36
-      08/24: 17
-      09/24: 5
     tags:
       - verified_ground_truth
 
@@ -490,7 +478,6 @@ queries:
       Zenith Aircraft Company: 2
     tags:
       - verified_ground_truth
-      - need_to_check
 
   - query: "Which incidents occurred in July involving birds?"
     expected: |
@@ -569,22 +556,49 @@ queries:
     tags:
       - need_ground_truth
 
-  - query: "How many documents have 194 in the pathname?"
-    expected: "91"
-    tags:
-      - verified_ground_truth
-
   - query: "How many incidents occurred in the first 10 days of July 2024?"
     expected: "11"
     tags:
-      - mdw
+      - verified_ground_truth
 
   - query: "How many states did incidents in the first 10 days of July 2024 occur in?"
     expected: "9"
     tags:
-      - mdw
+      - verified_ground_truth
 
   - query: "How many more incidents happened in Florida compared to Oklahoma?"
     expected: "7"
     tags:
       - verified_ground_truth
+
+  - query: "How many incidents occurred that involved serious injuries when the wind speed was greater than four knots?"
+    expected: "12"
+    tags:
+      - need_ground_truth
+
+  - query: "In incidents involving Piper aircraft, what was the most commonly damaged part of the aircraft?"
+    expected: "Wing, with 7 incidents in which it was damaged."
+    tags:
+      - need_ground_truth
+
+  - query: "In incidents involving damage to the fuselage, what are the number of incidents by aircraft type?"
+    expected: |
+      Cessna 172: 3
+      AIR TRACTOR INC AT-402: 2
+      CIRRUS DESIGN CORP SR20: 2
+      Cessna 172R: 2
+      Cessna 180: 2 are 2 incidents reported.
+      Cessna 305: 2
+      Cessna A185F: 2
+      Piper PA28: 2
+      Others: 1 each
+    tags:
+      - need_ground_truth
+
+  - query: "How many incidents were there, broken down by number of engines?"
+    expected: |
+      0 engines: 5
+      1 Engine: 87
+      2 Engines: 9
+    tags:
+      - need_ground_truth

--- a/apps/query-eval/queryeval/queryeval_types.py
+++ b/apps/query-eval/queryeval/queryeval_types.py
@@ -74,6 +74,7 @@ class DocumentSummary(BaseModel):
     doc_id: Optional[str] = None
     text_representation: Optional[str] = None
     path: Optional[str] = None
+    properties: Optional[Dict[str, Any]] = None
 
 
 class DocSetSummary(BaseModel):

--- a/apps/query-eval/queryeval/test_driver.py
+++ b/apps/query-eval/queryeval/test_driver.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 from sycamore.query.schema import OpenSearchSchema, OpenSearchSchemaField
 
 from queryeval.driver import QueryEvalDriver
-from queryeval.types import (
+from queryeval.queryeval_types import (
     QueryEvalQuery,
     QueryEvalResult,
     QueryEvalMetrics,


### PR DESCRIPTION
This PR makes some tweaks to the questions and ground truth answers for CIDR-25 evaluation, and fixes a bug in the query-eval tool.
