### PR TITLE
LLM Batch inference

### DIFF
--- a/lib/sycamore/sycamore/llms/anthropic.py
+++ b/lib/sycamore/sycamore/llms/anthropic.py
@@ -235,7 +235,7 @@ class Anthropic(LLM):
             kwargs = get_generate_kwargs(p, llm_kwargs)
             kwargs["model"] = self.model.value
             kwargs["max_tokens"] = kwargs.get("max_tokens", 1024)
-            mparams = MessageCreateParamsNonStreaming(**kwargs)
+            mparams = MessageCreateParamsNonStreaming(**kwargs)  # type: ignore
             rq = Request(custom_id=str(i), params=mparams)
             calls.append(rq)
 

--- a/lib/sycamore/sycamore/llms/llms.py
+++ b/lib/sycamore/sycamore/llms/llms.py
@@ -88,6 +88,10 @@ class LLM(ABC):
             raise ValueError("Either 'prompt' or 'messages' must be specified in prompt_kwargs")
         return await self.generate_async(prompt=rendered, llm_kwargs=llm_kwargs)
 
+    def generate_batch(self, *, prompts: list[RenderedPrompt], llm_kwargs: Optional[dict] = None) -> list[str]:
+        """Generates a series of responses from the LLM for the given series of prompts. Order is preserved."""
+        raise NotImplementedError("This LLM does not support batched generation")
+
     def __str__(self):
         return f"{self.__class__.__name__}({self._model_name})"
 

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -9,6 +9,9 @@ from typing import Any, Dict, Optional, Tuple, Union
 from datetime import datetime
 import asyncio
 import random
+import json
+import io
+import time
 
 from openai import AzureOpenAI as AzureOpenAIClient
 from openai import AsyncAzureOpenAI as AsyncAzureOpenAIClient
@@ -18,7 +21,8 @@ from openai import max_retries as DEFAULT_MAX_RETRIES
 from openai.lib.azure import AzureADTokenProvider
 from openai.lib._parsing import type_to_response_format_param
 from openai import APIConnectionError
-
+from openai.types.chat.chat_completion import ChatCompletion
+from tqdm import tqdm
 
 import pydantic
 
@@ -33,6 +37,7 @@ logger = logging.getLogger(__name__)
 # Base URL for Helicone API, if configured using the SYCAMORE_HELICONE_API_KEY environment variable.
 HELICONE_BASE_URL = "https://oai.helicone.ai/v1"
 INITIAL_BACKOFF = 0.2
+BATCH_POLL_DELAY = 10
 
 
 class OpenAIClientType(Enum):
@@ -488,3 +493,56 @@ class OpenAI(LLM):
             # 1.) The LLM ran out of output context length(usually do to hallucination of repeating the same phrase)
             # 2.) The LLM refused to respond to the request because it did not meet guidelines
             raise e
+
+    def generate_batch(self, *, prompts: list[RenderedPrompt], llm_kwargs: Optional[dict] = None) -> list[str]:
+        cache_hits = [self._llm_cache_get(p, llm_kwargs) for p in prompts]
+
+        calls = []
+        for p, ch, i in zip(prompts, cache_hits, range(len(prompts))):
+            if ch is not None:
+                continue
+            kwargs = self._get_generate_kwargs(p, llm_kwargs)
+            kwargs["model"] = self.model.name
+            call = {"custom_id": str(i), "method": "POST", "url": "/v1/chat/completions", "body": kwargs}
+            calls.append(call)
+        f = io.BytesIO()
+        for i, c in enumerate(calls):
+            f.write(json.dumps(c).encode("utf-8"))
+            if i != len(calls) - 1:
+                f.write(b"\n")
+        client = self.client_wrapper.get_client()
+        starttime = datetime.now()
+        batch_in_file = client.files.create(file=f, purpose="batch")
+        batch = client.batches.create(
+            input_file_id=batch_in_file.id, endpoint="/v1/chat/completions", completion_window="24h"
+        )
+        ctr = 0
+        prog = tqdm(total=len(calls))
+        while batch.status in ("validating", "in_progress", "finalizing"):
+            prog.set_description(batch.status)
+            if batch.request_counts is not None:
+                prog.update(n=(batch.request_counts.completed + batch.request_counts.failed - ctr))
+                ctr = batch.request_counts.completed + batch.request_counts.failed
+            time.sleep(10)
+            batch = client.batches.retrieve(batch.id)
+        prog.close()
+
+        wall_latency = datetime.now() - starttime
+        if batch.error_file_id:
+            errors = client.files.content(batch.error_file_id)
+            logging.error(errors.text)
+            raise ValueError(f"LLM batch call failed: {batch}")
+        if batch.output_file_id:
+            responses = client.files.content(batch.output_file_id)
+            for rs, call in zip(responses.iter_lines(), calls):
+                rdata = json.loads(rs)
+                id = int(rdata["custom_id"])
+                cc = ChatCompletion.model_construct(**rdata["response"]["body"])
+                response_text = cc.choices[0].message.content
+                ct, pt = self.validate_tokens(cc)
+                kws = call["body"]
+                self.add_llm_metadata(kws, response_text, wall_latency, ct, pt)
+                cache_hits[id] = response_text
+                self._llm_cache_set(prompts[id], llm_kwargs, response_text)
+            return cache_hits
+        raise ValueError(f"LLM batch call terminated with no output file or error file: {batch}")

--- a/lib/sycamore/sycamore/transforms/base_llm.py
+++ b/lib/sycamore/sycamore/transforms/base_llm.py
@@ -37,7 +37,7 @@ def _infer_prompts(
             res[i] = rs
         return res
     elif llm_mode == LLMMode.BATCH:
-        raise NotImplementedError("Haven't done batch yet")
+        return llm.generate_batch(prompts=prompts)
     else:
         raise NotImplementedError("Unknown LLM Mode")
 


### PR DESCRIPTION
Adds batch inference modes for openai and anthropic.
I didn't do bedrock or gemini bc those involve dealing with s3 and gcs/bigquery.

OpenAI batch is pretty slow - to be able to test it I ended up using 3.5 turbo as it has far less demand and batch inferences are low priority (expires only after 24h). Anthropic haiku 3 was decently fast (competitive with async!) although that may be the same effect. I did not test it with a more modern / powerful claude.