### PR TITLE
Fix when no sub docs in summary document

### DIFF
--- a/lib/sycamore/sycamore/tests/unit/transforms/test_summarize.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_summarize.py
@@ -306,6 +306,22 @@ class TestOneStepSummarize:
         assert "say what?" in usermessage
         assert "properties.state" not in usermessage
 
+    def test_no_sub_docs(self, mocker):
+        llm = mocker.Mock(spec=LLM)
+        generate = mocker.patch.object(llm, "generate")
+        generate.return_value = "sum"
+
+        doc = SummaryDocument()
+
+        summarizer = OneStepDocumentSummarizer(llm, question="What is this about?")
+        summarized_doc = summarizer.summarize(doc)
+
+        assert summarized_doc.properties["summary"] == "sum"
+        assert generate.call_count == 1
+        prompt = generate.call_args.kwargs["prompt"]
+        usermessage = prompt.messages[-1].content
+        assert "What is this about?" in usermessage
+
 
 def filter_elements_on_length(element: Element) -> bool:
     return False if element.text_representation is None else len(element.text_representation) > 10

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_summarize.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_summarize.py
@@ -150,6 +150,19 @@ class TestMultiStepSummarize:
         usermessage = prompt.messages[-1].content
         assert occurrences(usermessage, ": sum") == 2
 
+    def test_no_sub_docs(self, mocker):
+        llm = mocker.Mock(spec=LLM)
+        generate = mocker.patch.object(llm, "generate")
+        generate.return_value = "no summary"
+
+        single_element_doc = SummaryDocument()
+
+        summarizer = MultiStepDocumentSummarizer(llm=llm, question="What is this about?")
+        d = summarizer.summarize(single_element_doc)
+
+        assert d.properties["summary"] == "Empty Summary Document, nothing to summarize"
+        assert generate.call_count == 0  # No sub-documents to summarize
+
 
 class TestOneStepSummarize:
     doc = SummaryDocument(

--- a/lib/sycamore/sycamore/transforms/summarize.py
+++ b/lib/sycamore/sycamore/transforms/summarize.py
@@ -498,7 +498,11 @@ class OneStepDocumentSummarizer(Summarizer):
         """
         vars = self.get_const_vars()
         # This is complicated bc we might get a SummarizeDocument or a Document
-        max_numel = max(len(d.data.get("elements", [])) for d in doc.data.get("sub_docs", doc.elements))
+        max_numel = (
+            max(len(d.data.get("elements", [])) for d in doc.data.get("sub_docs", doc.elements))
+            if doc.data.get("sub_docs")
+            else 0
+        )
         # If elements can fit there's a little additional fluff added, so recompute baseline tokens
         # with no elements (but the element introduction fluff)
         doc.properties[vars["numel_key"]] = 1

--- a/lib/sycamore/sycamore/transforms/summarize.py
+++ b/lib/sycamore/sycamore/transforms/summarize.py
@@ -303,7 +303,10 @@ class MultiStepDocumentSummarizer(Summarizer):
                 break
             last_elt_len = len(remaining_elements)
             round += 1
-        document.properties["summary"] = remaining_elements[0].properties["summary"]
+        if remaining_elements:
+            document.properties["summary"] = remaining_elements[0].properties["summary"]
+        else:
+            document.properties["summary"] = "Empty Summary Document, nothing to summarize"
         for e in document.elements:
             e.properties.pop("summary", None)
         return document
@@ -327,9 +330,10 @@ class MultiStepDocumentSummarizer(Summarizer):
         final_elements = []
         to_infer = []
         for eb in elt_batches:
-            document.elements = eb
-            final_elements.append(eb[0])
-            to_infer.append(base_prompt.render_document(document))
+            if eb:
+                document.elements = eb
+                final_elements.append(eb[0])
+                to_infer.append(base_prompt.render_document(document))
 
         # Invoke the llm and attach summaries
         summaries = _infer_prompts(prompts=to_infer, llm=self.llm, llm_mode=self.llm_mode)


### PR DESCRIPTION
Came up when Query Database returned no docs, but summarize node still had to be executed