### PR TITLE
Add helper for thread local variables that can be used to add metadata to the output stream

### DIFF
--- a/lib/sycamore/sycamore/data/metadata.py
+++ b/lib/sycamore/sycamore/data/metadata.py
@@ -1,0 +1,11 @@
+from sycamore.data import MetadataDocument
+from sycamore.utils.thread_local import ThreadLocalAccess, ADD_METADATA_TO_OUTPUT
+
+
+def add_metadata(**metadata):
+    ThreadLocalAccess(ADD_METADATA_TO_OUTPUT).get().append(MetadataDocument(**metadata))
+
+
+# At some point we should define particular forms of metadata like metrics
+# Maybe following https://github.com/prometheus/OpenMetrics/blob/main/specification/OpenMetrics.md
+# as a structure for the metrics -- too complex for now.

--- a/lib/sycamore/sycamore/llms/bedrock.py
+++ b/lib/sycamore/sycamore/llms/bedrock.py
@@ -137,7 +137,6 @@ class Bedrock(LLM):
             body=body, modelId=self.model.name, accept="application/json", contentType="application/json"
         )
         wall_latency = datetime.datetime.now() - start
-
         md = response["ResponseMetadata"]
         assert md["HTTPStatusCode"] == 200, f"Request failed {md['HTTPStatusCode']}"
         hdrs = md["HTTPHeaders"]

--- a/lib/sycamore/sycamore/llms/llms.py
+++ b/lib/sycamore/sycamore/llms/llms.py
@@ -40,7 +40,11 @@ class LLM(ABC):
         data = pickle.dumps(combined)
         return self._cache.get_hash_context(data).hexdigest()
 
-    def _cache_get(self, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> Tuple[Optional[str], Optional[str]]:
+    # TODO fix cache_get and cache_set to have more consistent typing on the value.
+    # cache_set takes a value which is a dictionary and has a bunch of required values
+    # so that cache_get can verify the return value. cache_set then reaches inside that
+    # dictionary for its return value.
+    def _cache_get(self, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None) -> Tuple[Optional[str], Any]:
         """Get a cached result for the given prompt and LLM parameters. Returns the cache key
         and the cached result if found, otherwise returns None for both."""
         if (llm_kwargs or {}).get("temperature", 0) != 0 or not self._cache:

--- a/lib/sycamore/sycamore/tests/integration/llms/test_bedrock.py
+++ b/lib/sycamore/sycamore/tests/integration/llms/test_bedrock.py
@@ -110,3 +110,16 @@ def test_cached_bedrock_different_models(tmp_path: Path):
     # check for difference with model change
     assert key_HAIKU != key_SONNET
     assert res_HAIKU != res_SONNET
+
+
+def test_metadata():
+    llm = Bedrock(BedrockModels.CLAUDE_3_HAIKU)
+    prompt_kwargs = {"prompt": "Write a limerick about large language models."}
+
+    res = llm.generate_metadata(prompt_kwargs=prompt_kwargs, llm_kwargs={})
+
+    assert "output" in res
+    assert "wall_latency" in res
+    assert "server_latency" in res
+    assert "in_tokens" in res
+    assert "out_tokens" in res

--- a/lib/sycamore/sycamore/tests/unit/llms/test_bedrock.py
+++ b/lib/sycamore/sycamore/tests/unit/llms/test_bedrock.py
@@ -7,10 +7,32 @@ from sycamore.llms.bedrock import DEFAULT_ANTHROPIC_VERSION, DEFAULT_MAX_TOKENS
 from sycamore.utils.cache import DiskCache
 
 
+class BedrockBody:
+    def __init__(self, body):
+        self.body = body
+
+    def read(self):
+        return self.body
+
+
+def bedrock_reply(body):
+    return {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-bedrock-invocation-latency": 1111,
+                "x-amzn-bedrock-input-token-count": 30,
+                "x-amzn-bedrock-output-token-count": 50,
+            },
+        },
+        "body": BedrockBody(body),
+    }
+
+
 @patch("boto3.client")
-def test_bedrock(mock_boto3_client):
-    mock_boto3_client.return_value.invoke_model.return_value.get.return_value.read.return_value = (
-        '{"content": [{"text": "Here is your result: 56"}]}'
+def test_bedrock_simple(mock_boto3_client):
+    mock_boto3_client.return_value.invoke_model.return_value = bedrock_reply(
+        '{ "content": [{"text": "Here is your result: 56"}]}'
     )
 
     client = Bedrock(BedrockModels.CLAUDE_3_5_SONNET)
@@ -37,7 +59,7 @@ def test_bedrock(mock_boto3_client):
 
 @patch("boto3.client")
 def test_bedrock_system_role(mock_boto3_client):
-    mock_boto3_client.return_value.invoke_model.return_value.get.return_value.read.return_value = (
+    mock_boto3_client.return_value.invoke_model.return_value = bedrock_reply(
         '{"content": [{"text": "Here is your result: 56"}]}'
     )
 
@@ -68,7 +90,7 @@ def test_bedrock_system_role(mock_boto3_client):
 
 @patch("boto3.client")
 def test_bedrock_with_llm_kwargs(mock_boto3_client):
-    mock_boto3_client.return_value.invoke_model.return_value.get.return_value.read.return_value = (
+    mock_boto3_client.return_value.invoke_model.return_value = bedrock_reply(
         '{"content": [{"text": "Here is your result: 56"}]}'
     )
 
@@ -97,7 +119,7 @@ def test_bedrock_with_llm_kwargs(mock_boto3_client):
 
 @patch("boto3.client")
 def test_bedrock_with_cache(mock_boto3_client):
-    mock_boto3_client.return_value.invoke_model.return_value.get.return_value.read.return_value = (
+    mock_boto3_client.return_value.invoke_model.return_value = bedrock_reply(
         '{"content": [{"text": "Here is your result: 56"}]}'
     )
 

--- a/lib/sycamore/sycamore/utils/thread_local.py
+++ b/lib/sycamore/sycamore/utils/thread_local.py
@@ -1,0 +1,43 @@
+import logging
+import threading
+
+logger = logging.getLogger(__name__)
+# Used to inject metadata into the docset output stream to make it easier to use with
+# transforms like map.
+ADD_METADATA_TO_OUTPUT = "add_metadata_to_output"
+
+# Create a thread-local data object
+thread_local_data = threading.local()
+
+
+class ThreadLocalAccess:
+    def __init__(self, var_name):
+        self.var_name = var_name
+
+    def present(self):
+        return hasattr(thread_local_data, self.var_name)
+
+    def get(self):
+        assert hasattr(thread_local_data, self.var_name), f"{self.var_name} not present in TLS"
+        return getattr(thread_local_data, self.var_name)
+
+    def set(self, value):
+        assert hasattr(thread_local_data, self.var_name), f"{self.var_name} not present in TLS"
+        setattr(thread_local_data, self.var_name, value)
+
+
+class ThreadLocal(ThreadLocalAccess):
+    def __init__(self, var_name, var_value):
+        self.var_name = var_name
+        self.var_value = var_value
+
+    def __enter__(self):
+        assert not hasattr(thread_local_data, self.var_name), f"{self.var_name} already set in TLS"
+        setattr(thread_local_data, self.var_name, self.var_value)
+        logger.debug(f"Thread-local variable '{self.var_name}' removed.")
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        assert hasattr(thread_local_data, self.var_name), f"{self.var_name} vanished from TLS"
+        delattr(thread_local_data, self.var_name)
+        logger.debug(f"Thread-local variable '{self.var_name}' removed.")

--- a/poetry.lock
+++ b/poetry.lock
@@ -1907,6 +1907,22 @@ files = [
 ]
 
 [[package]]
+name = "devtools"
+version = "0.12.2"
+description = "Python's missing debug print command, and more."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "devtools-0.12.2-py3-none-any.whl", hash = "sha256:c366e3de1df4cdd635f1ad8cbcd3af01a384d7abda71900e68d43b04eb6aaca7"},
+    {file = "devtools-0.12.2.tar.gz", hash = "sha256:efceab184cb35e3a11fa8e602cc4fadacaa2e859e920fc6f87bf130b69885507"},
+]
+
+[package.dependencies]
+asttokens = ">=2.0.0,<3.0.0"
+executing = ">=1.1.1"
+pygments = ">=2.15.0"
+
+[[package]]
 name = "dill"
 version = "0.3.8"
 description = "serialize all of Python"
@@ -11122,4 +11138,4 @@ docs = ["furo", "myst-parser", "sphinx"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.9.7 || >3.9.7,<3.13"
-content-hash = "97db6ec89697efd7783b87cafdeeed778ecf7c785a694f2a55d80002707328a2"
+content-hash = "fb920f1ed2bad03362ff80535520dd5e3b3a75f86b2ed75c6540ffaaa3721a4c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ pre-commit = "^3.4.0"
 mypy = "^1.11.0"
 nbmake = "^1.4.5"
 pip = "^24.2"
+devtools = "^0.12"
 
 [tool.poetry.group.notebook.dependencies]
 jupyterlab = "^4.0.11"


### PR DESCRIPTION
* Could also be used to propagate metadata down, e.g. node ids in Luna
* Add devtools to help with debugging
* Extend llm generate to calculate metadata