### PR TITLE
Fix create_element to not crash on bad element types

### DIFF
--- a/lib/sycamore/sycamore/data/element.py
+++ b/lib/sycamore/sycamore/data/element.py
@@ -244,7 +244,7 @@ def create_element(element_index: Optional[int] = None, **kwargs) -> Element:
         type = type.lower()
     else:
         type = ""
-    
+
     if type == "table":
         if "properties" in kwargs:
             props = kwargs["properties"]

--- a/lib/sycamore/sycamore/tests/unit/data/test_element.py
+++ b/lib/sycamore/sycamore/tests/unit/data/test_element.py
@@ -1,0 +1,12 @@
+from sycamore.data.element import create_element, Element, ImageElement
+
+
+def test_create_element_bad_type():
+    e = create_element(type=None)
+    assert isinstance(e, Element)
+
+    e = create_element(type={})
+    assert isinstance(e, Element)
+
+    e = create_element(type="iMaGE")
+    assert isinstance(e, ImageElement)


### PR DESCRIPTION
Ran into a case of custom document processing that resulted in a missing element type.
