### PR TITLE
Add metadata loading to materialize

### DIFF
--- a/lib/sycamore/sycamore/docset.py
+++ b/lib/sycamore/sycamore/docset.py
@@ -38,6 +38,7 @@ from sycamore.materialize_config import MaterializeSourceMode
 if TYPE_CHECKING:
     from sycamore.writer import DocSetWriter
     from sycamore.grouped_data import GroupedData
+    from sycamore.materialize import Materialize
 
 logger = logging.getLogger(__name__)
 
@@ -1578,6 +1579,18 @@ class DocSet:
         from sycamore.materialize import clear_materialize
 
         clear_materialize(self.plan, path=path, clear_non_local=clear_non_local)
+
+    def get_materializes(self, *, fifo_order: bool = True) -> list["Materialize"]:
+        """
+        Returns a list of all Materialize nodes in the plan of the docset.
+
+        Args:
+            fifo_order: if True, return the first materialize first. If False,
+                returns them in lifo order (last materialize first)
+        """
+        from sycamore.materialize import get_materializes
+
+        return get_materializes(self.plan, fifo_order=fifo_order)
 
     def execute(self, **kwargs) -> None:
         """

--- a/lib/sycamore/sycamore/docset.py
+++ b/lib/sycamore/sycamore/docset.py
@@ -38,7 +38,6 @@ from sycamore.materialize_config import MaterializeSourceMode
 if TYPE_CHECKING:
     from sycamore.writer import DocSetWriter
     from sycamore.grouped_data import GroupedData
-    from sycamore.materialize import Materialize
 
 logger = logging.getLogger(__name__)
 
@@ -1579,18 +1578,6 @@ class DocSet:
         from sycamore.materialize import clear_materialize
 
         clear_materialize(self.plan, path=path, clear_non_local=clear_non_local)
-
-    def get_materializes(self, *, fifo_order: bool = True) -> list["Materialize"]:
-        """
-        Returns a list of all Materialize nodes in the plan of the docset.
-
-        Args:
-            fifo_order: if True, return the first materialize first. If False,
-                returns them in lifo order (last materialize first)
-        """
-        from sycamore.materialize import get_materializes
-
-        return get_materializes(self.plan, fifo_order=fifo_order)
 
     def execute(self, **kwargs) -> None:
         """

--- a/lib/sycamore/sycamore/tests/unit/query/test_result.py
+++ b/lib/sycamore/sycamore/tests/unit/query/test_result.py
@@ -75,7 +75,7 @@ def simple_plan() -> LogicalPlan:
             1: Count(
                 node_id=1,
                 description="Count the number of incidents",
-                field=None,
+                distinct_field=None,
                 inputs=[0],
             ),
         },
@@ -100,7 +100,7 @@ def complex_plan() -> LogicalPlan:
                 field="test_field_1",
                 question="test_question",
             ),
-            2: Count(node_id=2, description="Test count 1", field=None, inputs=[1]),
+            2: Count(node_id=2, description="Test count 1", distinct_field=None, inputs=[1]),
             3: LlmFilter(
                 node_id=3,
                 description="Filter by test_field_2",
@@ -108,7 +108,7 @@ def complex_plan() -> LogicalPlan:
                 field="test_field_2",
                 question="test_question",
             ),
-            4: Count(node_id=4, description="Test count 2", field=None, inputs=[3]),
+            4: Count(node_id=4, description="Test count 2", distinct_field=None, inputs=[3]),
             5: Math(node_id=5, description="Sum counts", operation="add", inputs=[2, 4]),
         },
     )
@@ -125,8 +125,8 @@ def forked_plan() -> LogicalPlan:
                 index="ntsb",
                 query={"match_all": {}},
             ),
-            2: Count(node_id=2, description="Test count 1", field=None, inputs=[0]),
-            4: Count(node_id=4, description="Test count 2", field=None, inputs=[0]),
+            2: Count(node_id=2, description="Test count 1", distinct_field=None, inputs=[0]),
+            4: Count(node_id=4, description="Test count 2", distinct_field=None, inputs=[0]),
             5: Math(node_id=5, description="Sum counts", operation="add", inputs=[2, 4]),
         },
     )

--- a/lib/sycamore/sycamore/tests/unit/query/test_result.py
+++ b/lib/sycamore/sycamore/tests/unit/query/test_result.py
@@ -2,7 +2,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 import sycamore
-from sycamore.data import Document
+from sycamore.data import Document, MetadataDocument
 from sycamore.query.result import SycamoreQueryResult, NodeExecution
 from sycamore.query.logical_plan import LogicalPlan
 from sycamore.query.operators.query_database import QueryDatabase
@@ -40,10 +40,29 @@ def fake_docset_2():
     return docset
 
 
-def test_get_source_docs(fake_docset_with_scores):
-    """Test that get_source_docs returns the correct set of documents."""
+@pytest.fixture
+def fake_docset_with_metadata():
+    """Return a docset with some metadata in it."""
+    docs = [
+        Document({"doc_id": "5", "properties": {"path": "path5.txt"}}),
+        Document({"doc_id": "6", "properties": {"path": "path6.txt"}}),
+        MetadataDocument(key="value"),
+    ]
+    context = sycamore.init(exec_mode=sycamore.EXEC_LOCAL)
+    docset = context.read.document(docs)
+    return docset
 
-    plan = LogicalPlan(
+
+@pytest.fixture
+def tmpdir():
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        yield d
+
+
+def simple_plan() -> LogicalPlan:
+    return LogicalPlan(
         query="Dummy query",
         result_node=1,
         nodes={
@@ -62,34 +81,9 @@ def test_get_source_docs(fake_docset_with_scores):
         },
     )
 
-    execution = {
-        0: NodeExecution(node_id=0, trace_dir="test_trace_dir_0"),
-        1: NodeExecution(node_id=1, trace_dir="test_trace_dir_1"),
-    }
 
-    def mock_materialize_result(trace_dir):
-        if trace_dir == "test_trace_dir_1":
-            return fake_docset_with_scores
-        else:
-            return None
-
-    context = sycamore.init()
-    mock_context = MagicMock(wraps=context)
-    mock_context.exec_mode = sycamore.ExecMode.RAY
-    mock_context.read.materialize.side_effect = mock_materialize_result
-    with patch("sycamore.init", return_value=mock_context):
-        result = SycamoreQueryResult(
-            query_id="test_query_id", plan=plan, result="Test query result", execution=execution
-        )
-        retrieved_docs = result.retrieved_docs()
-
-    assert ["path2.txt", "path1.txt", "path4.txt", "path3.txt"] == retrieved_docs
-
-
-def test_get_source_docs_complex(fake_docset_with_scores, fake_docset_2):
-    """Test that get_source_docs returns the correct set of documents for a complex query plan."""
-
-    plan = LogicalPlan(
+def complex_plan() -> LogicalPlan:
+    return LogicalPlan(
         query="Dummy query",
         result_node=5,
         nodes={
@@ -118,6 +112,41 @@ def test_get_source_docs_complex(fake_docset_with_scores, fake_docset_2):
             5: Math(node_id=5, description="Sum counts", operation="add", inputs=[2, 4]),
         },
     )
+
+
+def test_get_source_docs(fake_docset_with_scores):
+    """Test that get_source_docs returns the correct set of documents."""
+
+    plan = simple_plan()
+
+    execution = {
+        0: NodeExecution(node_id=0, trace_dir="test_trace_dir_0"),
+        1: NodeExecution(node_id=1, trace_dir="test_trace_dir_1"),
+    }
+
+    def mock_materialize_result(trace_dir):
+        if trace_dir == "test_trace_dir_1":
+            return fake_docset_with_scores
+        else:
+            return None
+
+    context = sycamore.init()
+    mock_context = MagicMock(wraps=context)
+    mock_context.exec_mode = sycamore.ExecMode.RAY
+    mock_context.read.materialize.side_effect = mock_materialize_result
+    with patch("sycamore.init", return_value=mock_context):
+        result = SycamoreQueryResult(
+            query_id="test_query_id", plan=plan, result="Test query result", execution=execution
+        )
+        retrieved_docs = result.retrieved_docs()
+
+    assert ["path2.txt", "path1.txt", "path4.txt", "path3.txt"] == retrieved_docs
+
+
+def test_get_source_docs_complex(fake_docset_with_scores, fake_docset_2):
+    """Test that get_source_docs returns the correct set of documents for a complex query plan."""
+
+    plan = complex_plan()
 
     execution = {
         0: NodeExecution(node_id=0, trace_dir="test_trace_dir_0"),
@@ -148,3 +177,44 @@ def test_get_source_docs_complex(fake_docset_with_scores, fake_docset_2):
 
     assert mock_context.read.materialize.call_count == 2
     assert retrieved_docs == ["path2.txt", "path1.txt", "path4.txt", "path3.txt", "path5.txt", "path6.txt"]
+
+
+def test_get_metadata_simpleplan(fake_docset_with_metadata, tmpdir):
+    fake_docset_with_metadata.materialize(path=tmpdir).execute()
+    plan = simple_plan()
+    execution = {
+        0: NodeExecution(node_id=0, trace_dir=tmpdir),
+        1: NodeExecution(node_id=1, trace_dir="no_trace"),
+    }
+    result = SycamoreQueryResult(
+        query_id="test_get_metadata_simple", plan=plan, result="Test get metadata", execution=execution
+    )
+    metadata = result.get_metadata()
+    assert len(metadata) == 1
+    assert metadata[0].metadata["key"] == "value"
+
+
+def test_get_metadata_complexplan(fake_docset_with_metadata, tmpdir):
+    fake_docset_with_metadata.materialize(path=tmpdir).execute()
+    plan = complex_plan()
+
+    execution = {
+        0: NodeExecution(node_id=0, trace_dir="dont_see_this"),
+        1: NodeExecution(node_id=1, trace_dir=tmpdir),
+        2: NodeExecution(node_id=2, trace_dir=None),
+        3: NodeExecution(node_id=3, trace_dir=tmpdir),
+        4: NodeExecution(node_id=4, trace_dir=None),
+        5: NodeExecution(node_id=5, trace_dir=None),
+    }
+    result = SycamoreQueryResult(
+        query_id="test_get_metadata_complex", plan=plan, result="Test get metadata", execution=execution
+    )
+    metadata = result.get_metadata()
+    assert isinstance(metadata, dict)
+    assert len(metadata) == 2
+    md1 = metadata[1]
+    md2 = metadata[3]
+    assert len(md1) == 1
+    assert md1[0].metadata["key"] == "value"
+    assert len(md2) == 1
+    assert md2[0].metadata["key"] == "value"

--- a/lib/sycamore/sycamore/tests/unit/test_materialize.py
+++ b/lib/sycamore/sycamore/tests/unit/test_materialize.py
@@ -529,13 +529,15 @@ class TestGetMetadata(unittest.TestCase):
                 .materialize(path=tmpdir + "/b")
                 .materialize(path=tmpdir + "/b2")
             )
-            materializes = ds.get_materializes(fifo_order=True)
+            materializes = ds.plan.get_plan_nodes(Materialize)
             assert len(materializes) == 3
             assert materializes[0]._orig_path == tmpdir + "/a"
             assert materializes[1]._orig_path == tmpdir + "/b"
             assert materializes[2]._orig_path == tmpdir + "/b2"
 
     def test_get_mat_lifo(self):
+        from sycamore.plan_nodes import NodeTraverse
+
         ctx = sycamore.init(exec_mode=ExecMode.LOCAL)
         with tempfile.TemporaryDirectory() as tmpdir:
             ds = (
@@ -545,7 +547,7 @@ class TestGetMetadata(unittest.TestCase):
                 .materialize(path=tmpdir + "/b")
                 .materialize(path=tmpdir + "/b2")
             )
-            materializes = ds.get_materializes(fifo_order=False)
+            materializes = ds.plan.get_plan_nodes(Materialize, order=NodeTraverse.BEFORE)
             assert len(materializes) == 3
             assert materializes[2]._orig_path == tmpdir + "/a"
             assert materializes[1]._orig_path == tmpdir + "/b"
@@ -564,7 +566,7 @@ class TestGetMetadata(unittest.TestCase):
                 .materialize(path=tmpdir + "/b2")
             )
             ds.execute()
-            materializes = ds.get_materializes()
+            materializes = ds.plan.get_plan_nodes(Materialize)
             assert len(materializes) == 3
             assert len(materializes[0].load_metadata()) == 2
             assert len(materializes[1].load_metadata()) == 3

--- a/lib/sycamore/sycamore/tests/unit/test_materialize.py
+++ b/lib/sycamore/sycamore/tests/unit/test_materialize.py
@@ -518,6 +518,59 @@ class TestClearMaterialize(unittest.TestCase):
             assert not Path(f"{tmpdir}/b2/materialize.success").exists()
 
 
+class TestGetMetadata(unittest.TestCase):
+    def test_get_mat_fifo(self):
+        ctx = sycamore.init(exec_mode=ExecMode.LOCAL)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ds = (
+                ctx.read.document(make_docs(3))
+                .map(noop_fn)
+                .materialize(path=tmpdir + "/a")
+                .materialize(path=tmpdir + "/b")
+                .materialize(path=tmpdir + "/b2")
+            )
+            materializes = ds.get_materializes(fifo_order=True)
+            assert len(materializes) == 3
+            assert materializes[0]._orig_path == tmpdir + "/a"
+            assert materializes[1]._orig_path == tmpdir + "/b"
+            assert materializes[2]._orig_path == tmpdir + "/b2"
+
+    def test_get_mat_lifo(self):
+        ctx = sycamore.init(exec_mode=ExecMode.LOCAL)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ds = (
+                ctx.read.document(make_docs(3))
+                .map(noop_fn)
+                .materialize(path=tmpdir + "/a")
+                .materialize(path=tmpdir + "/b")
+                .materialize(path=tmpdir + "/b2")
+            )
+            materializes = ds.get_materializes(fifo_order=False)
+            assert len(materializes) == 3
+            assert materializes[2]._orig_path == tmpdir + "/a"
+            assert materializes[1]._orig_path == tmpdir + "/b"
+            assert materializes[0]._orig_path == tmpdir + "/b2"
+
+    def test_get_metadata(self):
+        ctx = sycamore.init(exec_mode=ExecMode.LOCAL)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ds = (
+                ctx.read.document(make_docs(3))
+                .map(noop_fn)
+                .materialize(path=tmpdir + "/a")
+                .map(noop_fn)
+                .materialize(path=tmpdir + "/b")
+                .map(noop_fn)
+                .materialize(path=tmpdir + "/b2")
+            )
+            ds.execute()
+            materializes = ds.get_materializes()
+            assert len(materializes) == 3
+            assert len(materializes[0].load_metadata()) == 2
+            assert len(materializes[1].load_metadata()) == 3
+            assert len(materializes[2].load_metadata()) == 4
+
+
 class TestErrorChecking(unittest.TestCase):
     def test_duplicate_root(self):
         ctx = sycamore.init(exec_mode=ExecMode.LOCAL)

--- a/lib/sycamore/sycamore/tests/unit/utils/test_sycamore_logger.py
+++ b/lib/sycamore/sycamore/tests/unit/utils/test_sycamore_logger.py
@@ -1,7 +1,7 @@
 import logging
 import time
 
-from sycamore.utils.sycamore_logger import LoggerFilter
+from sycamore.utils.sycamore_logger import RateLimitLogger
 
 
 def test_logger_ratelimit(caplog):
@@ -11,7 +11,7 @@ def test_logger_ratelimit(caplog):
         for i in range(5):
             logger.info(f"Unbounded {i}")
 
-        logger.addFilter(LoggerFilter())
+        logger.addFilter(RateLimitLogger())
         for i in range(5):
             logger.info(f"Bounded {i}")
 

--- a/lib/sycamore/sycamore/utils/sycamore_logger.py
+++ b/lib/sycamore/sycamore/utils/sycamore_logger.py
@@ -31,13 +31,13 @@ def get_logger():
     return logger
 
 
-class LoggerFilter(logging.Filter):
+class RateLimitLogger(logging.Filter):
     def __init__(self, seconds=1):
         """
         A filter limit the rate of log messages.
 
         logger = logging.getLogger(__name__)
-        logger.setFilter(LoggerFilter())
+        logger.setFilter(RateLimitLogger())
 
 
         Args:


### PR DESCRIPTION
1. Adds a Materialize.load_metadata() that loads all metadata documents in memory for the materialize
2. Adds a docset.get_materializes() that returns a list of all the materializes in the docset plan (param for fifo/lifo)
3. Adds a QueryResponse.get_metadata() that returns the metadata documents for the last bits of the inner sycamore pipeline