### PR TITLE
fix materialize on windows

### DIFF
--- a/lib/sycamore/sycamore/data/docid.py
+++ b/lib/sycamore/sycamore/data/docid.py
@@ -44,6 +44,18 @@ def uuid_to_docid(uu: Optional[str], code: Optional[str] = None) -> Optional[str
     return f"aryn:{code}-{id}"
 
 
+def docid_to_typed_nanoid(id: Optional[str]) -> Optional[str]:
+    if not id or not id.startswith("aryn:"):
+        return id
+    return id[len("aryn:") :]
+
+
+def typed_nanoid_to_docid(tnid: str) -> str:
+    if tnid[1] != "-":
+        return f"aryn:d-{tnid}"
+    return f"aryn:{tnid}"
+
+
 def nanoid36_to_uuid(id: str, extra: int = 0) -> str:
     """
     Invertable conversion of docid to UUID for application that need UUID.

--- a/lib/sycamore/sycamore/materialize.py
+++ b/lib/sycamore/sycamore/materialize.py
@@ -4,6 +4,7 @@ from typing import Any, Optional, Tuple, Union, TYPE_CHECKING
 
 from sycamore.context import Context
 from sycamore.data import Document, MetadataDocument
+from sycamore.data.docid import docid_to_typed_nanoid
 from sycamore.materialize_config import MaterializeSourceMode
 from sycamore.plan_nodes import Node, UnaryNode, NodeTraverse
 from sycamore.transforms.base import rename
@@ -320,10 +321,10 @@ class Materialize(UnaryNode):
             doc_id = hash_id
 
         if isinstance(doc, MetadataDocument):
-            return f"md-{doc_id}.{hash_id}.pickle"
+            return f"md-{docid_to_typed_nanoid(doc_id)}.{hash_id}.pickle"
 
         assert isinstance(doc, Document)
-        return f"doc-{doc_id}.{hash_id}.pickle"
+        return f"doc-{docid_to_typed_nanoid(doc_id)}.{hash_id}.pickle"
 
 
 class AutoMaterialize(NodeTraverse):

--- a/lib/sycamore/sycamore/materialize.py
+++ b/lib/sycamore/sycamore/materialize.py
@@ -320,10 +320,10 @@ class Materialize(UnaryNode):
             doc_id = hash_id
 
         if isinstance(doc, MetadataDocument):
-            return f"md-{doc_id}:{hash_id}.pickle"
+            return f"md-{doc_id}.{hash_id}.pickle"
 
         assert isinstance(doc, Document)
-        return f"doc-{doc_id}:{hash_id}.pickle"
+        return f"doc-{doc_id}.{hash_id}.pickle"
 
 
 class AutoMaterialize(NodeTraverse):

--- a/lib/sycamore/sycamore/tests/unit/data/test_docid.py
+++ b/lib/sycamore/sycamore/tests/unit/data/test_docid.py
@@ -7,12 +7,14 @@ from sycamore.data.docid import (
     bignum_to_nybbles,
     bignum_to_str,
     docid_nanoid_chars,
+    docid_to_typed_nanoid,
     docid_to_uuid,
     mkdocid,
     nanoid36,
     nybbles_to_bignum,
     nybbles_to_uuid,
     str_to_bignum,
+    typed_nanoid_to_docid,
     uuid_to_docid,
 )
 
@@ -35,6 +37,10 @@ def test_convert():
         fwd = docid_to_uuid(id)
         rev = uuid_to_docid(fwd)
         assert id == rev
+        fwtnid = docid_to_typed_nanoid(id)
+        assert fwtnid is not None
+        rvtnid = typed_nanoid_to_docid(fwtnid)
+        assert id == rvtnid
 
 
 def test_zero():

--- a/lib/sycamore/sycamore/tests/unit/test_materialize.py
+++ b/lib/sycamore/sycamore/tests/unit/test_materialize.py
@@ -143,7 +143,7 @@ class TestMaterializeWrite(unittest.TestCase):
             for d in docs:
                 if isinstance(d, MetadataDocument):
                     continue
-                files = glob.glob(tmpdir + f"/doc-{d.doc_id}:*.pickle")
+                files = glob.glob(tmpdir + f"/doc-{d.doc_id}.*.pickle")
                 assert len(files) == 1
                 with open(files[0], "r") as f:
                     bits = f.read()


### PR DESCRIPTION
see #1090 

":" is illegal in windows filesystem

very useful [stackoverflow page](https://stackoverflow.com/questions/1976007/what-characters-are-forbidden-in-windows-and-linux-directory-names)