### PR TITLE
Add a globalstate in context

### DIFF
--- a/lib/sycamore/sycamore/transforms/map.py
+++ b/lib/sycamore/sycamore/transforms/map.py
@@ -44,7 +44,7 @@ class Map(BaseMapTransform):
     @staticmethod
     def wrap(f: Any) -> Callable[[list[Document]], list[Document]]:
         if isinstance(f, type):
-            # mypy doesn't understand the dynamic class inheritence.
+            # mypy doesn't understand the dynamic class inheritance.
             class _Wrap(f):  # type: ignore[valid-type,misc]
                 def __init__(self, *args, **kwargs):
                     super().__init__(*args, **kwargs)


### PR DESCRIPTION
Create a "State" class to store global data. The class can be stored in memory for local exec mode, and also be wrapped in a ray actor for ray global access.