### PR TITLE
Query planner improvements

### DIFF
--- a/lib/sycamore/sycamore/query/client.py
+++ b/lib/sycamore/sycamore/query/client.py
@@ -200,7 +200,7 @@ class SycamoreQueryClient:
             os_config=self.os_config,
             os_client=self._os_client,
             llm_client=llm_client,
-            strategy=self.query_plan_strategy or DefaultQueryPlanStrategy(llm_client),
+            strategy=self.query_plan_strategy or DefaultQueryPlanStrategy(),
             examples=examples,
             natural_language_response=natural_language_response,
         )

--- a/lib/sycamore/sycamore/query/operators/query_database.py
+++ b/lib/sycamore/sycamore/query/operators/query_database.py
@@ -64,8 +64,8 @@ class QueryVectorDatabase(Node):
     according to the vector similarity between the query string and record's text content.
 
     You should only use QueryVectorDatabase for the following query types:
-    1. "Is there *any* <record> similar to <query>?": yes or no questions about inclusion of any record
-    2. "Give me *some* <record>s similar to <query>", sample selection of records similar to a query
+    1. "Is there *any* <record> similar to <query>?" - yes or no questions about inclusion of any record
+    2. "Give me *some* <record>s similar to <query>" - sample selection of records similar to a query
 
     Important: Unless the query is asking for any or some records, DO NOT use QueryVectorDatabase.
 

--- a/lib/sycamore/sycamore/query/operators/query_database.py
+++ b/lib/sycamore/sycamore/query/operators/query_database.py
@@ -32,12 +32,8 @@ class QueryDatabase(Node):
                             }
                         }
                     },
-                    {
-                        "match": {
-                            "properties.path.keyword": "/path/to/data/*.pdf",
-                            "properties.entity.location": "Georgia"
-                        }
-                    }
+                    {"match": {"properties.entity.accidentNumber.keyword": "*K1234N*"}},
+                    {"match_phrase": {"properties.entity.location": "Georgia"}}
                 ]
             }
         }
@@ -49,6 +45,9 @@ class QueryDatabase(Node):
     The full range of OpenSearch Query DSL parameters are supported.
     Whenever possible, use the query parameter to filter data at the source, as this is more
     efficient than filtering data in subsequent data filtering operators.
+    
+    If filtering on a proper noun, e.g. "New York", use "match_phrase" instead of "match". 
+    If filtering on a phrase that doesn't have exact spellings or forms, e.g. "Color" or "Colour", prefer "match".
     """
 
     @property
@@ -63,19 +62,15 @@ class QueryDatabase(Node):
 class QueryVectorDatabase(Node):
     """Vector search to load records that are similar to a given query string. Returns the top k records
     according to the vector similarity between the query string and record's text content.
-    Use this if you need to filter on a field that can't suffice with an exact match, but also isn't complex enough to
-    require a llm_filter, i.e. a record level LLM call.
 
-    Here are some instructions about using QueryVectorDatabase instead of QueryDatabase:
-    1. Use QueryVectorDatabase if the query plan uses an LLM operator (LLMFilter or LLMExtractEntity),
-        and the final answer doesn't require you to scan the full dataset (e.g. find me an instance of a transcript
-        that talked about AI).
-    2. Use QueryVectorDatabase for RAG-style questions where you need to retrieve a set of candidate records where the
-        answer might exist.
-    3. Do not use QueryVectorDatabase when examining each record is essential (e.g. did all transcripts talk about AI?).
-    4. Do not use QueryVectorDatabase where you need to potentially return large datasets (e.g. give me all transcripts
-        that talked about AI).
+    You should only use QueryVectorDatabase for the following query types:
+    1. "Is there *any* <record> similar to <query>?": yes or no questions about inclusion of any record
+    2. "Give me *some* <record>s similar to <query>", sample selection of records similar to a query
 
+    Important: Unless the query is asking for any or some records, DO NOT use QueryVectorDatabase.
+
+    Do not use QueryVectorDatabase for questions that which require all results that match a criteria, even if it is a
+    similarity criteria, e.g. "What incidents involved tigers in 2022" as that requires all possible records that match.
     """
 
     index: str

--- a/lib/sycamore/sycamore/query/planner.py
+++ b/lib/sycamore/sycamore/query/planner.py
@@ -119,14 +119,8 @@ PLANNER_EXAMPLES: List[PlannerExample] = [
                     node_id=0,
                     description="Get all the incident reports",
                     index="ntsb",
-                ),
-                1: LlmFilter(
-                    node_id=1,
-                    description="Filter to only include incidents in Georgia",
-                    question="Did this incident occur in Georgia?",
-                    field="properties.entity.location",
-                    inputs=[0],
-                ),
+                    query={"match_phrase": {"properties.entity.location": "Georgia"}},
+                )
             },
         ),
     ),
@@ -155,7 +149,7 @@ PLANNER_EXAMPLES: List[PlannerExample] = [
         schema=EXAMPLE_NTSB_SCHEMA,
         plan=LogicalPlan(
             query="""Show incidents between July 1, 2023 and September 1, 2024 with an accident
- .         number containing 'K1234N' that occurred in Georgia.""",
+ .         number containing 'K1234N' that occurred in New Mexico.""",
             result_node=0,
             nodes={
                 0: QueryDatabase(
@@ -175,7 +169,7 @@ PLANNER_EXAMPLES: List[PlannerExample] = [
                                     }
                                 },
                                 {"match": {"properties.entity.accidentNumber.keyword": "*K1234N*"}},
-                                {"match": {"properties.entity.location": "Georgia"}},
+                                {"match_phrase": {"properties.entity.location": "New Mexico"}},
                             ]
                         }
                     },
@@ -193,7 +187,7 @@ PLANNER_EXAMPLES: List[PlannerExample] = [
                     node_id=0,
                     description="Get all the incident reports involving Cessna aircrafts",
                     index="ntsb",
-                    query={"match": {"properties.entity.aircraft": "Cessna"}},
+                    query={"match_phrase": {"properties.entity.aircraft": "Cessna"}},
                 ),
                 1: Count(
                     node_id=1,
@@ -288,10 +282,39 @@ PLANNER_EXAMPLES: List[PlannerExample] = [
             nodes={
                 0: QueryVectorDatabase(
                     node_id=0,
-                    description="Get all the incidents relating to sudden weather changes",
+                    description="Get some incidents relating to sudden weather changes",
                     index="ntsb",
                     query_phrase="sudden weather changes",
-                )
+                ),
+                1: LlmFilter(
+                    node_id=1,
+                    description="Filter to only include incidents caused due to sudden weather changes",
+                    question="Did this incident occur due to sudden weather changes?",
+                    field="text_representation",
+                    inputs=[0],
+                ),
+            },
+        ),
+    ),
+    PlannerExample(
+        schema=EXAMPLE_NTSB_SCHEMA,
+        plan=LogicalPlan(
+            query="Show me some sample incidents relating to water causes",
+            result_node=0,
+            nodes={
+                0: QueryVectorDatabase(
+                    node_id=0,
+                    description="Get some incidents relating to water causes",
+                    index="ntsb",
+                    query_phrase="water causes",
+                ),
+                1: LlmFilter(
+                    node_id=1,
+                    description="Filter to only include incidents that occur due to water causes",
+                    question="Did this incident occur because of water causes",
+                    field="text_representation",
+                    inputs=[0],
+                ),
             },
         ),
     ),

--- a/lib/sycamore/sycamore/query/strategy.py
+++ b/lib/sycamore/sycamore/query/strategy.py
@@ -181,10 +181,7 @@ class DefaultQueryPlanStrategy(QueryPlanStrategy):
     Default strategy that uses all available tools and optimizes result correctness.
     """
 
-    def __init__(self, llm: LLM, additional_post_processors: Optional[list[LogicalPlanProcessor]] = None) -> None:
-        post_processors: list[LogicalPlanProcessor] = [RemoveVectorSearchForAnalytics(llm)]
-        if additional_post_processors:
-            post_processors.extend(additional_post_processors)
+    def __init__(self, post_processors: Optional[list[LogicalPlanProcessor]] = None) -> None:
         super().__init__(ALL_OPERATORS, post_processors)
 
 

--- a/lib/sycamore/sycamore/tests/unit/query/test_strategy.py
+++ b/lib/sycamore/sycamore/tests/unit/query/test_strategy.py
@@ -24,11 +24,10 @@ class DummyLLMClient(LLM):
 class TestStrategies(unittest.TestCase):
     def test_default(self):
         processor = RemoveVectorSearchForAnalytics(DummyLLMClient("test_model"))
-        strategy = DefaultQueryPlanStrategy(llm=DummyLLMClient("test"), additional_post_processors=[processor])
+        strategy = DefaultQueryPlanStrategy(post_processors=[processor])
 
-        assert len(strategy.post_processors) == 2
+        assert len(strategy.post_processors) == 1
         assert isinstance(strategy.post_processors[0], RemoveVectorSearchForAnalytics)
-        assert isinstance(strategy.post_processors[1], RemoveVectorSearchForAnalytics)
         assert strategy.operators == ALL_OPERATORS
 
     def test_vector_search_only(self):


### PR DESCRIPTION
1. Magical prompting and example improvements for:
1 Using vector search when appropriate
2 Use match_phrase for proper nouns
1. Disable vector-search-removal from default strategy