### PR TITLE
when there's no table structure, take the token bbox for the cell bbox

### DIFF
--- a/lib/sycamore/sycamore/tests/unit/transforms/test_table_transfomers.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_table_transfomers.py
@@ -1,4 +1,4 @@
-from sycamore.transforms.table_structure.table_transformers import outputs_to_objects
+from sycamore.transforms.table_structure.table_transformers import outputs_to_objects, objects_to_table
 import torch
 import numpy as np
 
@@ -65,3 +65,90 @@ class TestTableTransformers:
         objects = outputs_to_objects(outputs, img_size, id2label)
 
         assert len(objects) == 0, "Invalid bbox should not be included in objects"
+
+    def test_no_structure_but_cell_bbox(self):
+        objects = [
+            {
+                "label": "table column",
+                "score": 0.9655721783638,
+                "bbox": [9.64848518371582, 11.819457054138184, 34.289146423339844, 299.254150390625],
+            },
+            {
+                "label": "table row",
+                "score": 0.8881772756576538,
+                "bbox": [12.466134071350098, 104.6300048828125, 1037.6905517578125, 136.64060974121094],
+                "column header": False,
+            },
+            {
+                "label": "table row",
+                "score": 0.7673768997192383,
+                "bbox": [12.334745407104492, 43.644412994384766, 1037.976806640625, 74.4501724243164],
+                "column header": False,
+            },
+            {
+                "label": "table column",
+                "score": 0.9910051822662354,
+                "bbox": [75.4512939453125, 0, 1035.6358642578125, 0],
+            },
+            {
+                "label": "table row",
+                "score": 0.8790714740753174,
+                "bbox": [12.15807819366455, 74.53314971923828, 1037.6246337890625, 105.62156677246094],
+                "column header": False,
+            },
+            {
+                "label": "table row",
+                "score": 0.9501585960388184,
+                "bbox": [12.459859848022461, 239.05477905273438, 1037.471923828125, 269.82366943359375],
+                "column header": False,
+            },
+            {
+                "label": "table row",
+                "score": 0.8935613036155701,
+                "bbox": [12.436494827270508, 178.2232208251953, 1037.421142578125, 208.3254852294922],
+                "column header": False,
+            },
+            {
+                "label": "table",
+                "score": 0.9958392381668091,
+                "bbox": [75.4512939453125, 0, 1035.6358642578125, 0],
+                "row_column_bbox": [75.4512939453125, 0, 1035.6358642578125, 0],
+            },
+            {
+                "label": "table row",
+                "score": 0.8249932527542114,
+                "bbox": [12.454593658447266, 148.0679931640625, 1037.531982421875, 177.94284057617188],
+                "column header": False,
+            },
+            {
+                "label": "table row",
+                "score": 0.9756750464439392,
+                "bbox": [12.40351390838623, 269.0418701171875, 1037.6041259765625, 299.9597473144531],
+                "column header": False,
+            },
+            {
+                "label": "table row",
+                "score": 0.5053465962409973,
+                "bbox": [12.367852210998535, 12.36871337890625, 1037.98388671875, 42.043609619140625],
+                "column header": False,
+            },
+            {
+                "label": "table row",
+                "score": 0.942719042301178,
+                "bbox": [12.402883529663086, 208.52511596679688, 1037.5247802734375, 239.34768676757812],
+                "column header": False,
+            },
+        ]
+        tokens = [
+            {
+                "text": "Something really long in the original",
+                "bbox": [14.906158447265625, 16.469563589409574, 1038.4617140028206, 334.5223640894096],
+                "span_num": 0,
+                "line_num": 0,
+                "block_num": 0,
+            }
+        ]
+
+        table = objects_to_table(objects, tokens)
+        assert table is not None
+        assert all(c.bbox is not None for c in table.cells)

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -174,6 +174,8 @@ class TableTransformerStructureExtractor(TableStructureExtractor):
 
         # Convert the raw objects to our internal table representation. This involves multiple
         # phases of postprocessing.
+        element.properties["backup_tokens"] = tokens
+        element.properties["object"] = objects
         table = table_transformers.objects_to_table(objects, tokens, union_tokens=union_tokens)
 
         if table is None:

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -174,8 +174,6 @@ class TableTransformerStructureExtractor(TableStructureExtractor):
 
         # Convert the raw objects to our internal table representation. This involves multiple
         # phases of postprocessing.
-        element.properties["backup_tokens"] = tokens
-        element.properties["object"] = objects
         table = table_transformers.objects_to_table(objects, tokens, union_tokens=union_tokens)
 
         if table is None:

--- a/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
@@ -119,6 +119,10 @@ def objects_to_table(
         if not tokens:
             return None
 
+        bb = BoundingBox(*tokens[0]["bbox"])
+        for t in tokens[1:]:
+            bb.union_self(BoundingBox(*t["bbox"]))
+
         table_cells = []
         table_cells.append(
             TableCell(
@@ -126,6 +130,7 @@ def objects_to_table(
                 cols=[0],
                 is_header=False,
                 content="\n".join(token["text"] for token in tokens),
+                bbox=bb,
             )
         )
         return Table(table_cells)
@@ -156,6 +161,10 @@ def objects_to_table(
         if not tokens:
             return None
 
+        bb = BoundingBox(*tokens[0]["bbox"])
+        for t in tokens[1:]:
+            bb.union_self(BoundingBox(*t["bbox"]))
+
         table_cells = []
         table_cells.append(
             TableCell(
@@ -163,6 +172,7 @@ def objects_to_table(
                 cols=[0],
                 is_header=False,
                 content="\n".join(token["text"] for token in tokens),
+                bbox=bb,
             )
         )
 


### PR DESCRIPTION
Found the codepath where we don't attach a bbox to the table cells