### PR TITLE
deserialize a summaryDocument as a SummaryDocument, not a Document

### DIFF
--- a/lib/sycamore/sycamore/data/document.py
+++ b/lib/sycamore/sycamore/data/document.py
@@ -195,6 +195,10 @@ class Document(UserDict):
             return MetadataDocument(data)
         elif "children" in data:
             return HierarchicalDocument(data)
+        elif "sub_docs" in data:
+            from sycamore.transforms.summarize import SummaryDocument
+
+            return SummaryDocument(data)
         else:
             return Document(data)
 

--- a/lib/sycamore/sycamore/transforms/summarize.py
+++ b/lib/sycamore/sycamore/transforms/summarize.py
@@ -528,10 +528,7 @@ class OneStepDocumentSummarizer(Summarizer):
         vars = self.get_const_vars()
         prompt = self.prompt.fork(ignore_none=True, question=self.question)
         fields = copy.deepcopy(self.fields)
-        if "sub_docs" in doc.data:
-            data = doc.data
-            data.pop("elements", None)
-            doc = SummaryDocument(**data)
+        if isinstance(doc, SummaryDocument):
             doc.properties = {k: True for d in doc.sub_docs for k in d.properties.keys()}
         doc_fields, elt_fields = _partition_fields(doc, fields)
         fieldset = {f for f in fields if f is not EtCetera}


### PR DESCRIPTION
Managed to run into this issue with the multistep summarizer too. The real fix is to deserialize it correctly rather than cast in place I guess