### PR TITLE
Bump `aryn-sdk` version to 0.1.12.post0

### DIFF
--- a/lib/aryn-sdk/aryn_sdk/partition/partition.py
+++ b/lib/aryn-sdk/aryn_sdk/partition/partition.py
@@ -21,7 +21,7 @@ _logger = logging.getLogger(__name__)
 _logger.setLevel(logging.INFO)
 _logger.addHandler(logging.StreamHandler(sys.stderr))
 
-g_version = "0.1.12"
+g_version = "0.1.12.post0"
 
 
 class PartitionError(Exception):

--- a/lib/aryn-sdk/pyproject.toml
+++ b/lib/aryn-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aryn-sdk"
-version = "0.1.12"
+version = "0.1.12.post0"
 description = "The client library for Aryn services"
 authors = ["aryn.ai <opensource@aryn.ai>"]
 license = "Apache 2.0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -481,7 +481,7 @@ test = ["dateparser (==1.*)", "pre-commit", "pytest", "pytest-cov", "pytest-mock
 
 [[package]]
 name = "aryn-sdk"
-version = "0.1.12"
+version = "0.1.12.post0"
 description = "The client library for Aryn services"
 optional = false
 python-versions = ">=3.9"


### PR DESCRIPTION
Follows [PEP 440](https://peps.python.org/pep-0440/) rules.