### PR TITLE
Fix similarity assert condition for LLM Filter

### DIFF
--- a/lib/sycamore/sycamore/tests/unit/utils/test_similarity.py
+++ b/lib/sycamore/sycamore/tests/unit/utils/test_similarity.py
@@ -1,0 +1,13 @@
+import pytest
+from unittest.mock import Mock
+from sycamore.utils.similarity import make_element_sorter_fn
+
+
+def test_make_element_sorter_fn_no_similarity_query():
+    sorter_fn = make_element_sorter_fn("test_field", None, Mock())
+    assert sorter_fn({}) is None
+
+
+def test_make_element_sorter_fn_no_similarity_scorer():
+    with pytest.raises(AssertionError, match="Similarity sorting requires a scorer"):
+        make_element_sorter_fn("test_field", "query", None)

--- a/lib/sycamore/sycamore/utils/similarity.py
+++ b/lib/sycamore/sycamore/utils/similarity.py
@@ -3,11 +3,10 @@ from sycamore.transforms.similarity import SimilarityScorer
 
 
 def make_element_sorter_fn(field: str, similarity_query: Optional[str], similarity_scorer: Optional[SimilarityScorer]):
-    assert not (
-        (similarity_query is None) ^ (similarity_scorer is None)
-    ), "set both or neither of similarity_query and similarity_scorer"
     if similarity_query is None:
         return lambda d: None
+
+    assert similarity_scorer is not None, "Similarity sorting requires a scorer"
 
     def f(doc):
         score_property_name = f"{field}_similarity_score"


### PR DESCRIPTION
The validation logic now allows similarity_scorer to be provided without requiring similarity_query, which restores the previous behavior. We only validate that if similarity_query is provided, similarity_scorer must also be provided.
Previous version of [code](https://github.com/aryn-ai/sycamore/pull/1078/files).
Reranking initialization in [docstore](https://github.com/aryn-ai/managed-service/blob/81a5ceeb23b64e1788606fe43fd8488e7508721e/aryn/docstore/common.py#L95)