### PR TITLE
Get random hits when filtering properties in sycamore query

### DIFF
--- a/lib/sycamore/sycamore/query/schema.py
+++ b/lib/sycamore/sycamore/query/schema.py
@@ -57,7 +57,11 @@ class OpenSearchSchemaFetcher:
         logger.debug(f"Getting schema for index {self._index}")
         # Fetch example values.
         query["index"] = self._index
-        query["query"] = {"query": {"match_all": {}}, "size": self.NUM_EXAMPLES}
+        query["query"] = {
+            "query": {"match_all": {}},
+            "size": self.NUM_EXAMPLES,
+            "sort": [{"_script": {"type": "number", "script": {"source": "Math.random()"}}}],
+        }
         random_sample = self._query_executor.query(query)["result"]["hits"]["hits"]
 
         result = OpenSearchSchema(


### PR DESCRIPTION
When indexing multiple datasets with different properties in finra, sycamore client was dropping properties from the dataset that was ingested later as only the first 1000 hits in the index are used to filter properties. This PR ensures random hits are selected.