### PR TITLE
Get sycamore.query to work with Schema instead of only OpenSearchSchema

### DIFF
--- a/apps/query-eval/queryeval/queryeval_types.py
+++ b/apps/query-eval/queryeval/queryeval_types.py
@@ -10,6 +10,7 @@ from sycamore.query.schema import OpenSearchSchema
 from sycamore.query.planner import PlannerExample
 from sycamore.schema import Schema
 
+
 class QueryEvalConfig(BaseModel):
     """Represents the configuration for a Query Eval run."""
 

--- a/apps/query-eval/queryeval/queryeval_types.py
+++ b/apps/query-eval/queryeval/queryeval_types.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from sycamore.query.logical_plan import LogicalPlan
 from sycamore.query.schema import OpenSearchSchema
 from sycamore.query.planner import PlannerExample
-
+from sycamore.schema import Schema
 
 class QueryEvalConfig(BaseModel):
     """Represents the configuration for a Query Eval run."""
@@ -102,6 +102,6 @@ class QueryEvalResultsFile(BaseModel):
     """Represents the format of the query eval results file."""
 
     config: QueryEvalConfig
-    data_schema: Optional[OpenSearchSchema] = None
+    data_schema: Optional[Union[Schema, OpenSearchSchema]] = None
     examples: Optional[List[PlannerExample]] = None
     results: Optional[List[QueryEvalResult]] = None

--- a/apps/query-server/queryserver/main.py
+++ b/apps/query-server/queryserver/main.py
@@ -17,7 +17,7 @@ from sycamore import DocSet
 from sycamore.data import Document, MetadataDocument
 from sycamore.query.client import SycamoreQueryClient
 from sycamore.query.logical_plan import LogicalPlan
-from sycamore.query.schema import OpenSearchSchema
+from sycamore.schema import Schema
 
 # This is the uvicorn general logger, the error name is misleading.
 # https://github.com/encode/uvicorn/issues/562
@@ -42,7 +42,7 @@ class Index(BaseModel):
     description: Optional[str] = None
     """Description of the index."""
 
-    index_schema: OpenSearchSchema
+    index_schema: Schema
     """The schema for this index."""
 
 

--- a/apps/query-ui/queryui/Sycamore_Query.py
+++ b/apps/query-ui/queryui/Sycamore_Query.py
@@ -32,8 +32,8 @@ def generate_code(client: SycamoreQueryClient, plan: LogicalPlan) -> str:
 def show_schema(_client: SycamoreQueryClient, index: str):
     schema = util.get_schema(_client, index)
     table_data = []
-    for field_name, field in schema.fields.items():
-        table_data.append([field_name] + list(field.examples or []))
+    for field in schema.fields:
+        table_data.append([field.name] + list(field.examples or []))
     with st.expander(f"Schema for index `[{index}]`"):
         st.dataframe(table_data)
 

--- a/apps/query-ui/queryui/util.py
+++ b/apps/query-ui/queryui/util.py
@@ -14,13 +14,13 @@ from sycamore.data import MetadataDocument
 from sycamore.query.client import SycamoreQueryClient
 from sycamore.query.logical_plan import LogicalPlan
 from sycamore.query.planner import PlannerExample
-from sycamore.query.schema import OpenSearchSchema
 from sycamore.query.result import SycamoreQueryResult
+from sycamore.schema import Schema
 
 from queryui.configuration import get_sycamore_query_client
 
 
-def get_schema(_client: SycamoreQueryClient, index: str) -> OpenSearchSchema:
+def get_schema(_client: SycamoreQueryClient, index: str) -> Schema:
     """Return the OpenSearch schema for the given index."""
     return _client.get_opensearch_schema(index)
 

--- a/lib/sycamore/sycamore/query/client.py
+++ b/lib/sycamore/sycamore/query/client.py
@@ -18,6 +18,7 @@ from typing import List, Optional, Union
 import structlog
 import yaml
 from rich.console import Console
+from sycamore.schema import Schema
 
 import sycamore
 from sycamore import Context, ExecMode
@@ -163,7 +164,7 @@ class SycamoreQueryClient:
         return indices
 
     @requires_modules("opensearchpy.client.indices", extra="opensearch")
-    def get_opensearch_schema(self, index: str) -> OpenSearchSchema:
+    def get_opensearch_schema(self, index: str) -> Schema:
         """Get the schema for the provided OpenSearch index.
 
         To debug:
@@ -172,13 +173,13 @@ class SycamoreQueryClient:
         from opensearchpy.client.indices import IndicesClient
 
         schema_provider = OpenSearchSchemaFetcher(IndicesClient(self._os_client), index, self._os_query_executor)
-        return schema_provider.get_schema()
+        return schema_provider.get_schema().to_schema()
 
     def generate_plan(
         self,
         query: str,
         index: str,
-        schema: OpenSearchSchema,
+        schema: Union[Schema, OpenSearchSchema],
         examples: Optional[List[PlannerExample]] = None,
         natural_language_response: bool = False,
     ) -> LogicalPlan:

--- a/lib/sycamore/sycamore/query/planner.py
+++ b/lib/sycamore/sycamore/query/planner.py
@@ -1,7 +1,7 @@
 import logging
 import typing
 from dataclasses import dataclass
-from typing import Any, List, Optional, Tuple, Type
+from typing import Any, List, Optional, Tuple, Type, Union
 
 from sycamore.schema import Schema, SchemaField
 
@@ -69,7 +69,7 @@ def process_json_plan(json_plan: str) -> LogicalPlan:
 class PlannerExample:
     """Represents an example query and query plan for the planner."""
 
-    def __init__(self, schema: typing.Union[OpenSearchSchema, Schema], plan: LogicalPlan) -> None:
+    def __init__(self, schema: Union[OpenSearchSchema, Schema], plan: LogicalPlan) -> None:
         super().__init__()
         self.plan = plan
         self.schema: Schema = schema.to_schema() if isinstance(schema, OpenSearchSchema) else schema
@@ -388,7 +388,7 @@ class LlmPlanner:
     def __init__(
         self,
         index: str,
-        data_schema: typing.Union[OpenSearchSchema, Schema],
+        data_schema: Union[OpenSearchSchema, Schema],
         os_config: dict[str, str],
         os_client: "OpenSearch",
         strategy: QueryPlanStrategy = QueryPlanStrategy(ALL_OPERATORS, []),

--- a/lib/sycamore/sycamore/query/schema.py
+++ b/lib/sycamore/sycamore/query/schema.py
@@ -1,8 +1,8 @@
 import logging
 import typing
-from typing import Any, Dict, List, Optional
-
+from typing import Dict, Optional
 from pydantic import BaseModel
+from sycamore.schema import Schema, SchemaField
 
 from sycamore.transforms.query import OpenSearchQueryExecutor
 from sycamore.data import OpenSearchQuery
@@ -12,24 +12,23 @@ if typing.TYPE_CHECKING:
     from opensearchpy.client.indices import IndicesClient
 
 
-class OpenSearchSchemaField(BaseModel):
+class OpenSearchSchemaField(SchemaField):
     """DEPRECATED: Migrating to docset.SchemaField."""
 
-    field_type: str
-    """The type of the field."""
-
-    description: Optional[str] = None
-    """A natural language description of the field."""
-
-    examples: Optional[List[Any]] = None
-    """A list of example values for the field."""
+    name: str = "default"
 
 
 class OpenSearchSchema(BaseModel):
     """DEPRECATED: Migrating to docset.Schema."""
 
-    fields: Dict[str, OpenSearchSchemaField]
+    fields: Dict[str, SchemaField]
     """A mapping from field name to field type and example values."""
+
+    def to_schema(self) -> Schema:
+        fields = list()
+        for field_name, field in self.fields.items():
+            fields.append(SchemaField(name=field_name, **field.dict()))
+        return Schema(fields=fields)
 
 
 logger = logging.getLogger(__name__)

--- a/lib/sycamore/sycamore/query/schema.py
+++ b/lib/sycamore/sycamore/query/schema.py
@@ -27,7 +27,7 @@ class OpenSearchSchema(BaseModel):
     def to_schema(self) -> Schema:
         fields = list()
         for field_name, field in self.fields.items():
-            fields.append(SchemaField(name=field_name, **field.dict()))
+            fields.append(SchemaField(**{**field.dict(), "name": field_name}))
         return Schema(fields=fields)
 
 

--- a/lib/sycamore/sycamore/tests/integration/query/test_planner.py
+++ b/lib/sycamore/sycamore/tests/integration/query/test_planner.py
@@ -26,3 +26,9 @@ def test_simple_llm_planner(query_integration_test_index: str):
     assert type(plan.nodes[1]).__name__ == "Count"
 
     assert [plan.nodes[0]] == plan.nodes[1].input_nodes()
+
+    # Just ensure we can run the planner with a Schema object as well
+    planner = LlmPlanner(
+        query_integration_test_index, data_schema=schema.to_schema(), os_config=OS_CONFIG, os_client=os_client
+    )
+    planner.plan("How many locations did incidents happen in?")


### PR DESCRIPTION
Other places are currently passing OpenSearchSchema to the planner (e.g. query-eval, testing scripts) so I need to support both OpenSearchSchema and Schema in the planner right now.

Also had to add an explicit `OpenSearchSchema.to_schema()` method because both objects define a 'fields' attribute of different types :( 