### PR TITLE
Propagate element level llm_filter output to doc.properties

### DIFF
--- a/lib/sycamore/sycamore/docset.py
+++ b/lib/sycamore/sycamore/docset.py
@@ -1034,8 +1034,15 @@ class DocSet:
                     continue
                 e_doc = entity_extractor.extract_entity(e_doc)
                 element.properties[new_field] = e_doc.properties[new_field]
+
                 # todo: move data extraction and validation to entity extractor
-                if int(re.findall(r"\d+", element.properties[new_field])[0]) >= threshold:
+                score = int(re.findall(r"\d+", element.properties[new_field])[0])
+                # we're storing the element_index of the element that provides the highest match score for a document.
+                doc_source_field_name = f"{new_field}_source_element_index"
+                if score >= doc.get(doc_source_field_name, 0):
+                    doc.properties[f"{new_field}"] = score
+                    doc.properties[f"{new_field}_source_element_index"] = element.element_index
+                if score >= threshold:
                     return True
                 evaluated_elements += 1
             if evaluated_elements == 0:  # no elements found for property

--- a/lib/sycamore/sycamore/tests/unit/test_docset.py
+++ b/lib/sycamore/sycamore/tests/unit/test_docset.py
@@ -392,8 +392,8 @@ class TestDocSet:
             Document(
                 doc_id="doc_2",
                 elements=[
-                    Element(text_representation="test2"),  # llm_filter result = 2,
-                    Element(text_representation="test1"),  # llm_filter result = 4
+                    Element(text_representation="test2", element_index=1),  # llm_filter result = 2,
+                    Element(text_representation="test1", element_index=2),  # llm_filter result = 4
                 ],
             ),
             Document(
@@ -419,6 +419,12 @@ class TestDocSet:
         assert taken[0].doc_id == "doc_1"
         assert taken[1].doc_id == "doc_2"
         assert mock_llm.generate.call_count == 4
+
+        # doc level field checks
+        assert taken[0].properties[new_field] == 4
+        assert taken[1].properties[new_field] == 4
+        assert taken[0].properties[new_field + "_source_element_index"] is None  # no index
+        assert taken[1].properties[new_field + "_source_element_index"] == 2
 
         filtered_docset = docset.llm_filter(
             new_field=new_field, prompt=[], field="text_representation", threshold=2, use_elements=True


### PR DESCRIPTION
Let's you look at a document and figure out what it's llm_filter score was + which element contributed to the highest score

We're probably want some generic version of this citation stuff for transforms that look at a doc's elements, but this is important for debugging right now