### PR TITLE
fallback to tatr if deformable fails

### DIFF
--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -316,6 +316,11 @@ class HybridTableStructureExtractor(TableStructureExtractor):
                 If no statements are matched, defaults to table transformer.
         """
         m = self._pick_model(element, doc_image, model_selection)
+        if m is self._deformable:
+            try:
+                return m.extract(element, doc_image, union_tokens)
+            except Exception:
+                m = self._tatr
         return m.extract(element, doc_image, union_tokens)
 
     @classmethod


### PR DESCRIPTION
With the two-stage approach it's possible that the encoder does not generate sufficient region proposals, which causes the inner topk to error out. We should fix that eventually but for now let's hack it so that if deformable fails, we fall back to tatr which (should) not have this issue