### PR TITLE
Revert overzealous no-rootification

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -73,7 +73,7 @@ jobs:
       - name: DF-5
         run: df
       - name: Run tests
-        run: poetry run pytest -n auto -vvv -s sycamore/tests/unit/
+        run: poetry run pytest -n auto sycamore/tests/unit/
         working-directory: lib/sycamore
       - name: Run more tests
         run: poetry run python sycamore/tests/manual/test_fast_sycamore_import.py

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -73,7 +73,7 @@ jobs:
       - name: DF-5
         run: df
       - name: Run tests
-        run: poetry run pytest -n auto sycamore/tests/unit/
+        run: poetry run pytest -n auto -vvv -s sycamore/tests/unit/
         working-directory: lib/sycamore
       - name: Run more tests
         run: poetry run python sycamore/tests/manual/test_fast_sycamore_import.py
@@ -182,8 +182,8 @@ jobs:
           NEO4J_apoc_import_file_use__neo4j__config: true
           NEO4JLABS_PLUGINS: '["apoc"]'
         options: >-
-           --name neo4j
-           --volume /neo4j/import:/var/lib/neo4j/import
+          --name neo4j
+          --volume /neo4j/import:/var/lib/neo4j/import
         ports:
           - 7474:7474
           - 7687:7687

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -73,7 +73,7 @@ jobs:
       - name: DF-5
         run: df
       - name: Run tests
-        run: poetry run pytest -vvv -s sycamore/tests/unit/
+        run: poetry run pytest -n auto -vvv -s sycamore/tests/unit/
         working-directory: lib/sycamore
       - name: Run more tests
         run: poetry run python sycamore/tests/manual/test_fast_sycamore_import.py

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -73,7 +73,7 @@ jobs:
       - name: DF-5
         run: df
       - name: Run tests
-        run: poetry run pytest -n auto -vvv -s sycamore/tests/unit/
+        run: poetry run pytest -vvv -s sycamore/tests/unit/
         working-directory: lib/sycamore
       - name: Run more tests
         run: poetry run python sycamore/tests/manual/test_fast_sycamore_import.py

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -59,7 +59,7 @@ jobs:
       - name: DF-3
         run: df
       - name: Install sycamore
-        run: poetry install --all-extras --no-root
+        run: poetry install --all-extras
         working-directory: lib/sycamore
       - name: Download nltk packages
         run: poetry run python -m nltk.downloader punkt_tab averaged_perceptron_tagger_eng

--- a/lib/sycamore/sycamore/tests/unit/test_docset.py
+++ b/lib/sycamore/sycamore/tests/unit/test_docset.py
@@ -273,7 +273,7 @@ class TestDocSet:
         for i in range(num_docs):
             docs.append(Document(text_representation=f"Document {i}", doc_id=i, properties={"document_number": i}))
 
-        context = sycamore.init(exec_mode=sycamore.ExecMode.LOCAL)
+        context = sycamore.init()
         docset = context.read.document(docs)
 
         assert len(docset.take_all()) == num_docs
@@ -306,7 +306,7 @@ class TestDocSet:
         texts = [self.random_string(min_size=20, max_size=100) for _ in range(10)]
         docs = [Document(text_representation=t, doc_id=i, properties={}) for i, t in enumerate(texts)]
 
-        context = sycamore.init()
+        context = sycamore.init(exec_mode=sycamore.ExecMode.LOCAL)
 
         docset = context.read.document(docs).with_property("text_size", self.text_len)
 
@@ -319,7 +319,7 @@ class TestDocSet:
         texts = [self.random_string(min_size=20, max_size=100) for _ in range(10)]
         docs = [Document(text_representation=t, doc_id=i, properties={}) for i, t in enumerate(texts)]
 
-        context = sycamore.init()
+        context = sycamore.init(exec_mode=sycamore.ExecMode.LOCAL)
         docset = context.read.document(docs).with_properties({"text_size": self.text_len, "num_as": self.num_as})
 
         expected_length = [len(t) for t in texts]

--- a/lib/sycamore/sycamore/tests/unit/test_docset.py
+++ b/lib/sycamore/sycamore/tests/unit/test_docset.py
@@ -273,7 +273,7 @@ class TestDocSet:
         for i in range(num_docs):
             docs.append(Document(text_representation=f"Document {i}", doc_id=i, properties={"document_number": i}))
 
-        context = sycamore.init()
+        context = sycamore.init(exec_mode=sycamore.ExecMode.LOCAL)
         docset = context.read.document(docs)
 
         assert len(docset.take_all()) == num_docs

--- a/lib/sycamore/sycamore/tests/unit/test_docset.py
+++ b/lib/sycamore/sycamore/tests/unit/test_docset.py
@@ -306,7 +306,7 @@ class TestDocSet:
         texts = [self.random_string(min_size=20, max_size=100) for _ in range(10)]
         docs = [Document(text_representation=t, doc_id=i, properties={}) for i, t in enumerate(texts)]
 
-        context = sycamore.init(exec_mode=sycamore.ExecMode.LOCAL)
+        context = sycamore.init()
 
         docset = context.read.document(docs).with_property("text_size", self.text_len)
 
@@ -319,7 +319,7 @@ class TestDocSet:
         texts = [self.random_string(min_size=20, max_size=100) for _ in range(10)]
         docs = [Document(text_representation=t, doc_id=i, properties={}) for i, t in enumerate(texts)]
 
-        context = sycamore.init(exec_mode=sycamore.ExecMode.LOCAL)
+        context = sycamore.init()
         docset = context.read.document(docs).with_properties({"text_size": self.text_len, "num_as": self.num_as})
 
         expected_length = [len(t) for t in texts]


### PR DESCRIPTION
we would poetry install --no-root from lib/sycamore and then somehow pytest is able to import things, but ray workers could not because there is no 'sycamore' module. -> some sort of weird loop trying to reboot workers that immediately die or something