### PR TITLE
Fix limit transform

### DIFF
--- a/lib/sycamore/sycamore/tests/unit/transforms/test_basics.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_basics.py
@@ -1,0 +1,48 @@
+import pytest
+from sycamore.data import Document, MetadataDocument
+from sycamore.plan_nodes import Node
+from sycamore.transforms import Limit
+import ray
+
+
+class MockNode(Node):
+    def __init__(self, docs):
+        self._docs = docs
+
+    def execute(self, **kwargs):
+        return ray.data.from_items([{"doc": doc.serialize()} for doc in self._docs])
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ray_init():
+    ray.init(ignore_reinit_error=True)
+    yield
+    ray.shutdown()
+
+
+def test_limit():
+    docs = [Document({"text": f"Doc {i}"}) for i in range(10)]
+    node = MockNode(docs)
+    limit_transform = Limit(node, limit=5)
+    result = limit_transform.execute()
+    assert len(result.take_all()) == 5
+
+
+def test_limit_empty_dataset():
+    node = MockNode([])
+    limit_transform = Limit(node, limit=5)
+    result = limit_transform.execute()
+    assert len(result.take_all()) == 0
+
+
+def test_limit_with_metadata():
+    docs = [Document({"id": i, "text": f"Doc {i}"}) for i in range(3)]
+    docs.extend([MetadataDocument({"id": i, "text": f"Doc {i}"}) for i in range(3, 6)])
+    docs.extend([Document({"id": i, "text": f"Doc {i}"}) for i in range(6, 9)])
+    node = MockNode(docs)
+    limit_transform = Limit(node, limit=4)
+    result = limit_transform.execute()
+    list_of_docs = [Document.deserialize(d["doc"]) for d in result.take_all()]
+    documents = [doc for doc in list_of_docs if not isinstance(doc, MetadataDocument)]
+    assert len(list_of_docs) == 7
+    assert len(documents) == 4

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_basics.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_basics.py
@@ -44,5 +44,5 @@ def test_limit_with_metadata():
     result = limit_transform.execute()
     list_of_docs = [Document.deserialize(d["doc"]) for d in result.take_all()]
     documents = [doc for doc in list_of_docs if not isinstance(doc, MetadataDocument)]
-    assert len(list_of_docs) == 7
+    assert len(list_of_docs) == 4
     assert len(documents) == 4

--- a/lib/sycamore/sycamore/transforms/basics.py
+++ b/lib/sycamore/sycamore/transforms/basics.py
@@ -41,7 +41,7 @@ class Limit(NonCPUUser, NonGPUUser, Transform):
                 count += 1
                 if count > self._limit:
                     break
-            rayDocs.append(doc)
+                rayDocs.append(doc)
 
         return ray.data.from_items(rayDocs)
 
@@ -54,7 +54,7 @@ class Limit(NonCPUUser, NonGPUUser, Transform):
                 count += 1
                 if count > self._limit:
                     break
-            filtered_docs.append(doc)
+                filtered_docs.append(doc)
 
         return filtered_docs
 


### PR DESCRIPTION
Updated the `execute` method in `Limit` to apply the limit to `Document` instances only and not `MetadataDocument` instances.
