### PR TITLE
Add Retries for OpenSearch Writer

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -36,7 +36,7 @@ jobs:
       - name: DF-3
         run: df -h
       - name: Install sycamore
-        run: poetry install --all-extras
+        run: poetry install --all-extras --no-root --no-root
       - name: DF-4
         run: df -h
       - name: Run mypy
@@ -56,7 +56,7 @@ jobs:
           python-version: '3.9'
           cache: 'poetry'
       - name: Install sycamore
-        run: poetry install --all-extras
+        run: poetry install --all-extras --no-root --no-root
       - name: Lint with ruff
         run: poetry run ruff check .
       - name: Lint with black

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -59,7 +59,7 @@ jobs:
       - name: DF-3
         run: df
       - name: Install sycamore
-        run: poetry install --all-extras
+        run: poetry install --all-extras --no-root
         working-directory: lib/sycamore
       - name: Download nltk packages
         run: poetry run python -m nltk.downloader punkt_tab averaged_perceptron_tagger_eng
@@ -134,7 +134,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "poetry"
       - name: Install sycamore
-        run: poetry install --all-extras
+        run: poetry install --all-extras --no-root
       - name: Download nltk packages
         run: poetry run python -m nltk.downloader punkt averaged_perceptron_tagger
       - name: Update Apt
@@ -203,7 +203,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "poetry"
       - name: Install sycamore
-        run: poetry install --all-extras
+        run: poetry install --all-extras --no-root
       - name: Download nltk packages
         run: poetry run python -m nltk.downloader punkt_tab averaged_perceptron_tagger_eng
       - name: Update Apt
@@ -244,7 +244,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "poetry"
       - name: Install sycamore
-        run: poetry install --all-extras
+        run: poetry install --all-extras --no-root
       - name: Download nltk packages
         run: poetry run python -m nltk.downloader punkt averaged_perceptron_tagger
       - name: Update Apt
@@ -283,7 +283,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "poetry"
       - name: Install sycamore
-        run: poetry install --all-extras
+        run: poetry install --all-extras --no-root
       - name: Download nltk packages
         run: poetry run python -m nltk.downloader punkt averaged_perceptron_tagger
       - name: Update Apt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Sycamore targets Python 3.9+ and runs primarily on Mac and Linux. The following 
 We use poetry to manage Python dependencies in Sycamore. You can install poetry using the instructions [here](https://python-poetry.org/docs/#installing-with-the-official-installer). Once you have poetry installed, you can install all dependencies by running
 
 ```bash
-poetry install --all-extras
+poetry install --all-extras --no-root
 
 ```
 

--- a/docs/source/sycamore/connectors/opensearch.md
+++ b/docs/source/sycamore/connectors/opensearch.md
@@ -38,6 +38,7 @@ To write a DocSet to a OpenSearch index from Sycamore, use the `docset.write.ope
 - `os_client_args`: Keyword parameters that are passed to the opensearch-py OpenSearch client constructor.
 - `index_name`: The name of the OpenSearch index into which to load this DocSet.
 - `index_settings`: Settings and mappings to pass when creating a new index. Specified as a Python dict corresponding to the JSON paramters taken by the OpenSearch CreateIndex API, more information is given [here](https://opensearch.org/docs/latest/api-reference/index-apis/create-index/).
+- `insert_settings`: (optional) Settings to pass when inserting documents into the index. Specified as a Python dict corresponding to the JSON parameters taken by the OpenSearch Index API, more information is given [here](https://opensearch.org/docs/latest/api-reference/document-apis/index-document/).
 - `execute`: (optional, default=`True`) Whether to execute this sycamore pipeline now, or return a docset to add more transforms.
 
 To write a docset to the OpenSearch index run by the Docker compose above, we can write the following:

--- a/lib/sycamore/sycamore/connectors/opensearch/opensearch_writer.py
+++ b/lib/sycamore/sycamore/connectors/opensearch/opensearch_writer.py
@@ -148,7 +148,7 @@ class OpenSearchWriterClient(BaseDBWriter.Client):
                 log.warning(f"Received 429, backing off for {sleep_time:.2f} seconds")
                 time.sleep(sleep_time)
                 retry_count += 1
-                requests = failed_requests
+            requests = failed_requests
 
     def create_target_idempotent(self, target_params: BaseDBWriter.TargetParams):
         from opensearchpy.exceptions import RequestError

--- a/lib/sycamore/sycamore/connectors/opensearch/opensearch_writer.py
+++ b/lib/sycamore/sycamore/connectors/opensearch/opensearch_writer.py
@@ -4,6 +4,8 @@ import logging
 import typing
 from typing import Any, Optional
 from typing_extensions import TypeGuard
+import random
+import time
 
 from sycamore.data import Document
 from sycamore.connectors.base_writer import BaseDBWriter
@@ -21,6 +23,8 @@ if typing.TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 OS_ADMIN_PASSWORD = os.getenv("OS_ADMIN_PASSWORD", "admin")
+MAX_RETRIES = 5  # Number of times to retry a failed request
+INITIAL_BACKOFF = 1  # Initial backoff time in seconds
 
 
 @dataclass
@@ -105,10 +109,35 @@ class OpenSearchWriterClient(BaseDBWriter.Client):
             target_params, OpenSearchWriterTargetParams
         ), f"Provided target_params was not of type OpenSearchWriterTargetParams:\n{target_params}"
         assert _narrow_list_of_os_records(records), f"A provided record was not of type OpenSearchRecord:\n{records}"
+        retry_count = 0
 
-        for success, info in parallel_bulk(self._client, [asdict(r) for r in records]):
-            if not success:
-                log.error("A Document failed to upload", info)
+        for success, item in parallel_bulk(
+            self._client,
+            (asdict(r) for r in records),
+            raise_on_error=False,
+            raise_on_exception=False,
+            thread_count=1,
+            chunk_size=100,
+        ):
+            if not success and item["index"]["status"] == 429:
+                if retry_count >= MAX_RETRIES:
+                    msg = f"Max retries ({MAX_RETRIES}) exceeded"
+                    log.error(msg)
+                    raise Exception(msg)
+
+                # Calculate backoff time with exponential increase and jitter
+                backoff = INITIAL_BACKOFF * (2**retry_count)
+                jitter = random.uniform(0, 0.1 * backoff)
+                sleep_time = backoff + jitter
+
+                log.warning(f"Received 429, backing off for {sleep_time:.2f} seconds")
+                time.sleep(sleep_time)
+
+                retry_count += 1
+            else:
+                msg = f"Failed to upload document: {item}"
+                log.error(msg)
+                raise Exception(msg)
 
     def create_target_idempotent(self, target_params: BaseDBWriter.TargetParams):
         from opensearchpy.exceptions import RequestError

--- a/lib/sycamore/sycamore/connectors/opensearch/opensearch_writer.py
+++ b/lib/sycamore/sycamore/connectors/opensearch/opensearch_writer.py
@@ -127,7 +127,7 @@ class OpenSearchWriterClient(BaseDBWriter.Client):
         while requests:
             failed_requests = []
             for success, item in parallel_bulk(
-                self._client, generate_records(records), **target_params.insert_settings
+                self._client, generate_records(requests), **target_params.insert_settings
             ):
                 if not success:
                     if item["index"]["status"] == 429:

--- a/lib/sycamore/sycamore/writer.py
+++ b/lib/sycamore/sycamore/writer.py
@@ -56,8 +56,8 @@ class DocSetWriter:
             index_settings: Settings and mappings to pass when creating a new index. Specified as a Python dict
                 corresponding to the JSON paramters taken by the OpenSearch CreateIndex API:
                 https://opensearch.org/docs/latest/api-reference/index-apis/create-index/
-            insert_settings: Settings to pass when inserting data into the index. Specified as a Python dict. Defaults to
-                {"raise_on_error": False, "raise_on_exception": False, "chunk_size": 100, "thread_count": 3}
+            insert_settings: Settings to pass when inserting data into the index. Specified as a Python dict. Defaults
+                to {"raise_on_error": False, "raise_on_exception": False, "chunk_size": 100, "thread_count": 3}
             execute: Execute the pipeline and write to opensearch on adding this operator. If false,
                 will return a new docset with the write in the plan
             kwargs: Keyword arguments to pass to the underlying execution engine


### PR DESCRIPTION
Adds automatic retries to the OpenSearch writer, along with default backoff and retry values. This helps deal with `TransportError` bugs when running on Local Mode.