### PR TITLE
Fix Extract Schema Empty Return

### DIFF
--- a/lib/sycamore/sycamore/connectors/elasticsearch/elasticsearch_writer.py
+++ b/lib/sycamore/sycamore/connectors/elasticsearch/elasticsearch_writer.py
@@ -6,7 +6,7 @@ from sycamore.utils.import_utils import requires_modules
 
 from sycamore.data.document import Document
 from sycamore.connectors.base_writer import BaseDBWriter
-from sycamore.connectors.common import flatten_data, check_dictionary_compatibility
+from sycamore.connectors.common import flatten_data, check_dictionary_compatibility, drop_types
 
 if typing.TYPE_CHECKING:
     from elasticsearch import Elasticsearch
@@ -90,7 +90,7 @@ class ElasticsearchWriterClient(BaseDBWriter.Client):
                     yield {
                         "_index": target_params.index_name,
                         "_id": r.doc_id,
-                        "properties": r.properties,
+                        "properties": drop_types(r.properties),
                         "embedding": r.embedding,
                         "parent_id": r.parent_id,
                     }

--- a/lib/sycamore/sycamore/transforms/extract_schema.py
+++ b/lib/sycamore/sycamore/transforms/extract_schema.py
@@ -174,7 +174,8 @@ class LLMPropertyExtractor(PropertyExtractor):
             answer = extract_json(payload)
         except (json.JSONDecodeError, AttributeError):
             answer = entities
-
+        if answer == "None":
+            answer = {}
         if "entity" in document.properties:
             document.properties["entity"].update(answer)
         else:


### PR DESCRIPTION
Extract schema would previously return a string with `None` in failure cases which is incompatible with the normal dictionary return type. This was causing issues when writing out to connectors, and is fixed here.