### PR TITLE
Fix `split_elements` for table elements with no `elem.table` attribute

### DIFF
--- a/lib/sycamore/sycamore/transforms/split_elements.py
+++ b/lib/sycamore/sycamore/transforms/split_elements.py
@@ -121,9 +121,7 @@ class SplitElements(SingleThreadUser, NonGPUUser, Map):
         ment = elem.copy()
         elem.text_representation = one
         elem.binary_representation = bytes(one, "utf-8")
-        if elem.type == "table":
-            if not isinstance(elem, TableElement) or elem.table is None:
-                raise ValueError("Element must be tableElement/ have table to perform splitting.")
+        if elem.type == "table" and isinstance(elem, TableElement) and elem.table is not None:
             if elem.table.column_headers:
                 two = ", ".join(elem.table.column_headers) + "\n" + two
             if elem.data["properties"].get("title"):


### PR DESCRIPTION
Previously, splitting documents that contained tables after partitioning them without using `extract_table_structure` could cause an exception to be raised when splitting a table element. This fix allows those documents to be split without error.