### PR TITLE
Inspect serialization issues only if TypeError is raised

### DIFF
--- a/lib/sycamore/sycamore/connectors/base_reader.py
+++ b/lib/sycamore/sycamore/connectors/base_reader.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 
 from sycamore.data.document import Document
 from sycamore.plan_nodes import Scan
+from sycamore.utils.ray_utils import handle_serialization_exception
 from sycamore.utils.time_trace import TimeTrace
 
 if TYPE_CHECKING:
@@ -73,10 +74,8 @@ class BaseDBReader(Scan):
             client.close()
         return docs
 
+    @handle_serialization_exception("_client_params", "._query_params")
     def execute(self, **kwargs) -> "Dataset":
-        from sycamore.utils.ray_utils import check_serializable
-
-        check_serializable(self._client_params, self._query_params)
         from ray.data import from_items
 
         with TimeTrace("Reader"):

--- a/lib/sycamore/sycamore/connectors/base_reader.py
+++ b/lib/sycamore/sycamore/connectors/base_reader.py
@@ -74,7 +74,7 @@ class BaseDBReader(Scan):
             client.close()
         return docs
 
-    @handle_serialization_exception("_client_params", "._query_params")
+    @handle_serialization_exception("_client_params", "_query_params")
     def execute(self, **kwargs) -> "Dataset":
         from ray.data import from_items
 

--- a/lib/sycamore/sycamore/connectors/opensearch/opensearch_reader.py
+++ b/lib/sycamore/sycamore/connectors/opensearch/opensearch_reader.py
@@ -519,7 +519,7 @@ class OpenSearchReader(BaseDBReader):
                 .map(lambda d: {"doc": Document(**d).serialize()})
             )
 
-    @handle_serialization_exception("_client_params", "._query_params")
+    @handle_serialization_exception("_client_params", "_query_params")
     def _execute_pit(self, **kwargs) -> "Dataset":
         """Distribute the work evenly across available workers.
         We don't want a slice with more than 10k documents as we need to use 'from' to paginate through the results."""

--- a/lib/sycamore/sycamore/tests/unit/utils/test_ray_utils.py
+++ b/lib/sycamore/sycamore/tests/unit/utils/test_ray_utils.py
@@ -9,6 +9,7 @@ def test_non_serializable():
     lock1 = threading.Lock()
     lock2 = threading.Lock()
     with pytest.raises(ValueError):
+        # Make sure this works with passing multiple objects.
         check_serializable(lock1, lock2)
 
 

--- a/lib/sycamore/sycamore/tests/unit/utils/test_ray_utils.py
+++ b/lib/sycamore/sycamore/tests/unit/utils/test_ray_utils.py
@@ -1,15 +1,35 @@
 import pytest
 
-from sycamore.utils.ray_utils import check_serializable
+from sycamore.utils.ray_utils import check_serializable, handle_serialization_exception
 
 
 def test_non_serializable():
     import threading
 
-    lock = threading.Lock()
+    lock1 = threading.Lock()
+    lock2 = threading.Lock()
     with pytest.raises(ValueError):
-        check_serializable(lock)
+        check_serializable(lock1, lock2)
 
 
 def test_serializable():
     check_serializable("a")
+
+
+def test_decorator_non_serializable():
+    import threading
+
+    class Dummy:
+        def __init__(self):
+            self.lock1 = threading.Lock()
+            self.lock2 = threading.Lock()
+
+        @handle_serialization_exception("lock1", "lock2")
+        def test_func(self):
+            raise TypeError("Not serializable")
+
+    with pytest.raises(ValueError) as error_info:
+        dummy = Dummy()
+        dummy.test_func()
+
+    print(error_info.value)

--- a/lib/sycamore/sycamore/transforms/partition.py
+++ b/lib/sycamore/sycamore/transforms/partition.py
@@ -395,7 +395,7 @@ class ArynPartitioner(Partitioner):
              is True. The default is the TableTransformerStructureExtractor.
              Ignored when local mode is false.
         table_extractor_options: Dictionary of options that are sent to the TableExtractor implementation. Currently
-            supports union_tokens, which is a boolean that controls whether to union OCR / PDFMiner tokens 
+            supports union_tokens, which is a boolean that controls whether to union OCR / PDFMiner tokens
             in the table cells.
             default: {"union_tokens": False}
         extract_images: If true, crops each region identified as an image and attaches it to the associated

--- a/lib/sycamore/sycamore/utils/ray_utils.py
+++ b/lib/sycamore/sycamore/utils/ray_utils.py
@@ -14,9 +14,9 @@ def check_serializable(*objects):
 def handle_serialization_exception(*objects):
     def decorator(func):
         @functools.wraps(func)
-        def wrapper(self, *args):
+        def wrapper(self, *args, **kwargs):
             try:
-                return func(self, *args)
+                return func(self, *args, **kwargs)
             except TypeError:
                 attrs = [getattr(self, attr) for attr in objects]
                 check_serializable(*tuple(attrs))

--- a/lib/sycamore/sycamore/utils/ray_utils.py
+++ b/lib/sycamore/sycamore/utils/ray_utils.py
@@ -1,3 +1,6 @@
+import functools
+
+
 def check_serializable(*objects):
     from ray.util import inspect_serializability
     import io
@@ -5,4 +8,19 @@ def check_serializable(*objects):
     log = io.StringIO()
     ok, s = inspect_serializability(objects, print_file=log)
     if not ok:
-        raise ValueError(f"Something isnt serializable: {s}\nLog: {log.getvalue()}")
+        raise ValueError(f"Something isn't serializable: {s}\nLog: {log.getvalue()}")
+
+
+def handle_serialization_exception(*objects):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(self, *args):
+            try:
+                return func(self, *args)
+            except TypeError:
+                attrs = [getattr(self, attr) for attr in objects]
+                check_serializable(*tuple(attrs))
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
A quick search on github on how 'inspect_serializability' is used shows that this is usually called when an exception of type TypeError is raised.  This way, we avoid calling this (which calls colorama.init()) prematurely.