### PR TITLE
Add hybrid table extractor

### DIFF
--- a/lib/sycamore/sycamore/tests/unit/transforms/test_table_extractor.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_table_extractor.py
@@ -1,0 +1,44 @@
+from PIL import Image
+from sycamore.data.bbox import BoundingBox
+from sycamore.data.element import TableElement
+from sycamore.transforms.table_structure.extract import (
+    TableTransformerStructureExtractor,
+    HybridTableStructureExtractor,
+    DeformableTableStructureExtractor,
+)
+
+
+class TestTableExtractors:
+
+    @staticmethod
+    def mock_doc_image(mocker, width, height):
+        im = mocker.Mock(spec=Image.Image)
+        im.size = width, height
+        return im
+
+    @staticmethod
+    def mock_table_element(mocker, width, height):
+        elt = mocker.Mock(spec=TableElement)
+        elt.bbox = BoundingBox(0, 0, width, height)
+        return elt
+
+    def test_hybrid_routing_both_gt500(self, mocker):
+        im = TestTableExtractors.mock_doc_image(mocker, 1000, 1000)
+        elt = TestTableExtractors.mock_table_element(mocker, 0.7, 0.7)
+        extractor = HybridTableStructureExtractor(deformable_model="dont initialize me")
+        chosen = extractor._pick_model(elt, im)
+        assert type(chosen) == DeformableTableStructureExtractor
+
+    def test_hybrid_routing_one_gt500(self, mocker):
+        im = TestTableExtractors.mock_doc_image(mocker, 1000, 1000)
+        elt = TestTableExtractors.mock_table_element(mocker, 0.7, 0.2)
+        extractor = HybridTableStructureExtractor(deformable_model="dont initialize me")
+        chosen = extractor._pick_model(elt, im)
+        assert type(chosen) == DeformableTableStructureExtractor
+
+    def test_hybrid_routing_neither_gt500(self, mocker):
+        im = TestTableExtractors.mock_doc_image(mocker, 1000, 1000)
+        elt = TestTableExtractors.mock_table_element(mocker, 0.2, 0.2)
+        extractor = HybridTableStructureExtractor(deformable_model="dont initialize me")
+        chosen = extractor._pick_model(elt, im)
+        assert type(chosen) == TableTransformerStructureExtractor

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -71,9 +71,9 @@ class TableTransformerStructureExtractor(TableStructureExtractor):
     More information about TableTransformers can be found at https://github.com/microsoft/table-transformer.
     """
 
-    DEFAULT_TTAR_MODEL = "microsoft/table-structure-recognition-v1.1-all"
+    DEFAULT_TATR_MODEL = "microsoft/table-structure-recognition-v1.1-all"
 
-    def __init__(self, model: str = DEFAULT_TTAR_MODEL, device=None):
+    def __init__(self, model: str = DEFAULT_TATR_MODEL, device=None):
         """
         Creates a TableTransformerStructureExtractor
 
@@ -238,7 +238,7 @@ class HybridTableStructureExtractor(TableStructureExtractor):
     def __init__(
         self,
         deformable_model: str,
-        tatr_model: str = TableTransformerStructureExtractor.DEFAULT_TTAR_MODEL,
+        tatr_model: str = TableTransformerStructureExtractor.DEFAULT_TATR_MODEL,
         device=None,
     ):
         self._deformable = DeformableTableStructureExtractor(deformable_model, device)

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -259,6 +259,10 @@ class HybridTableStructureExtractor(TableStructureExtractor):
             return self._deformable
         return self._tatr
 
+    def _init_structure_model(self):
+        self._deformable._init_structure_model()
+        self._tatr._init_structure_model()
+
     def extract(self, element: TableElement, doc_image: Image.Image, union_tokens=False) -> TableElement:
         """Extracts the table structure from the specified element using a either a DeformableDETR or
         TATR model, depending on the size of the table.


### PR DESCRIPTION
Adds a 'hybrid' table extractor that wraps DeformableTableExtractor and TableTransformerExtractor by selecting one to use based on the size of the table element.