### PR TITLE
Fix limit and add subquerying

### DIFF
--- a/lib/sycamore/sycamore/docset.py
+++ b/lib/sycamore/sycamore/docset.py
@@ -265,7 +265,7 @@ class DocSet:
             if include_metadata or not isinstance(doc, MetadataDocument):
                 yield doc
 
-    def limit(self, limit: int = 20, **kwargs) -> "DocSet":
+    def limit(self, limit: int = 20, field: Optional[str] = None, **kwargs) -> "DocSet":
         """
         Applies the Limit transforms on the Docset.
 
@@ -284,7 +284,7 @@ class DocSet:
         """
         from sycamore.transforms import Limit
 
-        return DocSet(self.context, Limit(self.plan, limit, **kwargs))
+        return DocSet(self.context, Limit(self.plan, limit, field, **kwargs))
 
     def partition(
         self, partitioner: Partitioner, table_extractor: Optional[TableExtractor] = None, **kwargs

--- a/lib/sycamore/sycamore/query/execution/sycamore_operator.py
+++ b/lib/sycamore/sycamore/query/execution/sycamore_operator.py
@@ -200,8 +200,8 @@ class SycamoreSummarizeData(SycamoreOperator):
         assert description is not None and isinstance(description, str)
         result = summarize_data(
             question=question,
-            result_description=description,
-            result_data=self.inputs,
+            data_description=description,
+            input_data=self.inputs,
             context=self.context,
             **self.get_execute_args(),
         )
@@ -222,8 +222,8 @@ class SycamoreSummarizeData(SycamoreOperator):
         result = f"""
 {output_var or get_var_name(self.logical_node)} = summarize_data(
     question='{question}',
-    result_description='{description}',
-    result_data=[{logical_deps_str}],
+    data_description='{description}',
+    input_data=[{logical_deps_str}],
     context=context,
     use_elements=True,
     **{get_str_for_dict(self.get_execute_args())},
@@ -266,7 +266,7 @@ class SycamoreLlmFilter(SycamoreOperator):
 
         # load into local vars for Ray serialization magic
 
-        prompt = LlmFilterMessagesJinjaPrompt.set(filter_question=question)
+        prompt = LlmFilterMessagesJinjaPrompt.fork(filter_question=question)
 
         result = self.inputs[0].llm_filter(
             new_field="_autogen_LLMFilterOutput",
@@ -283,7 +283,7 @@ class SycamoreLlmFilter(SycamoreOperator):
         input_str = input_var or get_var_name(self.logical_node.input_nodes()[0])
         output_str = output_var or get_var_name(self.logical_node)
         result = f"""
-prompt = LlmFilterMessagesPrompt(filter_question='{self.logical_node.question}').as_messages()
+prompt = LlmFilterMessagesJinjaPrompt.fork(filter_question='{self.logical_node.question}').as_messages()
 {output_str} = {input_str}.llm_filter(
     new_field='_autogen_LLMFilterOutput',
     prompt=prompt,

--- a/lib/sycamore/sycamore/query/execution/sycamore_operator.py
+++ b/lib/sycamore/sycamore/query/execution/sycamore_operator.py
@@ -283,7 +283,7 @@ class SycamoreLlmFilter(SycamoreOperator):
         input_str = input_var or get_var_name(self.logical_node.input_nodes()[0])
         output_str = output_var or get_var_name(self.logical_node)
         result = f"""
-prompt = LlmFilterMessagesJinjaPrompt.fork(filter_question='{self.logical_node.question}').as_messages()
+prompt = LlmFilterMessagesJinjaPrompt.fork(filter_question='{self.logical_node.question}')
 {output_str} = {input_str}.llm_filter(
     new_field='_autogen_LLMFilterOutput',
     prompt=prompt,
@@ -293,7 +293,7 @@ prompt = LlmFilterMessagesJinjaPrompt.fork(filter_question='{self.logical_node.q
 )
 """
         return result, [
-            "from sycamore.llms.prompts.default_prompts import LlmFilterMessagesPrompt",
+            "from sycamore.llms.prompts.default_prompts import LlmFilterMessagesJinjaPrompt",
         ]
 
 

--- a/lib/sycamore/sycamore/query/operators/limit.py
+++ b/lib/sycamore/sycamore/query/operators/limit.py
@@ -1,4 +1,5 @@
 from sycamore.query.logical_plan import Node
+from typing import Optional
 
 
 class Limit(Node):
@@ -8,4 +9,5 @@ class Limit(Node):
     """
 
     num_records: int
+    field: Optional[str] = None
     """The number of records of the database to return."""

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_basics.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_basics.py
@@ -1,0 +1,58 @@
+import pytest
+from sycamore.data import Document, MetadataDocument
+from sycamore.plan_nodes import Node
+from sycamore.transforms import Limit
+import ray
+
+class MockNode(Node):
+    def __init__(self, docs):
+        self._docs = docs
+
+    def execute(self, **kwargs):
+        return ray.data.from_items([{'doc': doc.serialize()} for doc in self._docs])
+
+@pytest.fixture(scope="module", autouse=True)
+def ray_init():
+    ray.init(ignore_reinit_error=True)
+    yield
+    ray.shutdown()
+
+def test_limit():
+    docs = [Document({'text': f'Doc {i}'}) for i in range(10)]
+    node = MockNode(docs)
+    limit_transform = Limit(node, limit=5)
+    result = limit_transform.execute()
+    assert len(result.take_all()) == 5
+
+def test_limit_with_field_and_metadata():
+    docs = [Document({'id': 1, 'text': f'Doc {i}'}) for i in range(3)]
+    docs.extend([MetadataDocument({ 'text': f'Doc {i}'}) for i in range(3)])
+    docs.extend([Document({'id': 3, 'text': f'Doc {i}'}) for i in range(3)])
+    docs.extend([Document({'id': 4, 'text': f'Doc {i}'}) for i in range(3)])
+    node = MockNode(docs)
+    limit_transform = Limit(node, limit=2, field='id')
+    result = limit_transform.execute()
+    assert len(result.take_all()) == 9
+    list_of_docs = [Document.deserialize(d['doc']) for d in result.take_all()]
+    documents = [doc for doc in list_of_docs if not isinstance(doc, MetadataDocument)]
+    assert len(documents) == 6
+    unique_ids = set(doc['id'] for doc in documents)
+    assert len(unique_ids) == 2
+
+def test_limit_empty_dataset():
+    node = MockNode([])
+    limit_transform = Limit(node, limit=5)
+    result = limit_transform.execute()
+    assert len(result.take_all()) == 0
+
+def test_limit_with_metadata():
+    docs = [Document({'id': i, 'text': f'Doc {i}'}) for i in range(3)]
+    docs.extend([MetadataDocument({'id': i, 'text': f'Doc {i}'}) for i in range(3,6)])
+    docs.extend([Document({'id': i, 'text': f'Doc {i}'}) for i in range(6,9)])
+    node = MockNode(docs)
+    limit_transform = Limit(node, limit=4)
+    result = limit_transform.execute()
+    list_of_docs = [Document.deserialize(d['doc']) for d in result.take_all()]
+    documents = [doc for doc in list_of_docs if not isinstance(doc, MetadataDocument)]
+    assert len(list_of_docs) == 7
+    assert len(documents) == 4


### PR DESCRIPTION
1. Fix limit to not count Metadata Documents.
2. Add hacky sub querying for a certain set of queries where you want to limit using a field on unique values rather than each row.