### PR TITLE
Prompt update for property extraction

### DIFF
--- a/lib/sycamore/sycamore/llms/prompts/default_prompts.py
+++ b/lib/sycamore/sycamore/llms/prompts/default_prompts.py
@@ -176,8 +176,9 @@ class ExtractPropertiesFromSchemaPrompt(SimplePrompt):
         Document text:
         {text}
         
-        Return your answers as a json dictionary, do not return any extra information.
-        If you cannot find a value, use the provided default or None.
+        Don't return extra information.
+        If you cannot find a value for a requested property, use the provided default or the value 'None'.
+        Return your answers as a valid json dictionary that will be parsed in python. 
 """
 
     @staticmethod


### PR DESCRIPTION
An attempt to get better json-parseable responses from the LLM with prompt tweaking. In this case we were previously getting python style dict responses.

Current, non-parseable responses with the json lib:
```
...
"someFieldWithNoValue": None
...
```

as opposed to this, which is parseable:

```
...
"someFieldWithNoValue": "None"
...
```


Another approach is to get `extract_json` to better parse these responses with regex/replace style approaches but that felt jankier and I want to avoid that as long as I can