### PR TITLE
Add param to control how model is selected in hybrid table extractor

### DIFF
--- a/lib/aryn-sdk/aryn_sdk/partition/partition.py
+++ b/lib/aryn-sdk/aryn_sdk/partition/partition.py
@@ -85,11 +85,12 @@ def partition_file(
             default: English
         extract_table_structure: extract tables and their structural content.
             default: False
-        table_extraction_options: Specify options for table extraction, currently only supports boolean
-            'include_additional_text': if table extraction is enabled, attempt to enhance the table
-            structure by merging in tokens from text extraction. This can be useful for tables with missing
-            or misaligned text, and is False by default.
-            default: {}
+        table_extraction_options: Specify options for table extraction. Only enabled if table extraction
+            is enabled. Default is {}. Options:
+            - 'include_additional_text': Attempt to enhance the table structure by merging in tokens from
+                text extraction. This can be useful for tables with missing or misaligned text. Default: False
+            - 'model_selection': expression to instruct DocParse how to choose which model to use for table
+                extraction. See https://docs.aryn.ai/docparse/processing_options for more details.
         extract_images: extract image contents in ppm format, base64 encoded.
             default: False
         selected_pages: list of individual pages (1-indexed) from the pdf to partition

--- a/lib/aryn-sdk/aryn_sdk/partition/partition.py
+++ b/lib/aryn-sdk/aryn_sdk/partition/partition.py
@@ -90,7 +90,8 @@ def partition_file(
             - 'include_additional_text': Attempt to enhance the table structure by merging in tokens from
                 text extraction. This can be useful for tables with missing or misaligned text. Default: False
             - 'model_selection': expression to instruct DocParse how to choose which model to use for table
-                extraction. See https://docs.aryn.ai/docparse/processing_options for more details.
+                extraction. See https://docs.aryn.ai/docparse/processing_options for more details. Default:
+                "pixels > 500 -> deformable_detr; table_transformer"
         extract_images: extract image contents in ppm format, base64 encoded.
             default: False
         selected_pages: list of individual pages (1-indexed) from the pdf to partition

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_table_extractor.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_table_extractor.py
@@ -124,3 +124,10 @@ class TestHybridSelectionStatements:
         assert f(5, 42) == "table_transformer"
         assert f(5, 32) == "deformable_detr"
         assert f(0, 32) == "table_transformer"
+
+    def test_excess_semicolons_ok(self):
+        f = HTSE.parse_model_selection("chars>0->table_transformer;")
+        assert f(10, 10) == "table_transformer"
+
+        f = HTSE.parse_model_selection(";;;chars>0->table_transformer;")
+        assert f(10, 10) == "table_transformer"

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_table_extractor.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_table_extractor.py
@@ -1,3 +1,4 @@
+import pytest
 from PIL import Image
 from sycamore.data.bbox import BoundingBox
 from sycamore.data.element import TableElement
@@ -6,6 +7,8 @@ from sycamore.transforms.table_structure.extract import (
     HybridTableStructureExtractor,
     DeformableTableStructureExtractor,
 )
+
+HTSE = HybridTableStructureExtractor
 
 
 class TestTableExtractors:
@@ -20,25 +23,103 @@ class TestTableExtractors:
     def mock_table_element(mocker, width, height):
         elt = mocker.Mock(spec=TableElement)
         elt.bbox = BoundingBox(0, 0, width, height)
+        elt.tokens = [{"text": "alrngea;rjgnekl"}]
         return elt
 
     def test_hybrid_routing_both_gt500(self, mocker):
         im = TestTableExtractors.mock_doc_image(mocker, 1000, 1000)
         elt = TestTableExtractors.mock_table_element(mocker, 0.7, 0.7)
         extractor = HybridTableStructureExtractor(deformable_model="dont initialize me")
-        chosen = extractor._pick_model(elt, im)
+        chosen = extractor._pick_model(elt, im, model_selection="pixels>500->deformable_detr;table_transformer")
         assert type(chosen) == DeformableTableStructureExtractor
 
     def test_hybrid_routing_one_gt500(self, mocker):
         im = TestTableExtractors.mock_doc_image(mocker, 1000, 1000)
         elt = TestTableExtractors.mock_table_element(mocker, 0.7, 0.2)
         extractor = HybridTableStructureExtractor(deformable_model="dont initialize me")
-        chosen = extractor._pick_model(elt, im)
+        chosen = extractor._pick_model(elt, im, model_selection="pixels>500->deformable_detr;table_transformer")
         assert type(chosen) == DeformableTableStructureExtractor
 
     def test_hybrid_routing_neither_gt500(self, mocker):
         im = TestTableExtractors.mock_doc_image(mocker, 1000, 1000)
         elt = TestTableExtractors.mock_table_element(mocker, 0.2, 0.2)
         extractor = HybridTableStructureExtractor(deformable_model="dont initialize me")
-        chosen = extractor._pick_model(elt, im)
+        chosen = extractor._pick_model(elt, im, model_selection="pixels>500->deformable_detr;table_transformer")
         assert type(chosen) == TableTransformerStructureExtractor
+
+
+class TestHybridSelectionStatements:
+    params = [(1000, 25), (25, 1000), (25, 25), (1000, 1000)]
+
+    def test_static(self):
+        f = HybridTableStructureExtractor.parse_model_selection("table_transformer")
+        for p in self.params:
+            assert f(*p) == "table_transformer"
+
+        f = HybridTableStructureExtractor.parse_model_selection("deformable_detr ")
+        for p in self.params:
+            assert f(*p) == "deformable_detr"
+
+        f = HybridTableStructureExtractor.parse_model_selection("deformable_detr; this is a comment")
+        for p in self.params:
+            assert f(*p) == "deformable_detr"
+
+    def test_pixelmetric(self):
+        f = HybridTableStructureExtractor.parse_model_selection("pixels > 500 -> deformable_detr; table_transformer")
+        selections = [f(*p) for p in self.params]
+        assert selections == ["deformable_detr", "table_transformer", "table_transformer", "deformable_detr"]
+
+    def test_charmetric(self):
+        f = HybridTableStructureExtractor.parse_model_selection("chars > 500 -> deformable_detr; table_transformer")
+        selections = [f(*p) for p in self.params]
+        assert selections == ["table_transformer", "deformable_detr", "table_transformer", "deformable_detr"]
+
+    def test_bad_modelname(self):
+        with pytest.raises(ValueError, match=r"Invalid statement.* model_name was not in.*"):
+            HTSE.parse_model_selection("tatr")
+
+        with pytest.raises(ValueError, match=r"Invalid statement.* Result model .* was not in.*"):
+            HTSE.parse_model_selection("pixels>500 -> nonmodel")
+
+        with pytest.raises(ValueError, match=r"Invalid statement.* model_name was not in.*"):
+            HTSE.parse_model_selection("pixels>500 -> deformable_detr; yo_mama")
+
+    def test_multiple_arrows(self):
+        with pytest.raises(ValueError, match=r"Invalid statement.* Found more than 2 instances of '->'"):
+            HTSE.parse_model_selection("pixels>500 -> vrooooom -> vrooooooooooom")
+
+    def test_no_comparison(self):
+        with pytest.raises(ValueError, match=r"Invalid statement.* Did not find a comparison operator .*"):
+            HTSE.parse_model_selection("pixels=3->deformable_detr")
+
+        with pytest.raises(ValueError, match=r"Invalid statement.* Did not find a comparison operator .*"):
+            HTSE.parse_model_selection("chars->deformable_detr")
+
+    def test_multiple_comparisons(self):
+        with pytest.raises(ValueError, match=r"Invalid comparison.* Comparison statements must take the form .*"):
+            HTSE.parse_model_selection("1000 > pixels > 300 -> deformable_detr")
+
+    def test_backwards_comparison(self):
+        with pytest.raises(ValueError, match=r"Invalid comparison.* Allowed metrics are.*"):
+            HTSE.parse_model_selection("1000 > pixels -> table_transformer")
+
+    def test_bad_metric(self):
+        with pytest.raises(ValueError, match=r"Invalid comparison.* Allowed metrics are.*"):
+            HTSE.parse_model_selection("pickles > 1000 -> table_transformer")
+
+        with pytest.raises(ValueError, match=r"Invalid comparison.* Allowed metrics are.*"):
+            HTSE.parse_model_selection("charm < 5 -> deformable_detr")
+
+    def test_bad_threshold(self):
+        with pytest.raises(ValueError, match=r"Invalid comparison.* Threshold .* must be numeric"):
+            HTSE.parse_model_selection("pixels > chars -> table_transformer")
+
+    def test_complicated(self):
+        f = HTSE.parse_model_selection(
+            "pixels>5->table_transformer; chars<30->deformable_detr;chars>35->table_transformer;pixels>2->deformable_detr;table_transformer;comment"
+        )
+        assert f(10, 14) == "table_transformer"
+        assert f(5, 15) == "deformable_detr"
+        assert f(5, 42) == "table_transformer"
+        assert f(5, 32) == "deformable_detr"
+        assert f(0, 32) == "table_transformer"

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_table_extractor.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_table_extractor.py
@@ -116,7 +116,8 @@ class TestHybridSelectionStatements:
 
     def test_complicated(self):
         f = HTSE.parse_model_selection(
-            "pixels>5->table_transformer; chars<30->deformable_detr;chars>35->table_transformer;pixels>2->deformable_detr;table_transformer;comment"
+            "pixels>5->table_transformer; chars<30->deformable_detr;chars>35->table_transformer;"
+            "pixels>2->deformable_detr;table_transformer;comment"
         )
         assert f(10, 14) == "table_transformer"
         assert f(5, 15) == "deformable_detr"

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Any, Union, Literal, Optional
+from typing import Any, Union, Literal, Optional, Callable
 
 from PIL import Image
 import pdf2image

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -341,15 +341,13 @@ class HybridTableStructureExtractor(TableStructureExtractor):
             a function that can be used to select a model given the pixels and chars metrics.
 
         Examples:
-            - "table_transformer" => always use table transformer
-            - "pixels > 500 -> deformable_detr; table_transformer" => if the biggest dimension of
+            - `"table_transformer"` => always use table transformer
+            - `"pixels > 500 -> deformable_detr; table_transformer"` => if the biggest dimension of
                 the table is greater than 500 pixels use deformable detr. Otherwise use table_transformer.
-            - "pixels>50->table_transformer; chars<30->deformable_detr;chars>35->table_transformer;"
-              "pixels>2->deformable_detr;table_transformer;comment" => if the biggest dimension is more than
-                50 pixels use table transformer. Else if the total number of chars in the table is less than
-                30 use deformable_detr. Else if there are mode than 35 chars use table transformer. Else if
-                there are more than 2 pixels in the biggest dimension use deformable detr. Otherwise use
-                table transformer. comment is not processed.
+            - `"pixels>50->table_transformer; chars<30->deformable_detr;chars>35->table_transformer;pixels>2->deformable_detr;table_transformer;comment"`
+                => if the biggest dimension is more than 50 pixels use table transformer. Else if the total number of chars in the table is less than
+                30 use deformable_detr. Else if there are mode than 35 chars use table transformer. Else if there are more than 2 pixels in the biggest
+                dimension use deformable detr. Otherwise use table transformer. comment is not processed.
         """
         statements = selection.split(sep=";")
         checks = []

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Any, Union, Literal, Optional, Callable
+from typing import Any, Union, Optional, Callable
 
 from PIL import Image
 import pdf2image
@@ -378,26 +378,47 @@ class HybridTableStructureExtractor(TableStructureExtractor):
 
     @classmethod
     def parse_comparison(cls, comparison: str) -> tuple[str, Callable[[Num, Num], bool], Union[int, float]]:
-        cmp = lambda a, b: False
         cmp_pieces = []
         if "!=" in comparison:
             cmp_pieces = comparison.split(sep="!=")
-            cmp = lambda a, b: a != b
+
+            def cmp(a, b):
+                return a != b
+
         elif ">=" in comparison:
             cmp_pieces = comparison.split(sep=">=")
-            cmp = lambda a, b: a >= b
+
+            def cmp(a, b):
+                return a >= b
+
         elif "<=" in comparison:
             cmp_pieces = comparison.split(sep="<=")
-            cmp = lambda a, b: a <= b
+
+            def cmp(a, b):
+                return a <= b
+
         elif "==" in comparison:
             cmp_pieces = comparison.split(sep="==")
-            cmp = lambda a, b: a == b
+
+            def cmp(a, b):
+                return a == b
+
         elif "<" in comparison:
             cmp_pieces = comparison.split("<")
-            cmp = lambda a, b: a < b
+
+            def cmp(a, b):
+                return a < b
+
         elif ">" in comparison:
             cmp_pieces = comparison.split(">")
-            cmp = lambda a, b: a > b
+
+            def cmp(a, b):
+                return a > b
+
+        else:
+            raise ValueError(
+                f"Invalid comparison: '{comparison}'. Did not find comparison operator (<, >, ==, <=, >=, !=)."
+            )
         if len(cmp_pieces) != 2:
             raise ValueError(
                 f"Invalid comparison: '{comparison}'. Comparison statements must take the form 'METRIC CMP THRESHOLD'."

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -264,8 +264,10 @@ class HybridTableStructureExtractor(TableStructureExtractor):
             threshold = -1
         elif model is None:
             threshold = 500
-        else:
+        elif isinstance(model, int):
             threshold = model
+        else:
+            raise ValueError(f"'model' argument must be either None, 'tatr', 'deformable', or an int. Found: {model}")
 
         width, height = doc_image.size
         bb = element.bbox.to_absolute(width, height)

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -289,7 +289,7 @@ class HybridTableStructureExtractor(TableStructureExtractor):
         element: TableElement,
         doc_image: Image.Image,
         union_tokens=False,
-        model: str = "pixels > 500 -> deformable_detr; table_transformer",
+        model_selection: str = "pixels > 500 -> deformable_detr; table_transformer",
     ) -> TableElement:
         """Extracts the table structure from the specified element using a either a DeformableDETR or
         TATR model, depending on the size of the table.
@@ -306,7 +306,7 @@ class HybridTableStructureExtractor(TableStructureExtractor):
           model: Control which model gets selected. If 'tatr', use TATR; if 'deformable', use deformable.
                 If an integer, use that as the size threshold. If None, the threshold is 500.
         """
-        m = self._pick_model(element, doc_image, model)
+        m = self._pick_model(element, doc_image, model_selection)
         return m.extract(element, doc_image, union_tokens)
 
     @classmethod

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -348,7 +348,7 @@ class HybridTableStructureExtractor(TableStructureExtractor):
                 => if the biggest dimension is more than 50 pixels use table transformer. Else if the total number of chars in the table is less than
                 30 use deformable_detr. Else if there are mode than 35 chars use table transformer. Else if there are more than 2 pixels in the biggest
                 dimension use deformable detr. Otherwise use table transformer. comment is not processed.
-        """
+        """  # noqa: E501 # line too long. long line is a long example. I want it that way.
         statements = selection.split(sep=";")
         checks = []
         for statement in statements:

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -333,6 +333,8 @@ class HybridTableStructureExtractor(TableStructureExtractor):
         checks = []
         for statement in statements:
             statement = statement.strip()
+            if statement == "":
+                continue
             if "->" not in statement:
                 if statement not in cls._model_names:
                     raise ValueError(

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -300,6 +300,8 @@ class HybridTableStructureExtractor(TableStructureExtractor):
                Used for bounding box calculations.
           union_tokens: Make sure that ocr/pdfminer tokens are _all_ included in the table.
           apply_thresholds: Apply class thresholds to the objects output by the model.
+          model: Control which model gets selected. If 'tatr', use TATR; if 'deformable', use deformable.
+                If an integer, use that as the size threshold. If None, the threshold is 500.
         """
         m = self._pick_model(element, doc_image, model)
         return m.extract(element, doc_image, union_tokens)

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -317,10 +317,11 @@ def parse_model_selection(selection: str) -> Callable[[int, int], Optional[_Mode
     statements = selection.split(sep=";")
     checks = []
     for statement in statements:
+        statement = statement.strip()
         if "->" not in statement:
             if statement not in _model_names:
                 raise ValueError(
-                    f"Invalid statement: '{statement}'. Did not find =, so this is assumed"
+                    f"Invalid statement: '{statement}'. Did not find '->', so this is assumed"
                     f" to be a static statement, but the model_name was not in {_model_names}"
                 )
             checks.append(lambda pixels, chars: statement)
@@ -328,7 +329,7 @@ def parse_model_selection(selection: str) -> Callable[[int, int], Optional[_Mode
         pieces = statement.split(sep="->")
         if len(pieces) > 2:
             raise ValueError(f"Invalid statement: '{statement}'. Found more than 2 instances of '->'")
-        result = pieces[1]
+        result = pieces[1].strip()
         if result not in _model_names:
             raise ValueError(f"Invalid statement: '{statement}'. Result model ({result}) was not in {_model_names}")
         if all(c not in pieces[0] for c in ("<", ">", "==", "<=", ">=", "!=")):
@@ -359,7 +360,7 @@ def parse_model_selection(selection: str) -> Callable[[int, int], Optional[_Mode
             raise ValueError(
                 f"Invalid statement: '{statement}'. Comparison statements must take the form 'METRIC CMP THRESHOLD'."
             )
-        metric, threshold = cmp_pieces[0], cmp_pieces[1]
+        metric, threshold = cmp_pieces[0].strip(), cmp_pieces[1].strip()
         if metric not in _metrics:
             raise ValueError(f"Invalid statement: '{statement}'. Allowed metrics are: '{_metrics}'")
         try:

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -355,15 +355,19 @@ class HybridTableStructureExtractor(TableStructureExtractor):
                 )
             metric, cmp, threshold = cls.parse_comparison(pieces[0])
 
-            def check(pixels: float, chars: int) -> Optional[str]:
-                if metric == "pixels":
-                    cmpval = pixels
-                else:
-                    cmpval = chars
-                if cmp(cmpval, threshold):
-                    return result
+            def make_check(metric, compare, threshold, result):
+                # otherwise captrued variables change their values
+                def check(pixels: float, chars: int) -> Optional[str]:
+                    if metric == "pixels":
+                        cmpval = pixels
+                    else:
+                        cmpval = chars
+                    if compare(cmpval, threshold):
+                        return result
 
-            checks.append(check)
+                return check
+
+            checks.append(make_check(metric, cmp, threshold, result))
 
         def select_fn(pixels: float, chars: int) -> Optional[str]:
             for c in checks:

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -364,6 +364,7 @@ class HybridTableStructureExtractor(TableStructureExtractor):
                         cmpval = chars
                     if compare(cmpval, threshold):
                         return result
+                    return None
 
                 return check
 
@@ -373,6 +374,7 @@ class HybridTableStructureExtractor(TableStructureExtractor):
             for c in checks:
                 if (rv := c(pixels, chars)) is not None:
                     return rv
+            return None
 
         return select_fn
 
@@ -427,7 +429,7 @@ class HybridTableStructureExtractor(TableStructureExtractor):
         if metric not in cls._metrics:
             raise ValueError(f"Invalid comparison: '{comparison}'. Allowed metrics are: '{cls._metrics}'")
         try:
-            threshold_num = int(threshold)
+            threshold_num: Num = int(threshold)
         except ValueError:
             try:
                 threshold_num = float(threshold)


### PR DESCRIPTION
add a model_selection param to hybrid table extractor that accepts expressions in this spec:
(take from the docstring)
```
        Parse a model selection expression. Model selection expressions are of the form:
            "metric cmp threshold -> model; metric cmp threshold -> model; model;"
        That is, any number of conditional expression selections followed by up to one unconditional
        selection expression, separated by semicolons. Expressions are processed from left to right.

        - Supported metrics are "pixels" - the number of pixels in the larger dimension of the table, and
        "chars" - the number of characters in the table, as detected by the partitioner's text_extractor.
        - Supported comparisons are the usual set - <, >, <=, >=, ==, !=.
        - The threshold must be numeric (and int or a float)
        - The model must be either "deformable_detr" or "table_transformer"

        Args:
            selection: the selection string.

        Returns:
            a function that can be used to select a model given the pixels and chars metrics.
```