### PR TITLE
LLM Async mode

### DIFF
--- a/lib/sycamore/sycamore/llms/gemini.py
+++ b/lib/sycamore/sycamore/llms/gemini.py
@@ -90,7 +90,7 @@ class Gemini(LLM):
         content_list: list[types.Content] = []
         for message in prompt.messages:
             if message.role == "system":
-                config["system_message"] = message.content
+                config["system_instruction"] = message.content
                 continue
             role = "model" if message.role == "assistant" else "user"
             content = types.Content(parts=[types.Part.from_text(text=message.content)], role=role)
@@ -107,6 +107,21 @@ class Gemini(LLM):
         kwargs["content"] = content_list
         return kwargs
 
+    def _metadata_from_response(self, kwargs, response, starttime) -> dict:
+        wall_latency = datetime.datetime.now() - starttime
+        md = response.usage_metadata
+        in_tokens = int(md.prompt_token_count) if md and md.prompt_token_count else 0
+        out_tokens = int(md.candidates_token_count) if md and md.candidates_token_count else 0
+        output = " ".join(part.text if part else "" for part in response.candidates[0].content.parts)
+        ret = {
+            "output": output,
+            "wall_latency": wall_latency,
+            "in_tokens": in_tokens,
+            "out_tokens": out_tokens,
+        }
+        self.add_llm_metadata(kwargs, output, wall_latency, in_tokens, out_tokens)
+        return ret
+
     def generate_metadata(self, *, prompt: RenderedPrompt, llm_kwargs: Optional[dict] = None) -> dict:
         ret = self._llm_cache_get(prompt, llm_kwargs)
         if isinstance(ret, dict):
@@ -119,21 +134,26 @@ class Gemini(LLM):
         response = self._client.models.generate_content(
             model=self.model.name, contents=kwargs["content"], config=kwargs["config"]
         )
-        wall_latency = datetime.datetime.now() - start
-        md = response.usage_metadata
-        in_tokens = int(md.prompt_token_count) if md and md.prompt_token_count else 0
-        out_tokens = int(md.candidates_token_count) if md and md.candidates_token_count else 0
-        output = " ".join(part.text if part else "" for part in response.candidates[0].content.parts)
-        ret = {
-            "output": output,
-            "wall_latency": wall_latency,
-            "in_tokens": in_tokens,
-            "out_tokens": out_tokens,
-        }
-        self.add_llm_metadata(kwargs, output, wall_latency, in_tokens, out_tokens)
+        ret = self._metadata_from_response(kwargs, response, start)
         self._llm_cache_set(prompt, llm_kwargs, ret)
         return ret
 
     def generate(self, *, prompt: RenderedPrompt, llm_kwargs: Optional[dict] = None) -> str:
         d = self.generate_metadata(prompt=prompt, llm_kwargs=llm_kwargs)
         return d["output"]
+
+    async def generate_async(self, *, prompt: RenderedPrompt, llm_kwargs: Optional[dict] = None) -> str:
+        ret = self._llm_cache_get(prompt, llm_kwargs)
+        if isinstance(ret, dict):
+            return ret["output"]
+        assert ret is None
+
+        kwargs = self.get_generate_kwargs(prompt, llm_kwargs)
+
+        start = datetime.datetime.now()
+        response = await self._client.aio.models.generate_content(
+            model=self.model.name, contents=kwargs["content"], config=kwargs["config"]
+        )
+        ret = self._metadata_from_response(kwargs, response, start)
+        self._llm_cache_set(prompt, llm_kwargs, ret)
+        return ret["output"]

--- a/lib/sycamore/sycamore/transforms/base_llm.py
+++ b/lib/sycamore/sycamore/transforms/base_llm.py
@@ -5,6 +5,14 @@ from sycamore.llms.prompts.prompts import SycamorePrompt, RenderedPrompt
 from sycamore.plan_nodes import Node
 from sycamore.transforms.map import MapBatch
 from sycamore.data import Document, Element
+import asyncio
+
+
+async def _infer_prompts_async(prompts: list[RenderedPrompt], llm: LLM) -> list[str]:
+    el = asyncio.get_running_loop()
+    awaitables = [llm.generate_async(prompt=p, llm_kwargs={}) for p in prompts]
+    tasks = [el.create_task(aw) for aw in awaitables]
+    return await asyncio.gather(*tasks)
 
 
 def _infer_prompts(
@@ -22,7 +30,12 @@ def _infer_prompts(
             res.append(s)
         return res
     elif llm_mode == LLMMode.ASYNC:
-        raise NotImplementedError("Haven't done async yet")
+        nonempty = [(i, p) for i, p in enumerate(prompts) if len(p.messages) > 0]
+        res = [""] * len(prompts)
+        rsps = asyncio.run(_infer_prompts_async([p for _, p in nonempty], llm))
+        for (i, _), rs in zip(nonempty, rsps):
+            res[i] = rs
+        return res
     elif llm_mode == LLMMode.BATCH:
         raise NotImplementedError("Haven't done batch yet")
     else:


### PR DESCRIPTION
Implements async mode for llm_map and llm_map_elements.
Also adds asynchronous llm implementations for anthropic and gemini (+exponential backoff for openai)

I left out bedrock bc bedrock async looks like "start job, poll get job until job is complete, then download result from s3 (oh by the way tell me where in s3 to put the result" and I didn't want to deal with that. (there might be better ways  - there's a converse stream client method that can give you an async iterator over the response that might do the trick but that's a whole 'nother API to deal with)