### PR TITLE
Make `lib/poetry-lock/poetry-lock-all.sh` failures more obvious

### DIFF
--- a/lib/poetry-lock/poetry-lock-all.sh
+++ b/lib/poetry-lock/poetry-lock-all.sh
@@ -26,19 +26,19 @@ for i in ${tomls}; do
         (
             echo "--------------------- special casing in $i"
             cd $(dirname "$i")
-            poetry lock --no-update || fail
+            poetry lock --no-update || fail "broke on special case 'poetry lock --no-update' for $i"
             # Do not apply the consistency logic, it can't do anything useful.
-        ) || fail
+        ) || fail "broke on special case for $i"
         continue
     fi
     (
         echo "--------------------- processing in $i"
         cd $(dirname "$i")
-        poetry lock --no-update || fail
-        poetry install 2>&1 | tee /tmp/poetry-install.out || fail
+        poetry lock --no-update || fail "broke on regular case 'poetry lock --no-update' $i"
+        poetry install 2>&1 | tee /tmp/poetry-install.out || fail "broke on 'poetry install' for $i"
         perl -ne 'print qq{$1 = "$2"\n} if /Downgrading (\S+) \((\S+) ->/o;' </tmp/poetry-install.out >/tmp/downgraded
         cat /tmp/downgraded
-        [[ $(wc -l </tmp/downgraded) -eq 0 ]] || fail
-    ) || fail
+        [[ $(wc -l </tmp/downgraded) -eq 0 ]] || fail "broke on downgrading $i it seems these packages are incompatible"
+    ) || fail "broke on regular case $i"
 done
 echo "SUCCESS"

--- a/lib/poetry-lock/poetry-lock-all.sh
+++ b/lib/poetry-lock/poetry-lock-all.sh
@@ -2,8 +2,9 @@
 
 root="$(pwd)"
 fail() {
-    echo FAILED
+    echo FAILED FAILED FAILED FAILED
     echo "$@"
+    echo FAILED FAILED FAILED FAILED
     exit 1
 }
 [[ -f "${root}/lib/sycamore/pyproject.toml" ]] || fail "run in root git directory"

--- a/lib/poetry-lock/poetry-lock-all.sh
+++ b/lib/poetry-lock/poetry-lock-all.sh
@@ -2,6 +2,7 @@
 
 root="$(pwd)"
 fail() {
+    echo FAILED
     echo "$@"
     exit 1
 }
@@ -25,19 +26,19 @@ for i in ${tomls}; do
         (
             echo "--------------------- special casing in $i"
             cd $(dirname "$i")
-            poetry lock --no-update || exit 1
+            poetry lock --no-update || fail
             # Do not apply the consistency logic, it can't do anything useful.
-        ) || exit 1
+        ) || fail
         continue
     fi
     (
         echo "--------------------- processing in $i"
         cd $(dirname "$i")
-        poetry lock --no-update || exit 1
-        poetry install 2>&1 | tee /tmp/poetry-install.out || exit 1
+        poetry lock --no-update || fail
+        poetry install 2>&1 | tee /tmp/poetry-install.out || fail
         perl -ne 'print qq{$1 = "$2"\n} if /Downgrading (\S+) \((\S+) ->/o;' </tmp/poetry-install.out >/tmp/downgraded
         cat /tmp/downgraded
-        [[ $(wc -l </tmp/downgraded) -eq 0 ]] || exit 1
-    ) || exit 1
+        [[ $(wc -l </tmp/downgraded) -eq 0 ]] || fail
+    ) || fail
 done
 echo "SUCCESS"


### PR DESCRIPTION
Previously, first time users who hadn't read the script could see the output abruptly stop and assume the script had completed successfully. Now, it will always either output a SUCCESS or a FAILED near the end of the output.