### PR TITLE
Schema object + entity extraction support

### DIFF
--- a/lib/sycamore/sycamore/docset.py
+++ b/lib/sycamore/sycamore/docset.py
@@ -697,7 +697,7 @@ class DocSet:
             .. code-block:: python
 
                 openai_llm = OpenAI(OpenAIModels.GPT_3_5_TURBO.value)
-                property_extractor = OpenAIPropertyExtractor(OpenaAIPropertyExtrator(llm=openai_llm))
+                property_extractor = OpenAIPropertyExtractor(OpenAIPropertyExtractor(llm=openai_llm))
 
                 context = sycamore.init()
 

--- a/lib/sycamore/sycamore/llms/prompts/default_prompts.py
+++ b/lib/sycamore/sycamore/llms/prompts/default_prompts.py
@@ -2,6 +2,8 @@ import logging
 from abc import ABC
 from typing import Any, Optional, Type
 
+from sycamore.schema import Schema
+
 logger = logging.getLogger(__name__)
 
 
@@ -71,16 +73,6 @@ class SchemaZeroShotGuidancePrompt(SimplePrompt):
     class {entity} from the document. Using this context, FIND, FORMAT, and RETURN the JSON-LD Schema.
     Return a flat schema, without nested properties. Return at most {max_num_properties} properties.
     Only return JSON Schema as part of your answer.
-    {query}
-    """
-
-
-class PropertiesZeroShotGuidancePrompt(SimplePrompt):
-    system = "You are a helpful property extractor. You only return JSON."
-    user = """You are given a few text elements of a document. Extract JSON representing one entity of
-    class {entity} from the document. The class only has properties {properties}. Using
-    this context, FIND, FORMAT, and RETURN the JSON representing one {entity}.
-    Only return JSON as part of your answer. If no entity is in the text, return "None".
     {query}
     """
 
@@ -170,6 +162,49 @@ class ExtractTablePropertiesPrompt(SimplePrompt):
             return ```{"header1": null, "header2": "value2", "header3": null, "header4": null, "header5": null, "header6": null}```
 
             """
+
+
+class ExtractPropertiesFromSchemaPrompt(SimplePrompt):
+    def __init__(self, schema: Schema, text: str):
+        super().__init__()
+
+        self.system = "You are given text contents from a document."
+        self.user = f"""
+        Extract values for the following fields:
+        {self._format_schema(schema)}
+        
+        Document text:
+        {text}
+        
+        Return your answers as a json dictionary, do not return any extra information.
+        If you cannot find a value, use the provided default or None.
+"""
+
+    @staticmethod
+    def _format_schema(schema: Schema) -> str:
+        text = ""
+        for i, field in enumerate(schema.fields):
+            text += f"""
+            {i} {field.name}: type={field.field_type}: default={field.default}
+                {field.description}\n
+                Examples values: {field.examples}
+                
+"""
+        return text
+
+
+class PropertiesZeroShotGuidancePrompt(SimplePrompt):
+    def __init__(self, entity: str, properties: Any, text: str):
+        super().__init__()
+
+        self.system = "You are a helpful property extractor. You only return JSON."
+
+        self.user = f"""You are given a few text elements of a document. Extract JSON representing one entity of
+        class {entity} from the document. The class only has properties {properties}. Using
+        this context, FIND, FORMAT, and RETURN the JSON representing one {entity}.
+        Only return JSON as part of your answer. If no entity is in the text, return "None".
+        {text}
+        """
 
 
 class EntityExtractorMessagesPrompt(SimplePrompt):

--- a/lib/sycamore/sycamore/llms/prompts/default_prompts.py
+++ b/lib/sycamore/sycamore/llms/prompts/default_prompts.py
@@ -194,12 +194,12 @@ class ExtractPropertiesFromSchemaPrompt(SimplePrompt):
 
 
 class PropertiesZeroShotGuidancePrompt(SimplePrompt):
-    def __init__(self, entity: str, properties: Any, text: str):
+    def __init__(self):
         super().__init__()
 
         self.system = "You are a helpful property extractor. You only return JSON."
 
-        self.user = f"""You are given a few text elements of a document. Extract JSON representing one entity of
+        self.user = """You are given a few text elements of a document. Extract JSON representing one entity of
         class {entity} from the document. The class only has properties {properties}. Using
         this context, FIND, FORMAT, and RETURN the JSON representing one {entity}.
         Only return JSON as part of your answer. If no entity is in the text, return "None".

--- a/lib/sycamore/sycamore/query/schema.py
+++ b/lib/sycamore/sycamore/query/schema.py
@@ -13,7 +13,7 @@ if typing.TYPE_CHECKING:
 
 
 class OpenSearchSchemaField(BaseModel):
-    """Represents a field in an OpenSearch schema."""
+    """DEPRECATED: Migrating to docset.SchemaField."""
 
     field_type: str
     """The type of the field."""
@@ -26,7 +26,7 @@ class OpenSearchSchemaField(BaseModel):
 
 
 class OpenSearchSchema(BaseModel):
-    """Represents the schema of an OpenSearch index."""
+    """DEPRECATED: Migrating to docset.Schema."""
 
     fields: Dict[str, OpenSearchSchemaField]
     """A mapping from field name to field type and example values."""

--- a/lib/sycamore/sycamore/schema.py
+++ b/lib/sycamore/sycamore/schema.py
@@ -1,0 +1,27 @@
+from typing import Optional, Any
+
+from pydantic import BaseModel
+
+
+class SchemaField(BaseModel):
+    """Represents a field in a DocSet schema."""
+
+    name: str
+
+    field_type: str
+    """The type of the field."""
+
+    default: Optional[Any] = None
+
+    description: Optional[str] = None
+    """A natural language description of the field."""
+
+    examples: Optional[list[Any]] = None
+    """A list of example values for the field."""
+
+
+class Schema(BaseModel):
+    """Represents the schema of a DocSet."""
+
+    fields: list[SchemaField]
+    """A list of fields belong to this schema."""

--- a/lib/sycamore/sycamore/schema.py
+++ b/lib/sycamore/sycamore/schema.py
@@ -7,11 +7,13 @@ class SchemaField(BaseModel):
     """Represents a field in a DocSet schema."""
 
     name: str
+    """The name of the field."""
 
     field_type: str
     """The type of the field."""
 
     default: Optional[Any] = None
+    """The default value for the field."""
 
     description: Optional[str] = None
     """A natural language description of the field."""

--- a/lib/sycamore/sycamore/tests/integration/transforms/test_data_extraction.py
+++ b/lib/sycamore/sycamore/tests/integration/transforms/test_data_extraction.py
@@ -11,13 +11,15 @@ def test_extract_properties_from_schema():
         Document(
             {
                 "doc_id": "doc_1",
-                "text_representation": "My name is Vinayak & I'm a 74 year old software engineer from Honolulu Hawaii",
+                "text_representation": "My name is Vinayak & I'm a 74 year old software engineer from Honolulu Hawaii. "
+                "This information was written on feb 24, 1923",
             }
         ),
         Document(
             {
                 "doc_id": "doc_2",
-                "text_representation": "is a strange case of anti-viral research found in New Delhi.",
+                "text_representation": "is a strange case of anti-viral research found in New Delhi.\n "
+                "info date: jan eleven 2014",
             }
         ),
     ]
@@ -31,6 +33,7 @@ def test_extract_properties_from_schema():
                 examples=["Mark", "Ollie", "Winston"],
             ),
             SchemaField(name="age", field_type="int", default=999),
+            SchemaField(name="date", field_type="str", description="Any date in the doc in YYYY-MM-DD format"),
             SchemaField(
                 name="from_location",
                 field_type="str",
@@ -52,7 +55,9 @@ def test_extract_properties_from_schema():
     assert taken[0].properties["entity"]["name"] == "Vinayak"
     assert taken[0].properties["entity"]["age"] == 74
     assert taken[0].properties["entity"]["from_location"] == "Honolulu, HI", "Invalid location extracted or formatted"
+    assert taken[0].properties["entity"]["date"] == "1923-02-24"
 
     assert taken[1].properties["entity"]["name"] is None, "Default None value not being used correctly"
     assert taken[1].properties["entity"]["age"] == 999, "Default value not being used correctly"
     assert taken[1].properties["entity"]["from_location"] == "New Delhi"
+    assert taken[1].properties["entity"]["date"] == "2014-01-11"

--- a/lib/sycamore/sycamore/tests/integration/transforms/test_data_extraction.py
+++ b/lib/sycamore/sycamore/tests/integration/transforms/test_data_extraction.py
@@ -1,0 +1,58 @@
+import sycamore
+from sycamore import ExecMode
+from sycamore.data import Document
+from sycamore.schema import Schema, SchemaField
+from sycamore.llms import OpenAI, OpenAIModels
+from sycamore.transforms.extract_schema import LLMPropertyExtractor
+
+
+def test_extract_properties_from_schema():
+    docs = [
+        Document(
+            {
+                "doc_id": "doc_1",
+                "text_representation": "My name is Vinayak & I'm a 74 year old software engineer from Honolulu Hawaii",
+            }
+        ),
+        Document(
+            {
+                "doc_id": "doc_2",
+                "text_representation": "is a strange case of anti-viral research found in New Delhi.",
+            }
+        ),
+    ]
+
+    schema = Schema(
+        fields=[
+            SchemaField(
+                name="name",
+                field_type="str",
+                description="This is the name of an entity",
+                examples=["Mark", "Ollie", "Winston"],
+            ),
+            SchemaField(name="age", field_type="int", default=999),
+            SchemaField(
+                name="from_location",
+                field_type="str",
+                description="This is the location the entity is from. "
+                "If it's a US location and explicitly states a city and state, format it as 'City, State' "
+                "The state is abbreviated in it's standard 2 letter form.",
+                examples=["Ann Arbor, MI", "Seattle, WA", "New Delhi"],
+            ),
+        ]
+    )
+    property_extractor = LLMPropertyExtractor(OpenAI(OpenAIModels.GPT_4O), schema=schema)
+
+    ctx = sycamore.init(exec_mode=ExecMode.LOCAL)
+    docs = ctx.read.document(docs)
+    docs = docs.extract_properties(property_extractor)
+
+    taken = docs.take_all()
+
+    assert taken[0].properties["entity"]["name"] == "Vinayak"
+    assert taken[0].properties["entity"]["age"] == 74
+    assert taken[0].properties["entity"]["from_location"] == "Honolulu, HI", "Invalid location extracted or formatted"
+
+    assert taken[1].properties["entity"]["name"] is None, "Default None value not being used correctly"
+    assert taken[1].properties["entity"]["age"] == 999, "Default value not being used correctly"
+    assert taken[1].properties["entity"]["from_location"] == "New Delhi"

--- a/lib/sycamore/sycamore/tests/integration/transforms/test_data_extraction.py
+++ b/lib/sycamore/sycamore/tests/integration/transforms/test_data_extraction.py
@@ -6,7 +6,7 @@ from sycamore.llms import OpenAI, OpenAIModels
 from sycamore.transforms.extract_schema import LLMPropertyExtractor
 
 
-def test_extract_properties_from_schema():
+def get_docs():
     docs = [
         Document(
             {
@@ -23,6 +23,27 @@ def test_extract_properties_from_schema():
             }
         ),
     ]
+    return docs
+
+
+def test_extract_properties_from_dict_schema():
+    docs = get_docs()[:1]  # only validate first doc because of technique reliability
+    schema = {"name": "str", "age": "int", "date": "str", "from_location": "str"}
+    property_extractor = LLMPropertyExtractor(OpenAI(OpenAIModels.GPT_4O), schema=schema, schema_name="entity")
+
+    ctx = sycamore.init(exec_mode=ExecMode.LOCAL)
+    docs = ctx.read.document(docs)
+    docs = docs.extract_properties(property_extractor)
+
+    taken = docs.take_all()
+
+    assert taken[0].properties["entity"]["name"] == "Vinayak"
+    assert taken[0].properties["entity"]["age"] == 74
+    assert "Honolulu" in taken[0].properties["entity"]["from_location"]
+
+
+def test_extract_properties_from_schema():
+    docs = get_docs()
 
     schema = Schema(
         fields=[

--- a/lib/sycamore/sycamore/transforms/extract_schema.py
+++ b/lib/sycamore/sycamore/transforms/extract_schema.py
@@ -202,10 +202,13 @@ class LLMPropertyExtractor(PropertyExtractor):
             schema_name = self._schema_name or document.properties.get("_schema_class")
             assert schema_name is not None, "Schema name must be provided or detected before extracting properties."
 
-            prompt = PropertiesZeroShotGuidancePrompt()
-
             entities = self._llm.generate(
-                prompt_kwargs={"prompt": prompt, "entity": schema_name, "properties": schema, "text": text}
+                prompt_kwargs={
+                    "prompt": PropertiesZeroShotGuidancePrompt(),
+                    "entity": schema_name,
+                    "properties": schema,
+                    "text": text,
+                }
             )
         return entities
 

--- a/lib/sycamore/sycamore/transforms/extract_schema.py
+++ b/lib/sycamore/sycamore/transforms/extract_schema.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Callable, Any, Optional, Tuple, Union
+from typing import Callable, Any, Optional, Union
 import json
 
 from sycamore.data import Element, Document


### PR DESCRIPTION
(This is a sequence of PRs)

Introduces a Schema class in sycamore. Allows you to extract properties from that schema in the `extract_properties` transform. Test validates some basic cleanup and formatting in the extracted info

Next big step will be to refactor sycamore.query to work against this object.