### PR TITLE
Add-tokenizer-and-reranking-to-LLM-ExtractEntity

### DIFF
--- a/lib/sycamore/sycamore/docset.py
+++ b/lib/sycamore/sycamore/docset.py
@@ -1038,10 +1038,10 @@ class DocSet:
             return self.filter(f, **resource_args)
 
         from sycamore.transforms.llm_filter import (
-            make_element_sorter_fn,
             tokenized_threshold_llm_filter,
             untokenized_threshold_llm_filter,
         )
+        from sycamore.utils.similarity import make_element_sorter_fn
 
         element_sorter = make_element_sorter_fn(field, similarity_query, similarity_scorer)
 

--- a/lib/sycamore/sycamore/tests/unit/test_docset.py
+++ b/lib/sycamore/sycamore/tests/unit/test_docset.py
@@ -43,13 +43,16 @@ class MockLLM(LLM):
 
     def generate(self, *, prompt_kwargs: dict, llm_kwargs: Optional[dict] = None):
         if (
+            prompt_kwargs == {"messages": [{"role": "user", "content": "Element_index: 1\nText: third element\n"}]}
+            and llm_kwargs == {}
+        ):
+            return "None"
+        elif (
             "first short element" in prompt_kwargs["messages"][0]["content"]
             and "second longer element with more words" in prompt_kwargs["messages"][0]["content"]
             and llm_kwargs == {}
         ):
             return "4"
-        elif "third element" in prompt_kwargs["messages"][0]["content"] and llm_kwargs == {}:
-            return "2"
         elif (
             "very long element with many words that might exceed token limit" in prompt_kwargs["messages"][0]["content"]
             and llm_kwargs == {}
@@ -94,6 +97,11 @@ class TestSimilarityScorer(SimilarityScorer):
         for _, content in inputs:
             results += [1.0 if content == "test2" else 0.0]
         return results
+
+
+class MockTokenizer:
+    def tokenize(self, text):
+        return text.split()
 
 
 class TestDocSet:

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_extract_entity.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_extract_entity.py
@@ -1,9 +1,10 @@
 from typing import Optional
 import logging
+from unittest.mock import MagicMock
 
-
-from sycamore import Context
-from sycamore.data import Document
+import sycamore
+from sycamore.context import Context, OperationTypes, ExecMode
+from sycamore.data import Document, Element
 from sycamore.transforms import ExtractEntity
 from sycamore.transforms.extract_entity import OpenAIEntityExtractor
 from sycamore.llms import LLM
@@ -11,6 +12,9 @@ from sycamore.llms.prompts.default_prompts import (
     EntityExtractorFewShotGuidancePrompt,
     EntityExtractorZeroShotGuidancePrompt,
 )
+from sycamore.tests.unit.test_docset import TestSimilarityScorer, MockTokenizer
+from sycamore.tests.unit.test_docset import MockLLM as docsetMockLLM
+from sycamore.tests.unit.transforms.test_llm_filter import tokenizer_doc
 
 
 class MockLLM(LLM):
@@ -136,3 +140,107 @@ class TestEntityExtraction:
         )
         out_doc = extract_entity.run(self.doc)
         assert out_doc.properties.get("title") == "alt_title"
+
+    def test_extract_entity_with_similarity_sorting(self, mocker):
+        doc_list = [
+            Document(
+                doc_id="doc_1",
+                elements=[
+                    Element(properties={"_element_index": 1}, text_representation="test1"),
+                    Element(properties={"_element_index": 2}, text_representation="test1"),
+                ],
+            ),
+            Document(
+                doc_id="doc_2",
+                elements=[
+                    Element(properties={"_element_index": 4}, text_representation="test1"),
+                    Element(properties={"_element_index": 9}, text_representation="test2"),
+                ],
+            ),
+            Document(
+                doc_id="doc_3",
+                elements=[
+                    Element(properties={"_element_index": 1}, text_representation="test2"),
+                ],
+            ),
+            Document(doc_id="doc_4", text_representation="empty elements, maybe an exploded doc", elements=[]),
+        ]
+        mock_llm = docsetMockLLM()
+        similarity_scorer = TestSimilarityScorer()
+        mock_llm.generate = MagicMock(wraps=mock_llm.generate)
+        context = sycamore.init(
+            params={
+                OperationTypes.BINARY_CLASSIFIER: {"llm": mock_llm},
+                OperationTypes.TEXT_SIMILARITY: {"similarity_scorer": similarity_scorer},
+            },
+            exec_mode=ExecMode.LOCAL,
+        )
+        docset = context.read.document(doc_list)
+        new_field = "_autogen_LLMExtractEntityOutput"
+        entity_extractor = OpenAIEntityExtractor(
+            new_field,
+            llm=mock_llm,
+            use_elements=True,
+            prompt=[],
+            field="text_representation",
+            similarity_scorer=similarity_scorer,
+            similarity_query="this is an unused query because unit test",
+        )
+
+        entity_docset = docset.extract_entity(
+            entity_extractor=entity_extractor,
+        )
+        entity_docset.show()
+        taken = entity_docset.take()
+        assert len(taken) == 4
+        assert len(taken[0].elements) == 2
+        assert (taken[1].elements[0]["properties"]["_element_index"]) == 9
+        assert (taken[1].elements[1]["properties"]["_element_index"]) == 4
+        assert (taken[0].elements[1]["properties"]["_element_index"]) == 2
+
+    def test_extract_entity_with_tokenizer(self, mocker):
+        mock_llm = docsetMockLLM()
+        mock_tokenizer = MockTokenizer()
+        similarity_scorer = TestSimilarityScorer()
+        mock_llm.generate = MagicMock(wraps=mock_llm.generate)
+        context = sycamore.init(
+            params={
+                OperationTypes.BINARY_CLASSIFIER: {"llm": mock_llm},
+                OperationTypes.TEXT_SIMILARITY: {"similarity_scorer": similarity_scorer},
+            },
+            exec_mode=ExecMode.LOCAL,
+        )
+        docset = context.read.document(tokenizer_doc)
+        new_field = "_autogen_LLMExtractEntityOutput"
+        entity_extractor = OpenAIEntityExtractor(
+            new_field,
+            llm=mock_llm,
+            use_elements=True,
+            prompt=[],
+            field="text_representation",
+            tokenizer=mock_tokenizer,
+            max_tokens=10,  # Low token limit to test windowing
+        )
+
+        entity_docset = docset.extract_entity(
+            entity_extractor=entity_extractor,
+        )
+        entity_docset.show()
+        taken = entity_docset.take()
+        for ele in taken:
+            print(ele.properties)
+        assert taken[0].properties[f"{new_field}_source_element_index"] == {0, 1, 2}
+        assert taken[1].properties[f"{new_field}_source_element_index"] == {2}
+        print(taken[0].properties[new_field])
+        assert taken[0].properties[new_field] == "4"
+        assert taken[1].properties[new_field] == "5"
+        assert taken[0].elements[0]["properties"]["_autogen_LLMExtractEntityOutput_source_element_index"] == {0, 1, 2}
+        assert taken[0].elements[1]["properties"]["_autogen_LLMExtractEntityOutput_source_element_index"] == {0, 1, 2}
+        assert taken[0].elements[2]["properties"]["_autogen_LLMExtractEntityOutput_source_element_index"] == {0, 1, 2}
+        assert taken[1].elements[0]["properties"]["_autogen_LLMExtractEntityOutput_source_element_index"] == {1}
+        assert taken[1].elements[1]["properties"]["_autogen_LLMExtractEntityOutput_source_element_index"] == {2}
+        assert taken[0].elements[0]["properties"]["_autogen_LLMExtractEntityOutput"] == "4"
+        assert taken[0].elements[1]["properties"]["_autogen_LLMExtractEntityOutput"] == "4"
+        assert taken[0].elements[2]["properties"]["_autogen_LLMExtractEntityOutput"] == "4"
+        assert taken[1].elements[0]["properties"]["_autogen_LLMExtractEntityOutput"] == "None"
+        assert taken[1].elements[1]["properties"]["_autogen_LLMExtractEntityOutput"] == "5"

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_extract_entity.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_extract_entity.py
@@ -190,7 +190,6 @@ class TestEntityExtraction:
         entity_docset = docset.extract_entity(
             entity_extractor=entity_extractor,
         )
-        entity_docset.show()
         taken = entity_docset.take()
         assert len(taken) == 4
         assert len(taken[0].elements) == 2
@@ -225,13 +224,9 @@ class TestEntityExtraction:
         entity_docset = docset.extract_entity(
             entity_extractor=entity_extractor,
         )
-        entity_docset.show()
         taken = entity_docset.take()
-        for ele in taken:
-            print(ele.properties)
         assert taken[0].properties[f"{new_field}_source_element_index"] == {0, 1, 2}
         assert taken[1].properties[f"{new_field}_source_element_index"] == {2}
-        print(taken[0].properties[new_field])
         assert taken[0].properties[new_field] == "4"
         assert taken[1].properties[new_field] == "5"
         assert taken[0].elements[0]["properties"]["_autogen_LLMExtractEntityOutput_source_element_index"] == {0, 1, 2}

--- a/lib/sycamore/sycamore/transforms/similarity.py
+++ b/lib/sycamore/sycamore/transforms/similarity.py
@@ -7,7 +7,7 @@ from sycamore.utils.import_utils import requires_modules
 
 from sycamore.data import Document, Element
 from sycamore.plan_nodes import Node
-from sycamore.transforms import MapBatch
+from sycamore.transforms.map import MapBatch
 from sycamore.utils import choose_device
 from sycamore.utils.time_trace import timetrace
 

--- a/lib/sycamore/sycamore/utils/llm_utils.py
+++ b/lib/sycamore/sycamore/utils/llm_utils.py
@@ -1,0 +1,51 @@
+from sycamore.data import Element
+from sycamore.functions.tokenizer import Tokenizer
+
+
+def merge_elements(
+    index: int,
+    elements: list[Element],
+    field: str,
+    tokenizer: Tokenizer,
+    max_tokens: int,
+) -> tuple[int, str, set]:
+    """
+    Processes document elements to generate combined text adhering to token limit.
+
+    Args:
+        index: index of element to start on
+        elements (list): List of document elements.
+        field (str): The field to extract values from elements.
+        tokenizer: Tokenizer to split text into tokens.
+        max_tokens (int): Maximum number of tokens allowed.
+
+    Returns:
+        tuple[int, str, set]:
+            Updated index after processing,
+            Combined text of processed elements,
+            Set of indices of processed elements.
+
+    """
+    combined_text = ""
+    window_indices = set()
+    current_tokens = 0
+    for element in elements[index:]:
+        txt = element.field_to_value(field)
+        if not txt:
+            index += 1
+            window_indices.add(element.element_index)
+            continue
+        element_tokens = len(tokenizer.tokenize(txt))
+        if current_tokens + element_tokens > max_tokens and current_tokens != 0:
+            break
+        if "type" in element:
+            combined_text += f"Element type: {element['type']}\n"
+        if "page_number" in element["properties"]:
+            combined_text += f"Page_number: {element['properties']['page_number']}\n"
+        if "_element_index" in element["properties"]:
+            combined_text += f"Element_index: {element['properties']['_element_index']}\n"
+        combined_text += f"Text: {txt}\n"
+        window_indices.add(element.element_index)
+        current_tokens += element_tokens
+        index += 1
+    return index, combined_text, window_indices

--- a/lib/sycamore/sycamore/utils/similarity.py
+++ b/lib/sycamore/sycamore/utils/similarity.py
@@ -1,6 +1,7 @@
 from typing import Optional
 from sycamore.transforms.similarity import SimilarityScorer
 
+
 def make_element_sorter_fn(field: str, similarity_query: Optional[str], similarity_scorer: Optional[SimilarityScorer]):
     assert not (
         (similarity_query is None) ^ (similarity_scorer is None)

--- a/lib/sycamore/sycamore/utils/similarity.py
+++ b/lib/sycamore/sycamore/utils/similarity.py
@@ -1,0 +1,18 @@
+from typing import Optional
+from sycamore.transforms.similarity import SimilarityScorer
+
+def make_element_sorter_fn(field: str, similarity_query: Optional[str], similarity_scorer: Optional[SimilarityScorer]):
+    assert not (
+        (similarity_query is None) ^ (similarity_scorer is None)
+    ), "set both or neither of similarity_query and similarity_scorer"
+    if similarity_query is None:
+        return lambda d: None
+
+    def f(doc):
+        score_property_name = f"{field}_similarity_score"
+        doc = similarity_scorer.generate_similarity_scores(
+            doc_batch=[doc], query=similarity_query, score_property_name=score_property_name
+        )[0]
+        doc.elements.sort(key=lambda e: e.properties.get(score_property_name, float("-inf")), reverse=True)
+
+    return f


### PR DESCRIPTION
1. Added reranking of elements and element merging/chunking for robustness in LLM Extract Entity. (Works only if LLM returns "None" if it doesn't find the entity in the chunk, which is the default in Luna operator prompt)
2. Refactored code to make use of element similarity sorter, mock tokenizer.
3. Minor bug fix: changed element_index to _element_index for adding to content for LLM Filter.