### PR TITLE
Increase max recursion depth for `split_element`'s `split_one`

### DIFF
--- a/lib/sycamore/sycamore/transforms/split_elements.py
+++ b/lib/sycamore/sycamore/transforms/split_elements.py
@@ -46,8 +46,8 @@ class SplitElements(SingleThreadUser, NonGPUUser, Map):
 
     @staticmethod
     def split_one(elem: Element, tokenizer: Tokenizer, max: int, depth: int = 0) -> list[Element]:
-        if depth > 10:
-            logger.warning(f"Max split depth exceeded, truncating at element: {elem}")
+        if depth > 20:
+            logger.warning(f"Max split depth exceeded, truncating splitting")
             return [elem]
 
         txt = elem.text_representation

--- a/lib/sycamore/sycamore/transforms/split_elements.py
+++ b/lib/sycamore/sycamore/transforms/split_elements.py
@@ -47,7 +47,7 @@ class SplitElements(SingleThreadUser, NonGPUUser, Map):
     @staticmethod
     def split_one(elem: Element, tokenizer: Tokenizer, max: int, depth: int = 0) -> list[Element]:
         if depth > 20:
-            logger.warning(f"Max split depth exceeded, truncating splitting")
+            logger.warning(f"Max split depth exceeded, truncating the splitting")
             return [elem]
 
         txt = elem.text_representation

--- a/lib/sycamore/sycamore/transforms/split_elements.py
+++ b/lib/sycamore/sycamore/transforms/split_elements.py
@@ -47,7 +47,7 @@ class SplitElements(SingleThreadUser, NonGPUUser, Map):
     @staticmethod
     def split_one(elem: Element, tokenizer: Tokenizer, max: int, depth: int = 0) -> list[Element]:
         if depth > 20:
-            logger.warning(f"Max split depth exceeded, truncating the splitting")
+            logger.warning("Max split depth exceeded, truncating the splitting")
             return [elem]
 
         txt = elem.text_representation


### PR DESCRIPTION
Also stops logging the element the recursion stopped on. We are increasing the recursion depth of the temporary fix from #1073 so that it is less likely to cause `split_elements` to fail on documents that worked before.