### PR TITLE
Keep newline in OpenAI Embedder

### DIFF
--- a/lib/sycamore/sycamore/transforms/embed.py
+++ b/lib/sycamore/sycamore/transforms/embed.py
@@ -197,11 +197,7 @@ class OpenAIEmbedder(Embedder):
             self.model_batch_size = 16
 
         for batch in batched(doc_batch, self.model_batch_size):
-            text_to_embed = [
-                self.pre_process_document(doc)
-                for doc in batch
-                if not _text_representation_is_empty(doc)
-            ]
+            text_to_embed = [self.pre_process_document(doc) for doc in batch if not _text_representation_is_empty(doc)]
 
             embeddings = self._client.embeddings.create(model=self.model_name, input=text_to_embed).data
 

--- a/lib/sycamore/sycamore/transforms/embed.py
+++ b/lib/sycamore/sycamore/transforms/embed.py
@@ -198,7 +198,7 @@ class OpenAIEmbedder(Embedder):
 
         for batch in batched(doc_batch, self.model_batch_size):
             text_to_embed = [
-                self.pre_process_document(doc).replace("\n", " ")
+                self.pre_process_document(doc)
                 for doc in batch
                 if not _text_representation_is_empty(doc)
             ]


### PR DESCRIPTION
1. https://github.com/openai/openai-python/issues/418 We do not need to remove newline characters in OpenAI embeddings.
2. Table structure (in csv form) would benefit the most from this.