### PR TITLE
better defaults for aryn writer

### DIFF
--- a/lib/sycamore/sycamore/connectors/aryn/ArynWriter.py
+++ b/lib/sycamore/sycamore/connectors/aryn/ArynWriter.py
@@ -20,9 +20,9 @@ class ArynWriterClientParams(BaseDBWriter.ClientParams):
 
 @dataclass
 class ArynWriterTargetParams(BaseDBWriter.TargetParams):
-    def __init__(self, docset_id: Optional[str] = None, autoschema: bool = False):
+    def __init__(self, docset_id: Optional[str] = None, update_schema: bool = False):
         self.docset_id = docset_id
-        self.autoschema = autoschema
+        self.update_schema = update_schema
 
     def compatible_with(self, other: "BaseDBWriter.TargetParams") -> bool:
         return True
@@ -53,7 +53,7 @@ class ArynWriterClient(BaseDBWriter.Client):
         docset_id = target_params.docset_id
 
         headers = {"Authorization": f"Bearer {self.api_key}"}
-        update_schema = target_params.autoschema
+        update_schema = target_params.update_schema
         sess = requests.Session()
         for record in records:
             assert isinstance(record, ArynWriterRecord)

--- a/lib/sycamore/sycamore/utils/aryn_config.py
+++ b/lib/sycamore/sycamore/utils/aryn_config.py
@@ -7,6 +7,7 @@ from typing import Dict, Any
 
 DEFAULT_PATH = os.path.join(pathlib.Path.home(), ".aryn", "config.yaml")
 _DEFAULT_PATH = DEFAULT_PATH
+DEFAULT_STORAGE_URL = "https://api.aryn.ai/v1/storage"
 ## ToDO: remove after 2024-08-31
 
 
@@ -25,7 +26,7 @@ class ArynConfig:
         if aryn_url:
             return aryn_url
 
-        return cls._get_aryn_config(config_path).get("aryn_url", "")
+        return cls._get_aryn_config(config_path).get("aryn_url", DEFAULT_STORAGE_URL)
 
     @classmethod
     def _get_aryn_config(cls, config_path: str = "") -> Dict[Any, Any]:

--- a/lib/sycamore/sycamore/writer.py
+++ b/lib/sycamore/sycamore/writer.py
@@ -820,7 +820,7 @@ class DocSetWriter:
         name: Optional[str] = None,
         aryn_api_key: Optional[str] = None,
         aryn_url: Optional[str] = None,
-        autoschema: bool = False,
+        update_schema: bool = True,
         **kwargs,
     ) -> Optional["DocSet"]:
         """
@@ -858,7 +858,7 @@ class DocSetWriter:
                 logger.error(f"Error creating new docset: {e}")
                 raise e
         client_params = ArynWriterClientParams(aryn_url, aryn_api_key)
-        target_params = ArynWriterTargetParams(docset_id, autoschema)
+        target_params = ArynWriterTargetParams(docset_id, update_schema)
         writer: Node = ArynWriter(self.plan, client_params=client_params, target_params=target_params, **kwargs)
 
         return self._maybe_execute(writer, True)


### PR DESCRIPTION
- name change: autoschema -> update_schema
- update_schema defaults to True. May need to set it to false in some of the JS scripts
- default aryn_url is now "https://api.aryn.ai/v1/storage" instead of ""