### PR TITLE
Add Embed at Element Level

### DIFF
--- a/lib/sycamore/sycamore/data/element.py
+++ b/lib/sycamore/sycamore/data/element.py
@@ -76,6 +76,16 @@ class Element(UserDict):
     def properties(self) -> None:
         self.data["properties"] = {}
 
+    @property
+    def embedding(self) -> Optional[list[float]]:
+        """Get the embedding for this element."""
+        return self.data.get("embedding")
+
+    @embedding.setter
+    def embedding(self, embedding: list[float]) -> None:
+        """Set the embedding for this element."""
+        self.data["embedding"] = embedding
+
     def __str__(self) -> str:
         """Return a pretty-printed string representing this Element."""
         d = {
@@ -84,6 +94,7 @@ class Element(UserDict):
             "binary_representation": (
                 f"<{len(self.binary_representation)} bytes>" if self.binary_representation else None
             ),
+            "embedding": (str(self.embedding[0:4]) + f"... <{len(self.embedding)} total>") if self.embedding else None,
             "bbox": str(self.bbox),
             "properties": {k: str(v) for k, v in self.properties.items()},
         }

--- a/lib/sycamore/sycamore/docset.py
+++ b/lib/sycamore/sycamore/docset.py
@@ -96,6 +96,13 @@ class DocSet:
             amount_truncated = len(s) - truncate_length
             return s[:truncate_length] + f" <{amount_truncated} chars>"
 
+        def _format_embedding(embedding):
+            """Format the embedding to display its length."""
+            if embedding is not None:
+                embedding_length = len(embedding)
+                return f"<{embedding_length} floats>"
+            return None
+
         for document in documents:
             if not show_elements:
                 num_elems = len(document.elements)
@@ -112,8 +119,7 @@ class DocSet:
                 document.text_representation = _truncate(document.text_representation)
 
             if not show_embedding and document.embedding is not None:
-                embedding_length = len(document.embedding)
-                document.data["embedding"] = f"<{embedding_length} floats>"
+                document.data["embedding"] = _format_embedding(document.embedding)
 
             if show_elements and "elements" in document.data:
                 if not show_binary:
@@ -126,9 +132,7 @@ class DocSet:
                         if e.get("text_representation") is not None:
                             e["text_representation"] = _truncate(e["text_representation"])
                         if e.get("embedding") is not None:
-                            embedding_length = len(e.embedding)
-                            e.data["embedding"] = f"<{embedding_length} floats>"
-
+                            e.data["embedding"] = _format_embedding(e.embedding)
             pprint.pp(document, stream=stream)
 
     def count(self, include_metadata=False, **kwargs) -> int:

--- a/lib/sycamore/sycamore/docset.py
+++ b/lib/sycamore/sycamore/docset.py
@@ -125,6 +125,9 @@ class DocSet:
                     for i, e in enumerate(document.data["elements"]):
                         if e.get("text_representation") is not None:
                             e["text_representation"] = _truncate(e["text_representation"])
+                        if e.get("embedding") is not None:
+                            embedding_length = len(e.embedding)
+                            e.data["embedding"] = f"<{embedding_length} floats>"
 
             pprint.pp(document, stream=stream)
 

--- a/lib/sycamore/sycamore/docset.py
+++ b/lib/sycamore/sycamore/docset.py
@@ -98,10 +98,9 @@ class DocSet:
 
         def _format_embedding(embedding):
             """Format the embedding to display its length."""
-            if embedding is not None:
-                embedding_length = len(embedding)
-                return f"<{embedding_length} floats>"
-            return None
+            if embedding is None:
+                return None
+            return f"<{len(embedding)} floats>"
 
         for document in documents:
             if not show_elements:

--- a/lib/sycamore/sycamore/tests/integration/transforms/test_embed.py
+++ b/lib/sycamore/sycamore/tests/integration/transforms/test_embed.py
@@ -31,7 +31,7 @@ def check_embedder(embedder: Embedder, expected_dim: int, use_documents: bool = 
                 "doc_id": f"doc_{i}",
                 "type": "test",
                 "text_representation": passage if use_documents else None,
-                "elements": [Element({"_element_index": 0, "text_representation": passage}) if use_elements else {}],
+                "elements": [Element({"_element_index": 0, "text_representation": passage})] if use_elements else [],
                 "properties": {},
             }
         )
@@ -91,13 +91,11 @@ def check_openai_embedding_batches(use_documents: bool = False, use_elements: bo
                 "doc_id": f"doc_{i}",
                 "type": "test",
                 "text_representation": f"Document text for passage {i}" if use_documents else None,
-                "elements": [
-                    Element(
-                        {"_element_index": 0, "text_representation": f"Element text for passage {i}"}
-                        if use_elements
-                        else {}
-                    )
-                ],
+                "elements": (
+                    [Element({"_element_index": 0, "text_representation": f"Element text for passage {i}"})]
+                    if use_elements
+                    else []
+                ),
                 "properties": {},
             }
         )

--- a/lib/sycamore/sycamore/tests/integration/transforms/test_embed.py
+++ b/lib/sycamore/sycamore/tests/integration/transforms/test_embed.py
@@ -1,4 +1,3 @@
-import sycamore
 from sycamore.data import Document, Element
 from sycamore.transforms.embed import Embedder, BedrockEmbedder, OpenAIEmbedder, SentenceTransformerEmbedder
 
@@ -46,11 +45,15 @@ def check_embedder(embedder: Embedder, expected_dim: int, use_documents: bool = 
             if doc.text_representation != "":
                 assert doc.embedding is not None
                 assert len(doc.embedding) == expected_dim
+            else:
+                assert doc.embedding is None
         if use_elements:
             for element in doc.elements:
                 if element.text_representation != "":
                     assert element.embedding is not None
                     assert len(element.embedding) == expected_dim
+                else:
+                    assert element.embedding is None
 
 
 def test_sentencetransformer_embedding():
@@ -73,53 +76,8 @@ def test_sentencetransformer_embedding():
 
 
 def test_openai_embedding():
-    check_embedder(embedder=OpenAIEmbedder(), expected_dim=1536, use_documents=True)
-    check_embedder(embedder=OpenAIEmbedder(), expected_dim=1536, use_elements=True)
     check_embedder(embedder=OpenAIEmbedder(), expected_dim=1536, use_elements=True, use_documents=True)
 
 
 def test_bedrock_embedding():
-    check_embedder(embedder=BedrockEmbedder(), expected_dim=1536, use_documents=True)
-    check_embedder(embedder=BedrockEmbedder(), expected_dim=1536, use_elements=True)
     check_embedder(embedder=BedrockEmbedder(), expected_dim=1536, use_elements=True, use_documents=True)
-
-
-def check_openai_embedding_batches(use_documents: bool = False, use_elements: bool = False):
-    docs = [
-        Document(
-            {
-                "doc_id": f"doc_{i}",
-                "type": "test",
-                "text_representation": f"Document text for passage {i}" if use_documents else None,
-                "elements": (
-                    [Element({"_element_index": 0, "text_representation": f"Element text for passage {i}"})]
-                    if use_elements
-                    else []
-                ),
-                "properties": {},
-            }
-        )
-        for i in range(5)
-    ]
-
-    context = sycamore.init()
-    doc_set = context.read.document(docs)
-    embedder = OpenAIEmbedder(model_batch_size=3)
-    embedded_doc_set = doc_set.embed(embedder=embedder)
-
-    new_docs = embedded_doc_set.take()
-
-    assert len(new_docs) == len(docs)
-
-    for doc in new_docs:
-        if use_documents:
-            assert len(doc.embedding) == 1536
-        if use_elements:
-            for element in doc.elements:
-                assert len(element.embedding) == 1536
-
-
-def test_openai_embedding_batches():
-    check_openai_embedding_batches(use_documents=True)
-    check_openai_embedding_batches(use_elements=True)
-    check_openai_embedding_batches(use_elements=True, use_documents=True)

--- a/lib/sycamore/sycamore/tests/integration/transforms/test_embed.py
+++ b/lib/sycamore/sycamore/tests/integration/transforms/test_embed.py
@@ -1,5 +1,5 @@
 import sycamore
-from sycamore.data import Document
+from sycamore.data import Document, Element
 from sycamore.transforms.embed import Embedder, BedrockEmbedder, OpenAIEmbedder, SentenceTransformerEmbedder
 
 passages = [
@@ -24,14 +24,14 @@ passages = [
 ]
 
 
-def check_embedder(embedder: Embedder, expected_dim: int):
+def check_embedder(embedder: Embedder, expected_dim: int, use_documents: bool = False, use_elements: bool = False):
     docs = [
         Document(
             {
                 "doc_id": f"doc_{i}",
                 "type": "test",
-                "text_representation": passage,
-                "elements": [],
+                "text_representation": passage if use_documents else None,
+                "elements": [Element({"_element_index": 0, "text_representation": passage}) if use_elements else {}],
                 "properties": {},
             }
         )
@@ -42,33 +42,62 @@ def check_embedder(embedder: Embedder, expected_dim: int):
     assert len(new_docs) == len(docs)
 
     for doc in new_docs:
-        if doc.text_representation != "":
-            assert doc.embedding is not None
-            assert len(doc.embedding) == expected_dim
+        if use_documents:
+            if doc.text_representation != "":
+                assert doc.embedding is not None
+                assert len(doc.embedding) == expected_dim
+        if use_elements:
+            for element in doc.elements:
+                if element.text_representation != "":
+                    assert element.embedding is not None
+                    assert len(element.embedding) == expected_dim
 
 
 def test_sentencetransformer_embedding():
     check_embedder(
-        embedder=SentenceTransformerEmbedder(model_name="thenlper/gte-small", batch_size=100), expected_dim=384
+        embedder=SentenceTransformerEmbedder(model_name="thenlper/gte-small", batch_size=100),
+        expected_dim=384,
+        use_documents=True,
+    )
+    check_embedder(
+        embedder=SentenceTransformerEmbedder(model_name="thenlper/gte-small", batch_size=100),
+        expected_dim=384,
+        use_elements=True,
+    )
+    check_embedder(
+        embedder=SentenceTransformerEmbedder(model_name="thenlper/gte-small", batch_size=100),
+        expected_dim=384,
+        use_documents=True,
+        use_elements=True,
     )
 
 
 def test_openai_embedding():
-    check_embedder(embedder=OpenAIEmbedder(), expected_dim=1536)
+    check_embedder(embedder=OpenAIEmbedder(), expected_dim=1536, use_documents=True)
+    check_embedder(embedder=OpenAIEmbedder(), expected_dim=1536, use_elements=True)
+    check_embedder(embedder=OpenAIEmbedder(), expected_dim=1536, use_elements=True, use_documents=True)
 
 
 def test_bedrock_embedding():
-    check_embedder(embedder=BedrockEmbedder(), expected_dim=1536)
+    check_embedder(embedder=BedrockEmbedder(), expected_dim=1536, use_documents=True)
+    check_embedder(embedder=BedrockEmbedder(), expected_dim=1536, use_elements=True)
+    check_embedder(embedder=BedrockEmbedder(), expected_dim=1536, use_elements=True, use_documents=True)
 
 
-def test_openai_embedding_batches():
+def check_openai_embedding_batches(use_documents: bool = False, use_elements: bool = False):
     docs = [
         Document(
             {
                 "doc_id": f"doc_{i}",
                 "type": "test",
-                "text_representation": f"Document text for passage {i}",
-                "elements": [],
+                "text_representation": f"Document text for passage {i}" if use_documents else None,
+                "elements": [
+                    Element(
+                        {"_element_index": 0, "text_representation": f"Element text for passage {i}"}
+                        if use_elements
+                        else {}
+                    )
+                ],
                 "properties": {},
             }
         )
@@ -77,13 +106,22 @@ def test_openai_embedding_batches():
 
     context = sycamore.init()
     doc_set = context.read.document(docs)
-
-    embedder = SentenceTransformerEmbedder(model_name="thenlper/gte-small", batch_size=100)
-    embedded_doc_set = doc_set.embed(embedder=embedder)  # OpenAIEmbedder(model_batch_size=3))
+    embedder = OpenAIEmbedder(model_batch_size=3)
+    embedded_doc_set = doc_set.embed(embedder=embedder)
 
     new_docs = embedded_doc_set.take()
 
     assert len(new_docs) == len(docs)
 
     for doc in new_docs:
-        assert len(doc.embedding) == 1536
+        if use_documents:
+            assert len(doc.embedding) == 1536
+        if use_elements:
+            for element in doc.elements:
+                assert len(element.embedding) == 1536
+
+
+def test_openai_embedding_batches():
+    check_openai_embedding_batches(use_documents=True)
+    check_openai_embedding_batches(use_elements=True)
+    check_openai_embedding_batches(use_elements=True, use_documents=True)

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_embed.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_embed.py
@@ -152,7 +152,7 @@ class TestEmbedding:
             original_embed_texts = embedder.embed_texts
 
             def mock_embed_texts(text_batch):
-                assert len(text_batch) <= 2, "All batches should be size 2 or smaller"
+                assert len(text_batch) == 2, "All batches should be size 2"
                 return original_embed_texts(text_batch)
 
             embedder.embed_texts = mock_embed_texts

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_embed.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_embed.py
@@ -140,14 +140,13 @@ class TestEmbedding:
         embedder = OpenAIEmbedder(model_batch_size=120)
         assert embedder.model_batch_size == 120
 
-        # Test batching using SentenceTransformer
+        # Test batching
         texts = ["text1", "text2", "text3", "text4"]
         docs = [Document({"text_representation": t}) for t in texts]
 
         embedders = [
             SentenceTransformerEmbedder(model_name="sentence-transformers/all-MiniLM-L6-v2", model_batch_size=2),
             OpenAIEmbedder(model_batch_size=2),
-            BedrockEmbedder(model_batch_size=1),
         ]
         for embedder in embedders:
             original_embed_texts = embedder.embed_texts

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_embed.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_embed.py
@@ -2,13 +2,38 @@ import pickle
 import pytest
 import ray.data
 
-from sycamore.data import Document
+from sycamore.data import Document, Element
 from sycamore.plan_nodes import Node
 from sycamore.transforms import Embed
-from sycamore.transforms.embed import OpenAIEmbedder, SentenceTransformerEmbedder
+from sycamore.transforms.embed import OpenAIEmbedder, SentenceTransformerEmbedder, BedrockEmbedder
 
 
 class TestEmbedding:
+
+    def check_sentence_transformer(
+        self, model_name, dimension, texts, use_documents: bool = False, use_elements: bool = False
+    ):
+        input_batch = []
+        for text in texts:
+            doc = Document()
+            if use_documents:
+                doc.text_representation = text
+            if use_elements:
+                element = Element()
+                element.text_representation = text
+                doc.elements = [element]
+            input_batch.append(doc)
+        embedder = SentenceTransformerEmbedder(model_name)
+        output_batch = embedder(doc_batch=input_batch)
+        for doc in output_batch:
+            if use_documents:
+                assert doc.embedding is not None
+                assert len(doc.embedding) == dimension
+            if use_elements:
+                for element in doc.elements:
+                    assert element.embedding is not None
+                    assert len(element.embedding) == dimension
+
     """Test data is sampled from different captions for the same image from
     the Flickr30k dataset"""
 
@@ -52,25 +77,33 @@ class TestEmbedding:
         ],
     )
     def test_sentence_transformer(self, model_name, dimension, texts):
-        input_batch = []
-        for text in texts:
-            doc = Document()
-            doc.text_representation = text
-            input_batch.append(doc)
-        embedder = SentenceTransformerEmbedder(model_name)
-        output_batch = embedder(doc_batch=input_batch)
-        for doc in output_batch:
-            assert len(doc.embedding) == dimension
+        self.check_sentence_transformer(model_name, dimension, texts, use_documents=True, use_elements=True)
+        self.check_sentence_transformer(model_name, dimension, texts, use_elements=True)
+        self.check_sentence_transformer(model_name, dimension, texts, use_documents=True)
 
-    def test_sentence_transformer_embedding(self, mocker):
+    def check_sentence_transformer_embedding(self, mocker, use_documents: bool = False, use_elements: bool = False):
         node = mocker.Mock(spec=Node)
         embedding = Embed(
             node,
             embedder=SentenceTransformerEmbedder(model_name="sentence-transformers/all-MiniLM-L6-v2", batch_size=100),
         )
+        texts = ["Members of a strike at Yale University.", "A woman is speaking at a podium outdoors."]
+        elements = [
+            {"_element_index": 1, "text_representation": texts[0], "embedding": None},
+            {
+                "_element_index": 2,
+                "text_representation": texts[1],
+                "embedding": None,
+            },
+        ]
         dicts = [
-            {"doc_id": 1, "text_representation": "Members of a strike at Yale University.", "embedding": None},
-            {"doc_id": 2, "text_representation": "A woman is speaking at a podium outdoors.", "embedding": None},
+            {
+                "doc_id": 1,
+                "text_representation": texts[0] if use_documents else None,
+                "embedding": None,
+                "elements": elements if use_elements else {},
+            },
+            {"doc_id": 2, "text_representation": texts[1] if use_documents else None, "embedding": None},
         ]
         input_dataset = ray.data.from_items([{"doc": Document(dict).serialize()} for dict in dicts])
         execute = mocker.patch.object(node, "execute")
@@ -79,9 +112,47 @@ class TestEmbedding:
         output_dataset = embedding.execute()
         output_dataset.show()
 
+    def test_sentence_transformer_embedding(self, mocker):
+        self.check_sentence_transformer_embedding(mocker, use_documents=True, use_elements=True)
+        self.check_sentence_transformer_embedding(mocker, use_elements=True)
+        self.check_sentence_transformer_embedding(mocker, use_documents=True)
+
     def test_openai_embedder_pickle(self):
         obj = OpenAIEmbedder()
         obj._client = obj.client_wrapper.get_client()
 
         pickle.dumps(obj)
         assert True
+
+    def test_sentence_transformer_batch_size(self):
+        embedder = SentenceTransformerEmbedder(model_name="sentence-transformers/all-MiniLM-L6-v2")
+        assert embedder.model_batch_size == 100
+
+        embedder = SentenceTransformerEmbedder(model_name="sentence-transformers/all-MiniLM-L6-v2", model_batch_size=50)
+        assert embedder.model_batch_size == 50
+
+        embedder = BedrockEmbedder(model_batch_size=100)
+        assert embedder.model_batch_size == 1
+
+        embedder = BedrockEmbedder(model_batch_size=1)
+        assert embedder.model_batch_size == 1
+
+        embedder = OpenAIEmbedder(model_batch_size=120)
+        assert embedder.model_batch_size == 120
+
+        # Test batching using SentenceTransformer
+        texts = ["text1", "text2", "text3", "text4"]
+        docs = [Document({"text_representation": t}) for t in texts]
+
+        embedder = SentenceTransformerEmbedder(model_name="sentence-transformers/all-MiniLM-L6-v2", model_batch_size=2)
+
+        original_embed_texts = embedder.embed_texts
+
+        def mock_embed_texts(text_batch):
+            assert len(text_batch) <= 2, "All batches should be size 2 or smaller"
+            return original_embed_texts(text_batch)
+
+        embedder.embed_texts = mock_embed_texts
+
+        embedded_docs = embedder(docs)
+        assert len(embedded_docs) == len(texts), "All texts should be processed"

--- a/lib/sycamore/sycamore/transforms/embed.py
+++ b/lib/sycamore/sycamore/transforms/embed.py
@@ -3,7 +3,6 @@ import logging
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, Optional, Callable, Union, List
-import logging
 
 from openai import OpenAI as OpenAIClient
 from openai import AzureOpenAI as AzureOpenAIClient

--- a/lib/sycamore/sycamore/transforms/embed.py
+++ b/lib/sycamore/sycamore/transforms/embed.py
@@ -3,7 +3,7 @@ import logging
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, Optional, Callable, Union, List
-from collections import defaultdict
+import logging
 
 from openai import OpenAI as OpenAIClient
 from openai import AzureOpenAI as AzureOpenAIClient
@@ -87,11 +87,15 @@ class Embedder(ABC):
 
     @staticmethod
     def clamp_batch_size(batch_size, max_and_default=None):
-        assert batch_size >= 1, f"bad batch size {batch_size} <1"
+        if batch_size < 1:
+            raise ValueError(f"Batch size must be at least 1, got {batch_size}")
         if max_and_default is None:
             return batch_size
         if batch_size > max_and_default:
-            print(f"bad batch size {batch_size} > {max_and_default}\n Reducing to {max_and_default}.")
+            logging.warning(
+                f"Requested batch size {batch_size} exceeds maximum {max_and_default}. "
+                f"Reducing to {max_and_default}."
+            )
             return max_and_default
         return batch_size
 


### PR DESCRIPTION
1. Allow .embed() transform to operate on element level (without exploding). 
2. Refactor code for Embedder class to handle orchestration of batching.