### PR TITLE
Fix sort so that it works with an unspecified or None default_value.

### DIFF
--- a/lib/sycamore/sycamore/docset.py
+++ b/lib/sycamore/sycamore/docset.py
@@ -1195,7 +1195,7 @@ class DocSet:
         plan = self.plan
         if default_val is None:
             import logging
-            logging.warning("Default value is none. Adding explicit filter step to work around ray issues")
+            logging.warning("Default value is none. Adding explicit filter step to drop documents missing the key. This includes any metadata.documents.")
             plan = DropIfMissingField(plan, field)
         return DocSet(self.context, Sort(plan, descending, field, default_val))
 

--- a/lib/sycamore/sycamore/docset.py
+++ b/lib/sycamore/sycamore/docset.py
@@ -1190,9 +1190,14 @@ class DocSet:
             field: Document field in relation to Document using dotted notation, e.g. properties.filetype
             default_val: Default value to use if field does not exist in Document
         """
-        from sycamore.transforms import Sort
+        from sycamore.transforms.sort import Sort, DropIfMissingField
 
-        return DocSet(self.context, Sort(self.plan, descending, field, default_val))
+        plan = self.plan
+        if default_val is None:
+            import logging
+            logging.warning("Default value is none. Adding explicit filter step to work around ray issues")
+            plan = DropIfMissingField(plan, field)
+        return DocSet(self.context, Sort(plan, descending, field, default_val))
 
     def groupby_count(self, field: str, unique_field: Optional[str] = None, **kwargs) -> "DocSet":
         """

--- a/lib/sycamore/sycamore/docset.py
+++ b/lib/sycamore/sycamore/docset.py
@@ -1195,7 +1195,11 @@ class DocSet:
         plan = self.plan
         if default_val is None:
             import logging
-            logging.warning("Default value is none. Adding explicit filter step to drop documents missing the key. This includes any metadata.documents.")
+
+            logging.warning(
+                "Default value is none. Adding explicit filter step to drop documents missing the key."
+                " This includes any metadata.documents."
+            )
             plan = DropIfMissingField(plan, field)
         return DocSet(self.context, Sort(plan, descending, field, default_val))
 

--- a/lib/sycamore/sycamore/query/operators/sort.py
+++ b/lib/sycamore/sycamore/query/operators/sort.py
@@ -15,4 +15,5 @@ class Sort(Node):
     field: str
     """The name of the database field to sort based on."""
 
-    default_value: Any
+    default_value: Any = None
+    """The default value used when sorting if a document is missing the specified field."""

--- a/lib/sycamore/sycamore/tests/integration/transforms/test_sort.py
+++ b/lib/sycamore/sycamore/tests/integration/transforms/test_sort.py
@@ -1,0 +1,8 @@
+from sycamore.context import ExecMode
+import sycamore.tests.unit.transforms.test_sort as unit
+
+
+class TestSort(unit.TestSort):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.exec_mode = ExecMode.RAY

--- a/lib/sycamore/sycamore/tests/unit/query/execution/test_sycamore_operator.py
+++ b/lib/sycamore/sycamore/tests/unit/query/execution/test_sycamore_operator.py
@@ -331,20 +331,23 @@ def test_llm_extract_entity():
 
 
 def test_sort():
-    context = sycamore.init()
-    doc_set = Mock(spec=DocSet)
-    return_doc_set = Mock(spec=DocSet)
-    doc_set.sort.return_value = return_doc_set
-    logical_node = Sort(node_id=0, descending=True, field="properties.counter", default_value=0)
-    sycamore_operator = SycamoreSort(context, logical_node, query_id="test", inputs=[doc_set])
-    result = sycamore_operator.execute()
+    Sort(node_id=0, descending=True, field="no-default-value")
 
-    doc_set.sort.assert_called_once_with(
-        descending=logical_node.descending,
-        field=logical_node.field,
-        default_val=logical_node.default_value,
-    )
-    assert result == return_doc_set
+    for default_value in [None, 0]:
+        context = sycamore.init()
+        doc_set = Mock(spec=DocSet)
+        return_doc_set = Mock(spec=DocSet)
+        doc_set.sort.return_value = return_doc_set
+        logical_node = Sort(node_id=0, descending=True, field="properties.counter", default_value=default_value)
+        sycamore_operator = SycamoreSort(context, logical_node, query_id="test", inputs=[doc_set])
+        result = sycamore_operator.execute()
+
+        doc_set.sort.assert_called_once_with(
+            descending=logical_node.descending,
+            field=logical_node.field,
+            default_val=logical_node.default_value,
+        )
+        assert result == return_doc_set
 
 
 def test_top_k():

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_sort.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_sort.py
@@ -1,14 +1,20 @@
 import string
 import pytest
 import random
+import unittest
 
 import sycamore
 from sycamore import DocSet, ExecMode
 from sycamore.data import Document, MetadataDocument
 
 
-class TestSort:
-    @pytest.fixture()
+class TestSort(unittest.TestCase):
+    NUM_DOCS = 10
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.exec_mode = ExecMode.LOCAL
+    
     def docs(self) -> list[Document]:
         doc_list = [
             # text_representation is random 6 letter strings
@@ -16,7 +22,7 @@ class TestSort:
                 text_representation=f"{''.join(random.choices(string.ascii_letters, k=6))}",
                 properties={"document_number": random.randint(1, 10000), "even": i if i % 2 == 0 else None},
             )
-            for i in range(10)
+            for i in range(self.NUM_DOCS)
         ]
 
         for doc in doc_list:
@@ -24,31 +30,34 @@ class TestSort:
                 doc.properties.pop("even")
         return doc_list
 
-    @pytest.fixture(params=(exec_mode for exec_mode in ExecMode if exec_mode != ExecMode.UNKNOWN))
-    def docset(self, docs: list[Document], exec_mode) -> DocSet:
-        context = sycamore.init(exec_mode=exec_mode)
-        return context.read.document(docs)
+    def docset(self) -> DocSet:
+        context = sycamore.init(exec_mode=self.exec_mode)
+        return context.read.document(self.docs())
 
-    def test_sort_descending(self, docset: DocSet):
-        sorted_docset = docset.sort(True, "text_representation")
+    def test_sort_descending(self):
+        sorted_docset = self.docset().sort(True, "text_representation")
         doc_list = sorted_docset.take_all()
 
         for i in range(1, len(doc_list)):
             assert str(doc_list[i].text_representation) <= str(doc_list[i - 1].text_representation)
 
-    def test_sort_ascending(self, docset: DocSet):
-        sorted_docset = docset.sort(False, "properties.document_number")
+    def test_sort_ascending(self):
+        sorted_docset = self.docset().sort(False, "properties.document_number")
         doc_list = sorted_docset.take_all()
 
         for i in range(1, len(doc_list)):
             assert doc_list[i].properties["document_number"] >= doc_list[i - 1].properties["document_number"]
 
-    def test_default_value(self, docset: DocSet):
-        with pytest.raises(Exception):
-            sorted_docset = docset.sort(False, "properties.even")
-            doc_list = sorted_docset.take_all()
+    def test_default_value(self):
+        sorted_docset = self.docset().sort(False, "properties.even")
+        doc_list = sorted_docset.take_all()
 
-        sorted_docset = docset.sort(False, "properties.even", 0)
+        for i in range(1, len(doc_list)):
+            assert doc_list[i].properties.get("even", 0) >= doc_list[i - 1].properties.get("even", 0)
+
+        assert len(doc_list) == self.NUM_DOCS / 2
+            
+        sorted_docset = self.docset().sort(False, "properties.even", 0)
         doc_list = sorted_docset.take_all()
 
         for i in range(1, len(doc_list)):
@@ -61,25 +70,39 @@ class TestSort:
             MetadataDocument(),
             Document(text_representation="C"),
             MetadataDocument(),
+            Document(text_representation=None)
         ]
 
-        context = sycamore.init()
+        context = sycamore.init(exec_mode=self.exec_mode)
         docset = context.read.document(doc_list)
 
-        with pytest.raises(Exception):
-            sorted_docset = docset.sort(False, "text_representation")
-            sorted_doc_list = sorted_docset.take_all(include_metadata=True)
+        sorted_docset = docset.sort(False, "text_representation")
+        sorted_doc_list = sorted_docset.take_all(include_metadata=True)
+        assert len(sorted_doc_list) == 3
+        assert sorted_doc_list[0].text_representation == "B"
+        assert sorted_doc_list[1].text_representation == "C"
+        assert sorted_doc_list[2].text_representation == "Z"
+        
 
-        # must include default value for docsets with MetadataDocuments
         sorted_docset = docset.sort(False, "text_representation", "A")
         sorted_doc_list = sorted_docset.take_all(include_metadata=True)
 
-        for i in range(len(sorted_doc_list)):
-            if i == 0 or i == 1:
-                assert isinstance(sorted_doc_list[i], MetadataDocument)
-            elif i == 2:
-                assert sorted_doc_list[i].text_representation == "B"
-            elif i == 3:
-                assert sorted_doc_list[i].text_representation == "C"
-            elif i == 4:
-                assert sorted_doc_list[i].text_representation == "Z"
+        for i in range(3):
+            d = sorted_doc_list[i]
+            assert isinstance(d, MetadataDocument) or d.text_representation is None
+
+        assert sorted_doc_list[3].text_representation == "B"
+        assert sorted_doc_list[4].text_representation == "C"
+        assert sorted_doc_list[5].text_representation == "Z"
+
+        sorted_docset = docset.sort(True, "text_representation", "A")
+        sorted_doc_list = sorted_docset.take_all(include_metadata=True)
+
+        assert sorted_doc_list[0].text_representation == "Z"
+        assert sorted_doc_list[1].text_representation == "C"
+        assert sorted_doc_list[2].text_representation == "B"
+        for i in range(3):
+            d = sorted_doc_list[i+3]
+            assert isinstance(d, MetadataDocument) or d.text_representation is None
+
+        

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_sort.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_sort.py
@@ -1,5 +1,4 @@
 import string
-import pytest
 import random
 import unittest
 
@@ -14,7 +13,7 @@ class TestSort(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.exec_mode = ExecMode.LOCAL
-    
+
     def docs(self) -> list[Document]:
         doc_list = [
             # text_representation is random 6 letter strings
@@ -56,7 +55,7 @@ class TestSort(unittest.TestCase):
             assert doc_list[i].properties.get("even", 0) >= doc_list[i - 1].properties.get("even", 0)
 
         assert len(doc_list) == self.NUM_DOCS / 2
-            
+
         sorted_docset = self.docset().sort(False, "properties.even", 0)
         doc_list = sorted_docset.take_all()
 
@@ -70,7 +69,7 @@ class TestSort(unittest.TestCase):
             MetadataDocument(),
             Document(text_representation="C"),
             MetadataDocument(),
-            Document(text_representation=None)
+            Document(text_representation=None),
         ]
 
         context = sycamore.init(exec_mode=self.exec_mode)
@@ -82,7 +81,6 @@ class TestSort(unittest.TestCase):
         assert sorted_doc_list[0].text_representation == "B"
         assert sorted_doc_list[1].text_representation == "C"
         assert sorted_doc_list[2].text_representation == "Z"
-        
 
         sorted_docset = docset.sort(False, "text_representation", "A")
         sorted_doc_list = sorted_docset.take_all(include_metadata=True)
@@ -102,7 +100,5 @@ class TestSort(unittest.TestCase):
         assert sorted_doc_list[1].text_representation == "C"
         assert sorted_doc_list[2].text_representation == "B"
         for i in range(3):
-            d = sorted_doc_list[i+3]
+            d = sorted_doc_list[i + 3]
             assert isinstance(d, MetadataDocument) or d.text_representation is None
-
-        

--- a/lib/sycamore/sycamore/transforms/sort.py
+++ b/lib/sycamore/sycamore/transforms/sort.py
@@ -8,19 +8,24 @@ if TYPE_CHECKING:
 
 from sycamore.plan_nodes import UnaryNode
 class DropIfMissingField(UnaryNode):
-    "Yes, this destroys metadata, fix it properly in sycamore. Customer HACKS FTW"
+    """Drop all documents that are missing the specified field, including metadata. This makes ray work because
+       ray requires a key value that is comparable between all entries which means None can't be used and there
+       is no easy way to auto-infer the correct type."""
     def __init__(self, child, field):
         super().__init__(child)
         self._field = field
 
-    def execute(self):
+    def execute(self) -> "Dataset":
         input_dataset = self.child().execute()
-        result = input_dataset.map_batches(self.ray_doit)
+        result = input_dataset.map_batches(self.ray_drop_documents)
         return result
 
-    def ray_doit(self, ray_input):
+    def local_execute(self, all_docs: list[Document]) -> list[Document]:
+        return [d for d in all_docs if d.field_to_value(self._field) is not None]
+
+    def ray_drop_documents(self, ray_input):
         all_docs = [Document.deserialize(s) for s in ray_input.get("doc", [])]
-        out_docs = [d for d in all_docs if d.field_to_value(self._field) is not None]
+        out_docs = self.local_execute(all_docs)
         return {"doc": [d.serialize() for d in out_docs]}
 
 class Sort(Transform):
@@ -65,20 +70,11 @@ class Sort(Transform):
         def ray_callable(input_dict: dict[str, Any]) -> dict[str, Any]:
             doc = Document.from_row(input_dict)
 
-            if isinstance(doc, MetadataDocument):
-                new_doc = doc.to_row()
-                new_doc["key"] = None
-                return new_doc
-
             val = doc.field_to_value(self._field)
 
             if val is None:
-                if self._default_val is None:
-                    exception_string = f'Field "{self._field}" not present in Document {doc.doc_id} and default value not provided.'
-                    logging.error(exception_string)
-                    raise Exception(exception_string)
-                else:
-                    val = self._default_val
+                assert self._default_val is not None
+                val = self._default_val
 
             # updates row to include new col
             new_doc = doc.to_row()

--- a/lib/sycamore/sycamore/transforms/sort.py
+++ b/lib/sycamore/sycamore/transforms/sort.py
@@ -1,11 +1,27 @@
 from typing import Any, Optional, TYPE_CHECKING
 
 from sycamore.plan_nodes import Node, Transform
-from sycamore.data import Document
+from sycamore.data import Document, MetadataDocument
 
 if TYPE_CHECKING:
     from ray.data import Dataset
 
+from sycamore.plan_nodes import UnaryNode
+class DropIfMissingField(UnaryNode):
+    "Yes, this destroys metadata, fix it properly in sycamore. Customer HACKS FTW"
+    def __init__(self, child, field):
+        super().__init__(child)
+        self._field = field
+
+    def execute(self):
+        input_dataset = self.child().execute()
+        result = input_dataset.map_batches(self.ray_doit)
+        return result
+
+    def ray_doit(self, ray_input):
+        all_docs = [Document.deserialize(s) for s in ray_input.get("doc", [])]
+        out_docs = [d for d in all_docs if d.field_to_value(self._field) is not None]
+        return {"doc": [d.serialize() for d in out_docs]}
 
 class Sort(Transform):
     """
@@ -49,11 +65,17 @@ class Sort(Transform):
         def ray_callable(input_dict: dict[str, Any]) -> dict[str, Any]:
             doc = Document.from_row(input_dict)
 
+            if isinstance(doc, MetadataDocument):
+                new_doc = doc.to_row()
+                new_doc["key"] = None
+                return new_doc
+
             val = doc.field_to_value(self._field)
 
             if val is None:
                 if self._default_val is None:
-                    exception_string = f'Field "{self._field}" not present in Document and default value not provided.'
+                    exception_string = f'Field "{self._field}" not present in Document {doc.doc_id} and default value not provided.'
+                    logging.error(exception_string)
                     raise Exception(exception_string)
                 else:
                     val = self._default_val

--- a/lib/sycamore/sycamore/transforms/sort.py
+++ b/lib/sycamore/sycamore/transforms/sort.py
@@ -1,21 +1,24 @@
 from typing import Any, Optional, TYPE_CHECKING
 
 from sycamore.plan_nodes import Node, Transform
-from sycamore.data import Document, MetadataDocument
+from sycamore.data import Document
 
 if TYPE_CHECKING:
     from ray.data import Dataset
 
 from sycamore.plan_nodes import UnaryNode
+
+
 class DropIfMissingField(UnaryNode):
     """Drop all documents that are missing the specified field, including metadata. This makes ray work because
-       ray requires a key value that is comparable between all entries which means None can't be used and there
-       is no easy way to auto-infer the correct type."""
+    ray requires a key value that is comparable between all entries which means None can't be used and there
+    is no easy way to auto-infer the correct type."""
+
     def __init__(self, child, field):
         super().__init__(child)
         self._field = field
 
-    def execute(self) -> "Dataset":
+    def execute(self, **kwargs) -> "Dataset":
         input_dataset = self.child().execute()
         result = input_dataset.map_batches(self.ray_drop_documents)
         return result
@@ -27,6 +30,7 @@ class DropIfMissingField(UnaryNode):
         all_docs = [Document.deserialize(s) for s in ray_input.get("doc", [])]
         out_docs = self.local_execute(all_docs)
         return {"doc": [d.serialize() for d in out_docs]}
+
 
 class Sort(Transform):
     """


### PR DESCRIPTION
The core of the problem is that the ray sort operator requires that each document be associated with a value of the same type. Ray sort doesn't let us specify a comparator, and we don't know the type. Documents can be missing the sort key,
metadata documents are mostly guaranteed to be missing the sort key.

* In the sycamore sort operator, drop documents that do not have the sort parameter if there is no default value.
* In the Luna sort operator accept a default None value for the default_value.
* Split the test into a local-mode (0.04s) unit test and ray (21.25s) integration test
* Fix the tests to check the new semantics, previously they checked the "crashes if no default value specified" semantics.
