### PR TITLE
don't die if box is None in try_draw_boxes

### DIFF
--- a/lib/sycamore/sycamore/utils/image_utils.py
+++ b/lib/sycamore/sycamore/utils/image_utils.py
@@ -3,6 +3,7 @@ from io import BytesIO
 from packaging.version import InvalidVersion, Version
 from pathlib import Path
 from typing import Any, Callable, Optional, TypeVar, Union
+import logging
 import PIL
 from PIL import Image, ImageDraw, ImageFont
 from sycamore.data import Document
@@ -198,7 +199,11 @@ def try_draw_boxes(
         font = ImageFont.load_default()
 
     for i, box in enumerate(boxes):
-        raw_coords = coord_fn(box)
+        try:
+            raw_coords = coord_fn(box)
+        except:
+            logging.warn(f"Could not extract bbox coords from {box}")
+            continue
 
         # If the coordinates are all less than or equal to 1.0, then we treat them
         # as relative coordinates, and we convert them to absolute coordinates.

--- a/lib/sycamore/sycamore/utils/image_utils.py
+++ b/lib/sycamore/sycamore/utils/image_utils.py
@@ -201,7 +201,7 @@ def try_draw_boxes(
     for i, box in enumerate(boxes):
         try:
             raw_coords = coord_fn(box)
-        except:
+        except Exception:
             logging.warn(f"Could not extract bbox coords from {box}")
             continue
 


### PR DESCRIPTION
we got a table with a cell with no bbox. looking into where that came from but for now let's not crash if we can't get a bbox.

```python
doc = "s3://aryn-public/ntsb/FTW95FA129.pdf"
ds = ctx.read.binary(paths = doc, binary_format = "pdf").partition(ArynPartitioner(extract_table_structure=True, extract_images=True))
show_pages(ds)
```