### PR TITLE
Speed up import sycamore by ~10x; add module/tool for timing imports.

### DIFF
--- a/docs/source/sycamore/tutorials/etl_for_opensearch.md
+++ b/docs/source/sycamore/tutorials/etl_for_opensearch.md
@@ -42,7 +42,7 @@ docset = docset.partition(partitioner=ArynPartitioner())
 
 ```python
 from sycamore.transforms.extract_entity import OpenAIEntityExtractor
-from sycamore.llms import OpenAIModels, OpenAI
+from sycamore.llms.openai import OpenAIModels, OpenAI
 import os
 
 # The following prompt templates will be used to extract the relevant entities

--- a/docs/source/sycamore/tutorials/sycamore_jupyter_dev_example.md
+++ b/docs/source/sycamore/tutorials/sycamore_jupyter_dev_example.md
@@ -70,7 +70,7 @@ import sycamore
 from sycamore.data import Document
 from sycamore.transforms.embed import SentenceTransformerEmbedder
 from sycamore.transforms.extract_entity import OpenAIEntityExtractor
-from sycamore.llms import OpenAIModels, OpenAI, LLM
+from sycamore.llms.openai import OpenAIModels, OpenAI, LLM
 from sycamore.transforms.partition import UnstructuredPdfPartitioner, HtmlPartitioner
 from sycamore.llms.prompts.default_prompts import TEXT_SUMMARIZER_GUIDANCE_PROMPT_CHAT
 from sycamore.transforms.summarize import Summarizer

--- a/examples/bench.py
+++ b/examples/bench.py
@@ -10,7 +10,7 @@ import pyarrow.fs
 
 import sycamore
 from sycamore.functions.tokenizer import HuggingFaceTokenizer
-from sycamore.llms import OpenAIModels, OpenAI
+from sycamore.llms.openai import OpenAIModels, OpenAI
 from sycamore.transforms import COALESCE_WHITESPACE
 from sycamore.transforms.merge_elements import MarkedMerger
 from sycamore.transforms.partition import SycamorePartitioner

--- a/examples/html_ingest.py
+++ b/examples/html_ingest.py
@@ -6,7 +6,7 @@ sys.path.append("../sycamore")
 import sycamore
 from sycamore.functions import TextOverlapChunker
 from sycamore.functions.tokenizer import HuggingFaceTokenizer
-from sycamore.llms import OpenAIModels, OpenAI
+from sycamore.llms.openai import OpenAIModels, OpenAI
 from sycamore.transforms import COALESCE_WHITESPACE
 from sycamore.transforms.merge_elements import GreedyTextElementMerger
 from sycamore.transforms.partition import HtmlPartitioner

--- a/examples/query/ntsb_loader.py
+++ b/examples/query/ntsb_loader.py
@@ -14,7 +14,7 @@ from sycamore.transforms.merge_elements import GreedyTextElementMerger
 from sycamore.transforms.extract_schema import (
     OpenAIPropertyExtractor,
 )
-from sycamore.llms import OpenAI, OpenAIModels
+from sycamore.llms.openai import OpenAI, OpenAIModels
 from sycamore.transforms.embed import SentenceTransformerEmbedder
 import os
 from dateutil import parser

--- a/examples/s3_ingest.py
+++ b/examples/s3_ingest.py
@@ -9,7 +9,7 @@ sys.path.append("../lib/sycamore")
 
 import sycamore
 from sycamore.functions.tokenizer import HuggingFaceTokenizer
-from sycamore.llms import OpenAIModels, OpenAI
+from sycamore.llms.openai import OpenAIModels, OpenAI
 from sycamore.transforms import COALESCE_WHITESPACE
 from sycamore.transforms.merge_elements import MarkedMerger
 from sycamore.transforms.partition import UnstructuredPdfPartitioner

--- a/examples/simple_duckdb.py
+++ b/examples/simple_duckdb.py
@@ -2,7 +2,7 @@ import sys
 
 import sycamore
 from sycamore.functions.tokenizer import HuggingFaceTokenizer
-from sycamore.llms import OpenAI, OpenAIModels
+from sycamore.llms.openai import OpenAI, OpenAIModels
 from sycamore.transforms import COALESCE_WHITESPACE
 from sycamore.transforms.merge_elements import MarkedMerger
 from sycamore.transforms.partition import SycamorePartitioner

--- a/examples/simple_ingest.py
+++ b/examples/simple_ingest.py
@@ -5,7 +5,7 @@ sys.path.append("../sycamore")
 
 import sycamore
 from sycamore.functions.tokenizer import HuggingFaceTokenizer
-from sycamore.llms import OpenAIModels, OpenAI
+from sycamore.llms.openai import OpenAIModels, OpenAI
 from sycamore.transforms import COALESCE_WHITESPACE
 from sycamore.transforms.merge_elements import MarkedMerger
 from sycamore.transforms.partition import UnstructuredPdfPartitioner

--- a/examples/simple_neo4j.py
+++ b/examples/simple_neo4j.py
@@ -4,7 +4,7 @@ from sycamore.transforms.extract_graph_entities import EntityExtractor
 from sycamore.transforms.extract_graph_relationships import RelationshipExtractor
 from sycamore.transforms.partition import ArynPartitioner
 
-from sycamore.llms import OpenAI, OpenAIModels
+from sycamore.llms.openai import OpenAI, OpenAIModels
 
 from typing import Optional
 from pydantic import BaseModel, Field

--- a/examples/simple_pinecone.py
+++ b/examples/simple_pinecone.py
@@ -8,7 +8,7 @@ sys.path.append("../sycamore")
 
 import sycamore
 from sycamore.functions.tokenizer import HuggingFaceTokenizer
-from sycamore.llms import OpenAIModels, OpenAI
+from sycamore.llms.openai import OpenAIModels, OpenAI
 from sycamore.transforms import COALESCE_WHITESPACE
 from sycamore.transforms.merge_elements import MarkedMerger
 from sycamore.transforms.partition import SycamorePartitioner

--- a/examples/simple_qdrant.py
+++ b/examples/simple_qdrant.py
@@ -6,7 +6,7 @@ sys.path.append("../sycamore")
 
 import sycamore
 from sycamore.functions.tokenizer import HuggingFaceTokenizer
-from sycamore.llms import OpenAIModels, OpenAI
+from sycamore.llms.openai import OpenAIModels, OpenAI
 from sycamore.transforms import COALESCE_WHITESPACE
 from sycamore.transforms.merge_elements import MarkedMerger
 from sycamore.transforms.partition import SycamorePartitioner

--- a/examples/simple_weaviate.py
+++ b/examples/simple_weaviate.py
@@ -10,7 +10,7 @@ sys.path.append("../sycamore")
 
 import sycamore
 from sycamore.functions.tokenizer import HuggingFaceTokenizer
-from sycamore.llms import OpenAIModels, OpenAI
+from sycamore.llms.openai import OpenAIModels, OpenAI
 from sycamore.transforms import COALESCE_WHITESPACE
 from sycamore.transforms.merge_elements import MarkedMerger
 from sycamore.transforms.partition import SycamorePartitioner

--- a/lib/import_timer/import_timer.py
+++ b/lib/import_timer/import_timer.py
@@ -20,15 +20,14 @@ import sys
 import time
 import os
 import builtins
-from typing import Dict, List
 
 original_import = builtins.__import__
 
-import_times: Dict[str, float] = {}
-parent_imports: Dict[str, str] = {}
-import_counts: Dict[str, int] = {}
-import_stack: List[str] = []
-import_depths: Dict[str, int] = {}
+import_times: dict[str, float] = {}
+parent_imports: dict[str, str] = {}
+import_counts: dict[str, int] = {}
+import_stack: list[str] = []
+import_depths: dict[str, int] = {}
 
 
 def timed_import(name, globals=None, locals=None, fromlist=(), level=0):

--- a/lib/import_timer/import_timer.py
+++ b/lib/import_timer/import_timer.py
@@ -1,0 +1,163 @@
+"""
+import_timer.py - Automatically instrument Python imports to measure timing
+
+This script patches Python's import system to measure the time each import takes.
+It can be used in two ways:
+1. As a module to be imported at the start of your script
+2. As a command line tool that runs your script with instrumentation
+
+Usage as module:
+    import import_timer
+    # All subsequent imports will be timed
+    import numpy as np  # This import will be timed
+    import_timer.show()
+
+Usage from command line:
+    python import_timer.py your_script.py [args...]
+"""
+
+import sys
+import time
+import os
+import builtins
+from typing import Dict, List
+
+original_import = builtins.__import__
+
+import_times: Dict[str, float] = {}
+parent_imports: Dict[str, str] = {}
+import_counts: Dict[str, int] = {}
+import_stack: List[str] = []
+import_depths: Dict[str, int] = {}
+
+
+def timed_import(name, globals=None, locals=None, fromlist=(), level=0):
+    """
+    A replacement for the built-in __import__ function that measures execution time.
+    """
+    parent = import_stack[-1] if import_stack else None
+
+    # record the first parent on import
+    if parent and name not in parent_imports:
+        parent_imports[name] = parent
+
+    depth = len(import_stack)
+    import_depths[name] = min(depth, import_depths.get(name, float("inf")))
+
+    import_stack.append(name)
+
+    start_time = time.time()
+    try:
+        result = original_import(name, globals, locals, fromlist, level)
+    finally:
+        end_time = time.time()
+        elapsed = end_time - start_time
+
+        if name in import_times:
+            # Re-imports can be really slow; not sure why, but sycamore.llms.llm can be 0.19s -> 0.62s
+            import_times[name] += elapsed
+            import_counts[name] += 1
+        else:
+            import_times[name] = elapsed
+            import_counts[name] = 1
+
+        if import_stack:
+            import_stack.pop()
+
+    return result
+
+
+# TODO: figure out a tree display; that would be nicer to figure out what to fix
+def show(sort_by="time", min_time=None):
+    """
+    Print the import timing results.
+
+    Args:
+        sort_by: 'time' (default) or 'name' to sort the output
+        min_time: Minimum time threshold to include in the report (in seconds)
+                  Defaults to 5% of the longest import if unspecified.
+    """
+    print("\n=== Import Timing Results ===")
+
+    if min_time is None:
+        max_time = max([v for _, v in import_times.items()])
+        min_time = max_time * 0.05
+    filtered_times = {k: v for k, v in import_times.items() if v >= min_time}
+
+    if sort_by == "time":
+        sorted_items = sorted(filtered_times.items(), key=lambda x: x[1], reverse=True)
+    else:
+        sorted_items = sorted(filtered_times.items(), key=lambda x: x[0])
+
+    if not sorted_items:
+        print("No imports took longer than the minimum threshold of {:.3f}s".format(min_time))
+        return
+
+    max_name_len = max(len(name) for name in filtered_times.keys())
+
+    print(f"{'Module':<{max_name_len+2}} {'Time (s)':>10} {'Count':>5} {'Depth':>5} {'Parent'}")
+    print("-" * (max_name_len + 30))
+
+    for name, elapsed in sorted_items:
+        depth = import_depths[name]
+        parent = parent_imports.get(name, "")
+        count = import_counts[name]
+
+        print(f"{name:<{max_name_len+2}} {elapsed:10.6f} {count:>5} {depth:>5} {parent}")
+
+
+def initialize():
+    """Install the import timer by replacing the built-in __import__ function."""
+    builtins.__import__ = timed_import
+    import_depths.clear()
+    import_times.clear()
+    parent_imports.clear()
+    import_stack.clear()
+    # Add root value so it isn't empty
+    import_stack.append("__main__")
+
+
+def run_script(script_path, args=None):
+    """
+    Run a Python script with import timing instrumentation.
+
+    Args:
+        script_path: Path to the Python script to run
+        args: Optional list of command line arguments for the script
+    """
+    assert os.path.exists(script_path), f'Error: Script "{script_path}" not found'
+
+    if args:
+        sys.argv = [script_path] + args
+    else:
+        sys.argv = [script_path]
+
+    initialize()
+
+    script_globals = {
+        "__file__": script_path,
+        "__name__": "__main__",
+        "__package__": None,
+        "__cached__": None,
+    }
+
+    with open(script_path, "rb") as file:
+        code = compile(file.read(), script_path, "exec")
+        exec(code, script_globals)
+
+    show()
+
+    return 0
+
+
+# Enable timing when module is imported
+initialize()
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python import_timer.py your_script.py [args...]")
+        sys.exit(1)
+
+    script_path = sys.argv[1]
+    script_args = sys.argv[2:]
+    sys.exit(run_script(script_path, script_args))

--- a/lib/import_timer/pyproject.toml
+++ b/lib/import_timer/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.poetry]
+name = "import_timer"
+version = "0.0.1"
+description = "Import timing library"
+authors = ["aryn.ai <opensource@aryn.ai>"]
+license = "Apache 2.0"
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = ">=3.9"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/lib/sycamore/poetry.lock
+++ b/lib/sycamore/poetry.lock
@@ -3476,6 +3476,20 @@ files = [
 ]
 
 [[package]]
+name = "import-timer"
+version = "0.0.1"
+description = "Import timing library"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = []
+develop = true
+
+[package.source]
+type = "directory"
+url = "../import_timer"
+
+[[package]]
 name = "importlib-metadata"
 version = "8.6.1"
 description = "Read metadata from Python packages"
@@ -11666,4 +11680,4 @@ weaviate = ["weaviate-client"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9.2,<3.13"
-content-hash = "1d0e4433e49efe22618fcbade4af72a77bab94def6b069fc856f3e42580045ba"
+content-hash = "c7f98a821072120c2ad9fcd94d0f2b7fa69dc1db1634bbf7d59e262087d52892"

--- a/lib/sycamore/pyproject.toml
+++ b/lib/sycamore/pyproject.toml
@@ -103,6 +103,7 @@ pytest-xdist = "^3.6.1"
 
 [tool.poetry.group.dev.dependencies]
 sycamore-poetry-lock = { path = "../../lib/poetry-lock", develop = true }
+import_timer = { path = "../import_timer", develop = true }
 ruff = ">=0.11.2"
 black = ">=25.1"
 pre-commit = ">=4.2.0"

--- a/lib/sycamore/sycamore/connectors/common.py
+++ b/lib/sycamore/sycamore/connectors/common.py
@@ -1,13 +1,14 @@
 from dataclasses import dataclass
-from typing import Callable, Iterator, Union, Iterable, Tuple, Any, Dict
+from typing import Callable, Iterator, Union, Iterable, Tuple, Any, Dict, TYPE_CHECKING
 from sycamore.data import Document, Element
 import json
 import string
 import random
 import math
-import numpy as np
-import pyarrow as pa
 import re
+
+if TYPE_CHECKING:
+    import pyarrow
 
 
 @dataclass
@@ -55,10 +56,14 @@ def check_dictionary_compatibility(dict1: dict[Any, Any], dict2: dict[Any, Any],
 
 
 def compare_docs(doc1: Document, doc2: Document):
+    import numpy
+
     filtered_doc1 = filter_doc(doc1, DEFAULT_RECORD_PROPERTIES.keys())
     filtered_doc2 = filter_doc(doc2, DEFAULT_RECORD_PROPERTIES.keys())
     for key in filtered_doc1:
-        if isinstance(filtered_doc1[key], (list, np.ndarray)) or isinstance(filtered_doc2.get(key), (list, np.ndarray)):
+        if isinstance(filtered_doc1[key], (list, numpy.ndarray)) or isinstance(
+            filtered_doc2.get(key), (list, numpy.ndarray)
+        ):
             assert len(filtered_doc1[key]) == len(filtered_doc2[key])
             for item1, item2 in zip(filtered_doc1[key], filtered_doc2[key]):
                 try:
@@ -313,13 +318,15 @@ def _make_type_filter(types: list[type]) -> Callable[[Any], bool]:
     return _type_filter
 
 
-def _get_pyarrow_type(key: str, dtype: str) -> pa.DataType:
+def _get_pyarrow_type(key: str, dtype: str) -> "pyarrow.DataType":
+    import pyarrow
+
     if dtype == ("VARCHAR"):
-        return pa.string()
+        return pyarrow.string()
     elif dtype == ("DOUBLE"):
-        return pa.float64()
+        return pyarrow.float64()
     elif dtype == ("BIGINT"):
-        return pa.int64()
+        return pyarrow.int64()
     elif dtype.startswith("MAP"):
         match = re.match(r"MAP\((.+),\s*(.+)\)", dtype)
         if not match:
@@ -327,14 +334,14 @@ def _get_pyarrow_type(key: str, dtype: str) -> pa.DataType:
         key_type, value_type = match.groups()
         pa_key_type = _get_pyarrow_type(key, key_type)
         pa_value_type = _get_pyarrow_type(key, value_type)
-        return pa.map_(pa_key_type, pa_value_type)
+        return pyarrow.map_(pa_key_type, pa_value_type)
     elif dtype == "VARCHAR[]":
-        return pa.list_(pa.string())
+        return pyarrow.list_(pyarrow.string())
     elif dtype == "DOUBLE[]" or key == "embedding":  # embedding is a list of floats with a fixed dimension
-        return pa.list_(pa.float64())
+        return pyarrow.list_(pyarrow.float64())
     elif dtype == "BIGINT[]":
-        return pa.list_(pa.int64())
+        return pyarrow.list_(pyarrow.int64())
     elif dtype == "FLOAT":
-        return pa.float32()
+        return pyarrow.float32()
     else:
         raise ValueError(f"Unsupported pyarrow datatype: {dtype}")

--- a/lib/sycamore/sycamore/llms/__init__.py
+++ b/lib/sycamore/sycamore/llms/__init__.py
@@ -1,10 +1,19 @@
 from typing import Callable, Dict
 
 from sycamore.llms.llms import LLM
-from sycamore.llms.openai import OpenAI, OpenAIClientType, OpenAIModels, OpenAIClientParameters, OpenAIClientWrapper
+from sycamore.llms.config import OpenAIModels
+
+# from sycamore.llms.openai import OpenAI, OpenAIClientType, OpenAIModels, OpenAIClientParameters, OpenAIClientWrapper
 from sycamore.llms.bedrock import Bedrock, BedrockModels
 from sycamore.llms.anthropic import Anthropic, AnthropicModels
 from sycamore.llms.gemini import Gemini, GeminiModels
+
+
+def OpenAI(name, **kwargs):
+    from sycamore.llms.openai import OpenAI as OpenAIReal
+
+    return OpenAIReal(name, **kwargs)
+
 
 # Register the model constructors.
 MODELS: Dict[str, Callable[..., LLM]] = {}
@@ -32,10 +41,10 @@ __all__ = [
     "get_llm",
     "LLM",
     "OpenAI",
-    "OpenAIClientType",
-    "OpenAIModels",
-    "OpenAIClientParameters",
-    "OpenAIClientWrapper",
+    #   "OpenAIClientType",
+    #   "OpenAIModels",
+    #   "OpenAIClientParameters",
+    #   "OpenAIClientWrapper",
     "Bedrock",
     "BedrockModels",
     "Anthropic",

--- a/lib/sycamore/sycamore/llms/__init__.py
+++ b/lib/sycamore/sycamore/llms/__init__.py
@@ -1,12 +1,25 @@
 from typing import Callable, Dict
 
 from sycamore.llms.llms import LLM
-from sycamore.llms.config import OpenAIModels
+from sycamore.llms.config import AnthropicModels, BedrockModels, GeminiModels, OpenAIModels
 
-# from sycamore.llms.openai import OpenAI, OpenAIClientType, OpenAIModels, OpenAIClientParameters, OpenAIClientWrapper
-from sycamore.llms.bedrock import Bedrock, BedrockModels
-from sycamore.llms.anthropic import Anthropic, AnthropicModels
-from sycamore.llms.gemini import Gemini, GeminiModels
+
+def Anthropic(name, **kwargs):
+    from sycamore.llms.anthropic import Anthropic as AnthropicReal
+
+    return AnthropicReal(name, **kwargs)
+
+
+def Bedrock(name, **kwargs):
+    from sycamore.llms.bedrock import Bedrock as BedrockReal
+
+    return BedrockReal(name, **kwargs)
+
+
+def Gemini(name, **kwargs):
+    from sycamore.llms.gemini import Gemini as GeminiReal
+
+    return GeminiReal(name, **kwargs)
 
 
 def OpenAI(name, **kwargs):
@@ -36,15 +49,17 @@ def get_llm(model_name: str) -> Callable[..., LLM]:
     return MODELS[model_name]
 
 
+# commented out bits can be removed after 2025-08-01; they are here to help people
+# find where things should be imported from
 __all__ = [
     "MODELS",
     "get_llm",
     "LLM",
     "OpenAI",
-    #   "OpenAIClientType",
-    #   "OpenAIModels",
-    #   "OpenAIClientParameters",
-    #   "OpenAIClientWrapper",
+    "OpenAIModels",
+    #   "OpenAIClientType", # sycamore.llms.openai
+    #   "OpenAIClientParameters", # sycamore.llms.openai
+    #   "OpenAIClientWrapper", # sycamore.llms.openai
     "Bedrock",
     "BedrockModels",
     "Anthropic",

--- a/lib/sycamore/sycamore/llms/anthropic.py
+++ b/lib/sycamore/sycamore/llms/anthropic.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from enum import Enum
 import logging
 from typing import Any, Optional, Union
 import asyncio
@@ -8,6 +7,7 @@ import time
 
 from PIL import Image
 
+from sycamore.llms.config import AnthropicModels
 from sycamore.llms.llms import LLM, LLMMode
 from sycamore.llms.prompts import RenderedPrompt
 from sycamore.utils.cache import Cache
@@ -17,24 +17,6 @@ from sycamore.utils.import_utils import requires_modules
 DEFAULT_MAX_TOKENS = 1000
 INITIAL_BACKOFF = 1
 BATCH_POLL_INTERVAL = 10
-
-
-class AnthropicModels(Enum):
-    """Represents available Claude models."""
-
-    CLAUDE_3_7_SONNET = "claude-3-7-sonnet-latest"
-    CLAUDE_3_5_SONNET = "claude-3-5-sonnet-latest"
-    CLAUDE_3_5_HAIKU = "claude-3-5-haiku-latest"
-    CLAUDE_3_OPUS = "claude-3-opus-latest"
-    CLAUDE_3_SONNET = "claude-3-sonnet-20240229"
-    CLAUDE_3_HAIKU = "claude-3-haiku-20240307"
-
-    @classmethod
-    def from_name(cls, name: str) -> Optional["AnthropicModels"]:
-        for m in iter(cls):
-            if m.value == name:
-                return m
-        return None
 
 
 def rewrite_system_messages(messages: Optional[list[dict]]) -> Optional[list[dict]]:

--- a/lib/sycamore/sycamore/llms/bedrock.py
+++ b/lib/sycamore/sycamore/llms/bedrock.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 import datetime
 from enum import Enum
-import boto3
 import json
 from typing import Any, Optional, Union
 
@@ -52,6 +51,8 @@ class Bedrock(LLM):
         model_name: Union[BedrockModels, str],
         cache: Optional[Cache] = None,
     ):
+        import boto3
+
         self.model_name = model_name
 
         if isinstance(model_name, BedrockModels):

--- a/lib/sycamore/sycamore/llms/bedrock.py
+++ b/lib/sycamore/sycamore/llms/bedrock.py
@@ -1,11 +1,10 @@
-from dataclasses import dataclass
 import datetime
-from enum import Enum
 import json
 from typing import Any, Optional, Union
 
 from PIL import Image
 
+from sycamore.llms.config import BedrockModel, BedrockModels
 from sycamore.llms.llms import LLM, LLMMode
 from sycamore.llms.anthropic import format_image, get_generate_kwargs
 from sycamore.llms.prompts.prompts import RenderedPrompt
@@ -13,29 +12,6 @@ from sycamore.utils.cache import Cache
 
 DEFAULT_MAX_TOKENS = 1000
 DEFAULT_ANTHROPIC_VERSION = "bedrock-2023-05-31"
-
-
-@dataclass
-class BedrockModel:
-    name: str
-    is_chat: bool = False
-
-
-class BedrockModels(Enum):
-    """Represents available Bedrock models."""
-
-    # Note that the models available on a given Bedrock account may vary.
-    CLAUDE_3_HAIKU = BedrockModel(name="anthropic.claude-3-haiku-20240307-v1:0", is_chat=True)
-    CLAUDE_3_SONNET = BedrockModel(name="anthropic.claude-3-sonnet-20240229-v1:0", is_chat=True)
-    CLAUDE_3_OPUS = BedrockModel(name="anthropic.claude-3-opus-20240229-v1:0", is_chat=True)
-    CLAUDE_3_5_SONNET = BedrockModel(name="anthropic.claude-3-5-sonnet-20240620-v1:0", is_chat=True)
-
-    @classmethod
-    def from_name(cls, name: str):
-        for m in iter(cls):
-            if m.value.name == name:
-                return m
-        return None
 
 
 class Bedrock(LLM):

--- a/lib/sycamore/sycamore/llms/config.py
+++ b/lib/sycamore/sycamore/llms/config.py
@@ -1,5 +1,71 @@
 from dataclasses import dataclass
 from enum import Enum
+from typing import Optional
+
+
+class AnthropicModels(Enum):
+    """Represents available Claude models."""
+
+    CLAUDE_3_7_SONNET = "claude-3-7-sonnet-latest"
+    CLAUDE_3_5_SONNET = "claude-3-5-sonnet-latest"
+    CLAUDE_3_5_HAIKU = "claude-3-5-haiku-latest"
+    CLAUDE_3_OPUS = "claude-3-opus-latest"
+    CLAUDE_3_SONNET = "claude-3-sonnet-20240229"
+    CLAUDE_3_HAIKU = "claude-3-haiku-20240307"
+
+    @classmethod
+    def from_name(cls, name: str) -> Optional["AnthropicModels"]:
+        for m in iter(cls):
+            if m.value == name:
+                return m
+        return None
+
+
+@dataclass
+class BedrockModel:
+    name: str
+    is_chat: bool = False
+
+
+class BedrockModels(Enum):
+    """Represents available Bedrock models."""
+
+    # Note that the models available on a given Bedrock account may vary.
+    CLAUDE_3_HAIKU = BedrockModel(name="anthropic.claude-3-haiku-20240307-v1:0", is_chat=True)
+    CLAUDE_3_SONNET = BedrockModel(name="anthropic.claude-3-sonnet-20240229-v1:0", is_chat=True)
+    CLAUDE_3_OPUS = BedrockModel(name="anthropic.claude-3-opus-20240229-v1:0", is_chat=True)
+    CLAUDE_3_5_SONNET = BedrockModel(name="anthropic.claude-3-5-sonnet-20240620-v1:0", is_chat=True)
+
+    @classmethod
+    def from_name(cls, name: str):
+        for m in iter(cls):
+            if m.value.name == name:
+                return m
+        return None
+
+
+@dataclass
+class GeminiModel:
+    name: str
+    is_chat: bool = False
+
+
+class GeminiModels(Enum):
+    """Represents available Gemini models. More info: https://googleapis.github.io/python-genai/"""
+
+    # Note that the models available on a given Gemini account may vary.
+    GEMINI_2_FLASH = GeminiModel(name="gemini-2.0-flash", is_chat=True)
+    GEMINI_2_FLASH_LITE = GeminiModel(name="gemini-2.0-flash-lite", is_chat=True)
+    GEMINI_2_FLASH_THINKING = GeminiModel(name="gemini-2.0-flash-thinking-exp", is_chat=True)
+    GEMINI_2_PRO = GeminiModel(name="gemini-2.0-pro-exp-02-05", is_chat=True)
+    GEMINI_1_5_PRO = GeminiModel(name="gemini-1.5-pro", is_chat=True)
+
+    @classmethod
+    def from_name(cls, name: str):
+        for m in iter(cls):
+            if m.value.name == name:
+                return m
+        return None
 
 
 @dataclass

--- a/lib/sycamore/sycamore/llms/config.py
+++ b/lib/sycamore/sycamore/llms/config.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+from enum import Enum
+
+
+@dataclass
+class OpenAIModel:
+    name: str
+    is_chat: bool = False
+
+
+class OpenAIModels(Enum):
+    TEXT_DAVINCI = OpenAIModel(name="text-davinci-003", is_chat=True)
+    GPT_3_5_TURBO = OpenAIModel(name="gpt-3.5-turbo", is_chat=True)
+    GPT_4_TURBO = OpenAIModel(name="gpt-4-turbo", is_chat=True)
+    GPT_4O = OpenAIModel(name="gpt-4o", is_chat=True)
+    GPT_4O_STRUCTURED = OpenAIModel(
+        name="gpt-4o-2024-08-06", is_chat=True
+    )  # remove after october 2nd, gpt-4o will point to this model then
+    GPT_4O_MINI = OpenAIModel(name="gpt-4o-mini", is_chat=True)
+    GPT_3_5_TURBO_INSTRUCT = OpenAIModel(name="gpt-3.5-turbo-instruct", is_chat=False)
+    GPT_4_1 = OpenAIModel(name="gpt-4.1", is_chat=True)
+    GPT_4_1_MINI = OpenAIModel(name="gpt-4.1-mini", is_chat=True)
+    GPT_4_1_NANO = OpenAIModel(name="gpt-4.1-nano", is_chat=True)
+
+    @classmethod
+    def from_name(cls, name: str):
+        for m in iter(cls):
+            if m.value.name == name:
+                return m
+        return None

--- a/lib/sycamore/sycamore/llms/gemini.py
+++ b/lib/sycamore/sycamore/llms/gemini.py
@@ -1,11 +1,10 @@
-from dataclasses import dataclass
 import datetime
-from enum import Enum
 import logging
 from typing import Any, Optional, Union
 import os
 import io
 
+from sycamore.llms.config import GeminiModel, GeminiModels
 from sycamore.llms.llms import LLM, LLMMode
 from sycamore.llms.prompts.prompts import RenderedPrompt
 from sycamore.utils.cache import Cache
@@ -15,30 +14,6 @@ DEFAULT_MAX_TOKENS = 1024
 
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class GeminiModel:
-    name: str
-    is_chat: bool = False
-
-
-class GeminiModels(Enum):
-    """Represents available Gemini models. More info: https://googleapis.github.io/python-genai/"""
-
-    # Note that the models available on a given Gemini account may vary.
-    GEMINI_2_FLASH = GeminiModel(name="gemini-2.0-flash", is_chat=True)
-    GEMINI_2_FLASH_LITE = GeminiModel(name="gemini-2.0-flash-lite", is_chat=True)
-    GEMINI_2_FLASH_THINKING = GeminiModel(name="gemini-2.0-flash-thinking-exp", is_chat=True)
-    GEMINI_2_PRO = GeminiModel(name="gemini-2.0-pro-exp-02-05", is_chat=True)
-    GEMINI_1_5_PRO = GeminiModel(name="gemini-1.5-pro", is_chat=True)
-
-    @classmethod
-    def from_name(cls, name: str):
-        for m in iter(cls):
-            if m.value.name == name:
-                return m
-        return None
 
 
 class Gemini(LLM):

--- a/lib/sycamore/sycamore/llms/llms.py
+++ b/lib/sycamore/sycamore/llms/llms.py
@@ -9,7 +9,7 @@ import pydantic
 from sycamore.utils.cache import Cache
 from sycamore.utils.thread_local import ThreadLocalAccess, ADD_METADATA_TO_OUTPUT
 from sycamore.data.metadata import add_metadata
-from sycamore.llms.prompts import RenderedPrompt, RenderedMessage, SimplePrompt
+from sycamore.llms.prompts import RenderedPrompt, RenderedMessage
 
 from sycamore.utils.deprecate import deprecated
 
@@ -40,6 +40,8 @@ class LLM(ABC):
     @deprecated(version="0.1.31", reason="Use generate, with a RenderedPrompt, instead")
     def generate_old(self, *, prompt_kwargs: dict[str, Any], llm_kwargs: Optional[dict] = None) -> str:
         """Generates a response from the LLM"""
+        from sycamore.llms.prompts.default_prompts import SimplePrompt
+
         if "prompt" in prompt_kwargs:
             prompt = prompt_kwargs.get("prompt")
             if isinstance(prompt, SimplePrompt):
@@ -74,6 +76,8 @@ class LLM(ABC):
 
     @deprecated(version="0.1.31", reason="Use generate_async, with a RenderedPrompt, instead")
     async def generate_async_old(self, *, prompt_kwargs: dict[str, Any], llm_kwargs: Optional[dict] = None) -> str:
+        from sycamore.llms.prompts.default_prompts import SimplePrompt
+
         if "prompt" in prompt_kwargs:
             prompt = prompt_kwargs.get("prompt")
             if isinstance(prompt, SimplePrompt):

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -2,7 +2,6 @@ import functools
 import inspect
 import logging
 import os
-from dataclasses import dataclass
 from enum import Enum
 from PIL import Image
 from typing import Any, Dict, Optional, Tuple, Union
@@ -26,7 +25,8 @@ from openai.types.chat.chat_completion import ChatCompletion
 import pydantic
 
 from sycamore.llms.llms import LLM, LLMMode
-from sycamore.llms.prompts import RenderedPrompt
+from sycamore.llms.config import OpenAIModel, OpenAIModels
+from sycamore.llms.prompts.prompts import RenderedPrompt
 from sycamore.utils.cache import Cache
 from sycamore.utils.image_utils import base64_data_url
 
@@ -42,34 +42,6 @@ BATCH_POLL_INTERVAL = 10
 class OpenAIClientType(Enum):
     OPENAI = 0
     AZURE = 1
-
-
-@dataclass
-class OpenAIModel:
-    name: str
-    is_chat: bool = False
-
-
-class OpenAIModels(Enum):
-    TEXT_DAVINCI = OpenAIModel(name="text-davinci-003", is_chat=True)
-    GPT_3_5_TURBO = OpenAIModel(name="gpt-3.5-turbo", is_chat=True)
-    GPT_4_TURBO = OpenAIModel(name="gpt-4-turbo", is_chat=True)
-    GPT_4O = OpenAIModel(name="gpt-4o", is_chat=True)
-    GPT_4O_STRUCTURED = OpenAIModel(
-        name="gpt-4o-2024-08-06", is_chat=True
-    )  # remove after october 2nd, gpt-4o will point to this model then
-    GPT_4O_MINI = OpenAIModel(name="gpt-4o-mini", is_chat=True)
-    GPT_3_5_TURBO_INSTRUCT = OpenAIModel(name="gpt-3.5-turbo-instruct", is_chat=False)
-    GPT_4_1 = OpenAIModel(name="gpt-4.1", is_chat=True)
-    GPT_4_1_MINI = OpenAIModel(name="gpt-4.1-mini", is_chat=True)
-    GPT_4_1_NANO = OpenAIModel(name="gpt-4.1-nano", is_chat=True)
-
-    @classmethod
-    def from_name(cls, name: str):
-        for m in iter(cls):
-            if m.value.name == name:
-                return m
-        return None
 
 
 class OpenAIClientWrapper:

--- a/lib/sycamore/sycamore/tests/integration/connectors/elasticsearch/test_elasticsearch_read.py
+++ b/lib/sycamore/sycamore/tests/integration/connectors/elasticsearch/test_elasticsearch_read.py
@@ -1,6 +1,6 @@
 import sycamore
 from sycamore.functions.tokenizer import HuggingFaceTokenizer
-from sycamore.llms import OpenAIModels, OpenAI
+from sycamore.llms.openai import OpenAIModels, OpenAI
 from sycamore.transforms import COALESCE_WHITESPACE
 from sycamore.transforms.merge_elements import MarkedMerger
 from sycamore.transforms.partition import UnstructuredPdfPartitioner

--- a/lib/sycamore/sycamore/tests/integration/connectors/elasticsearch/test_pdf_to_elasticsearch.py
+++ b/lib/sycamore/sycamore/tests/integration/connectors/elasticsearch/test_pdf_to_elasticsearch.py
@@ -1,6 +1,6 @@
 import sycamore
 from sycamore.functions.tokenizer import HuggingFaceTokenizer
-from sycamore.llms import OpenAIModels, OpenAI
+from sycamore.llms.openai import OpenAIModels, OpenAI
 from sycamore.transforms import COALESCE_WHITESPACE
 from sycamore.transforms.merge_elements import MarkedMerger
 from sycamore.transforms.partition import UnstructuredPdfPartitioner

--- a/lib/sycamore/sycamore/tests/integration/connectors/opensearch/test_opensearch_read.py
+++ b/lib/sycamore/sycamore/tests/integration/connectors/opensearch/test_opensearch_read.py
@@ -11,7 +11,7 @@ from sycamore import EXEC_LOCAL, ExecMode
 from sycamore.connectors.doc_reconstruct import DocumentReconstructor
 from sycamore.data import Document
 from sycamore.data.document import DocumentPropertyTypes
-from sycamore.llms import OpenAI, OpenAIModels
+from sycamore.llms.openai import OpenAI, OpenAIModels
 from sycamore.tests.integration.connectors.common import compare_connector_docs
 from sycamore.tests.config import TEST_DIR
 from sycamore.transforms.partition import ArynPartitioner

--- a/lib/sycamore/sycamore/tests/integration/connectors/opensearch/test_pdf_to_opensearch.py
+++ b/lib/sycamore/sycamore/tests/integration/connectors/opensearch/test_pdf_to_opensearch.py
@@ -8,7 +8,7 @@ import sycamore
 from sycamore.connectors.opensearch.utils import OpenSearchClientWithLogging
 from sycamore.context import OperationTypes, ExecMode
 from sycamore.functions import HuggingFaceTokenizer
-from sycamore.llms import OpenAIModels, OpenAI
+from sycamore.llms.openai import OpenAIModels, OpenAI
 from sycamore.tests.config import TEST_DIR
 from sycamore.transforms.embed import SentenceTransformerEmbedder
 from sycamore.transforms.extract_entity import OpenAIEntityExtractor

--- a/lib/sycamore/sycamore/tests/integration/connectors/weaviate/test_pdf_to_weaviate.py
+++ b/lib/sycamore/sycamore/tests/integration/connectors/weaviate/test_pdf_to_weaviate.py
@@ -7,7 +7,7 @@ from weaviate.collections.classes.config import Configure, DataType
 
 import sycamore
 from sycamore.functions.tokenizer import HuggingFaceTokenizer
-from sycamore.llms import OpenAIModels, OpenAI
+from sycamore.llms.openai import OpenAIModels, OpenAI
 from sycamore.transforms import COALESCE_WHITESPACE
 from sycamore.transforms.merge_elements import MarkedMerger
 from sycamore.transforms.partition import UnstructuredPdfPartitioner

--- a/lib/sycamore/sycamore/tests/integration/llms/test_openai.py
+++ b/lib/sycamore/sycamore/tests/integration/llms/test_openai.py
@@ -4,7 +4,7 @@ import base64
 import pytest
 from typing import Any
 
-from sycamore.llms import OpenAI, OpenAIModels, OpenAIClientWrapper
+from sycamore.llms.openai import OpenAI, OpenAIModels, OpenAIClientWrapper
 from sycamore.llms.openai import OpenAIModel, OpenAIClientType
 from sycamore.llms.prompts import RenderedPrompt, RenderedMessage, StaticPrompt
 from sycamore.utils.cache import DiskCache

--- a/lib/sycamore/sycamore/tests/integration/query/execution/test_operations.py
+++ b/lib/sycamore/sycamore/tests/integration/query/execution/test_operations.py
@@ -3,7 +3,7 @@ import pytest
 import sycamore
 from sycamore import EXEC_RAY
 from sycamore.data import Document
-from sycamore.llms import OpenAI, OpenAIModels
+from sycamore.llms.openai import OpenAI, OpenAIModels
 from sycamore.llms.llms import LLMMode
 from sycamore.query.execution.operations import (
     MultiStepDocumentSummarizer,

--- a/lib/sycamore/sycamore/tests/integration/transforms/test_data_extraction.py
+++ b/lib/sycamore/sycamore/tests/integration/transforms/test_data_extraction.py
@@ -3,7 +3,8 @@ import sycamore
 from sycamore import ExecMode
 from sycamore.data import Document
 from sycamore.schema import Schema, SchemaField
-from sycamore.llms import OpenAI, OpenAIModels, Anthropic, AnthropicModels
+from sycamore.llms.openai import OpenAI, OpenAIModels
+from sycamore.llms.anthropic import Anthropic, AnthropicModels
 from sycamore.transforms.extract_schema import LLMPropertyExtractor
 
 

--- a/lib/sycamore/sycamore/tests/unit/llms/test_llms.py
+++ b/lib/sycamore/sycamore/tests/unit/llms/test_llms.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 from unittest.mock import patch
 
-from sycamore.llms import OpenAI, OpenAIModels, Bedrock, BedrockModels, get_llm, MODELS
+from sycamore.llms import get_llm, MODELS
+from sycamore.llms.openai import OpenAI, OpenAIModels
+from sycamore.llms.bedrock import Bedrock, BedrockModels
 from sycamore.llms.llms import FakeLLM, LLMMode
 from sycamore.llms.prompts import RenderedPrompt, RenderedMessage
 from sycamore.utils.cache import DiskCache

--- a/lib/sycamore/sycamore/tests/unit/test_docset.py
+++ b/lib/sycamore/sycamore/tests/unit/test_docset.py
@@ -18,19 +18,23 @@ from sycamore.llms.prompts.default_prompts import (
 from sycamore.transforms import (
     Embedder,
     Embed,
+    Filter,
     Partitioner,
     FlatMap,
     Map,
     MapBatch,
     Partition,
-    ExtractBatchSchema,
     Query,
 )
-from sycamore.transforms import Filter
 from sycamore.transforms.base import get_name_from_callable, CompositeTransform
 from sycamore.transforms.base_llm import LLMMap, LLMMapElements
 from sycamore.transforms.extract_entity import OpenAIEntityExtractor
-from sycamore.transforms.extract_schema import SchemaExtractor, LLMPropertyExtractor, LLMSchemaExtractor
+from sycamore.transforms.extract_schema import (
+    ExtractBatchSchema,
+    SchemaExtractor,
+    LLMPropertyExtractor,
+    LLMSchemaExtractor,
+)
 from sycamore.transforms.query import QueryExecutor
 from sycamore.transforms.similarity import SimilarityScorer
 from sycamore.transforms.sort import Sort

--- a/lib/sycamore/sycamore/tests/unit/test_import_speed.py
+++ b/lib/sycamore/sycamore/tests/unit/test_import_speed.py
@@ -21,9 +21,11 @@ def test_sycamore_import_speed():
     #    all of the LLM logic.
 
     # elapsed time is charging for starting a python process also; just the import time is
-    # shorter. Current constant was emperically determined after optimization, if we fix the
-    # remaining LLM slowness the constant can be reduced.
-    max_elapsed = 0.01 # 0.364227 * 2
+    # shorter. Current constant was emperically determined after optimization. The max is 1.5x the
+    # slowest run seen in github after setting max_elapsed = 0.001. If we fix the remaining LLM
+    # import slowness the constant can be reduced.
+
+    max_elapsed = 0.364227 * 1.5
 
     all_elapsed = []
     # First run is sometimes slow, give it 10 tries to get under the target

--- a/lib/sycamore/sycamore/tests/unit/test_import_speed.py
+++ b/lib/sycamore/sycamore/tests/unit/test_import_speed.py
@@ -21,12 +21,13 @@ def test_sycamore_import_speed():
     #    all of the LLM logic.
 
     # elapsed time is charging for starting a python process also; just the import time is
-    # usually faster.
-    max_elapsed = 0.01
+    # shorter. Current constant was emperically determined after optimization, if we fix the
+    # remaining LLM slowness the constant can be reduced.
+    max_elapsed = 0.01 # 0.364227 * 2
 
     all_elapsed = []
-    # First run is sometimes slow, give it 5 tries to get under the target
-    for i in range(5):
+    # First run is sometimes slow, give it 10 tries to get under the target
+    for i in range(10):
         start = datetime.datetime.now()
         ret = subprocess.run(["python", "-c", "import sycamore"])
         assert ret.returncode == 0

--- a/lib/sycamore/sycamore/tests/unit/test_import_speed.py
+++ b/lib/sycamore/sycamore/tests/unit/test_import_speed.py
@@ -1,0 +1,42 @@
+import subprocess
+import datetime
+
+
+def test_sycamore_import_speed():
+    # Attention future developer: You're here, your PR just made this test fail, you're thinking
+    # "I'll just increase this by a little bit, it's not a big deal."  You're probably not even
+    # responsible for most of the slowdown. Please, take the time to fix it and not let it get
+    # "just a little bit worse."  That's the way that we get back up to taking >1s to import a
+    # library when it should take <0.1s.
+    #
+    # There are several techniques for improving import speed:
+    # 1. Making dependencies lazy -- move the import statement into the class init or
+    #    function and the dependency won't be loaded unless the function is called.
+    # 2. Removing typing only dependencies -- add the imports under an if TYPE_CHECKING block,
+    #    and add "" around the conditionally imported types.
+    # 3. Removing things from __init__.py -- chhange the user inputs to import from the underlying
+    #    file, and remove them from __init__.py so they aren't unconditionally imported.
+    # 4. Split out partial dependencies, e.g. sycamore/llms/config.py which just holds some
+    #    configuration information needed by callers to determine valid LLMs, instead of importing
+    #    all of the LLM logic.
+
+    # elapsed time is charging for starting a python process also; just the import time is
+    # usually faster.
+    max_elapsed = 0.01
+
+    all_elapsed = []
+    # First run is sometimes slow, give it 5 tries to get under the target
+    for i in range(5):
+        start = datetime.datetime.now()
+        ret = subprocess.run(["python", "-c", "import sycamore"])
+        assert ret.returncode == 0
+        elapsed = (datetime.datetime.now() - start).total_seconds()
+        if elapsed <= max_elapsed:
+            break
+
+        all_elapsed.append(elapsed)
+
+    if elapsed > max_elapsed:
+        subprocess.run(["python", "-c", "import import_timer; import sycamore; import_timer.show()"])
+        print(f"ERROR: All runtimes > {max_elapsed}: {all_elapsed}")
+        raise ValueError("Import too slow")

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_embed.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_embed.py
@@ -106,17 +106,6 @@ class TestEmbedding:
             },
             {"doc_id": 2, "text_representation": texts[1] if use_documents else None, "embedding": None},
         ]
-        import time
-
-        def sleepfn(d):
-            print("Sleeping...")
-            time.sleep(10)
-            return d
-
-        import sycamore
-
-        sycamore.init().read.document([Document(d) for d in dicts]).map(sleepfn).take_all()
-
         input_dataset = ray.data.from_items([{"doc": Document(dict).serialize()} for dict in dicts])
         execute = mocker.patch.object(node, "execute")
         execute.return_value = input_dataset

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_embed.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_embed.py
@@ -106,6 +106,17 @@ class TestEmbedding:
             },
             {"doc_id": 2, "text_representation": texts[1] if use_documents else None, "embedding": None},
         ]
+        import time
+
+        def sleepfn(d):
+            print("Sleeping...")
+            time.sleep(10)
+            return d
+
+        import sycamore
+
+        sycamore.init().read.document([Document(d) for d in dicts]).map(sleepfn).take_all()
+
         input_dataset = ray.data.from_items([{"doc": Document(dict).serialize()} for dict in dicts])
         execute = mocker.patch.object(node, "execute")
         execute.return_value = input_dataset

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_extract_table_properties.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_extract_table_properties.py
@@ -1,5 +1,5 @@
 from sycamore.data import Document, Element, Table, TableCell
-from sycamore.llms import OpenAI
+from sycamore.llms.openai import OpenAI
 from sycamore.transforms.extract_table_properties import ExtractTableProperties
 from PIL import Image
 from io import BytesIO

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_llm_query.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_llm_query.py
@@ -2,7 +2,7 @@ import random
 import string
 
 from sycamore.data import Document, Element
-from sycamore.llms import OpenAI
+from sycamore.llms.openai import OpenAI
 from sycamore.transforms.llm_query import LLMTextQueryAgent
 
 

--- a/lib/sycamore/sycamore/transforms/__init__.py
+++ b/lib/sycamore/sycamore/transforms/__init__.py
@@ -36,12 +36,6 @@ from sycamore.transforms.mark_misc import (
 )
 from sycamore.transforms.merge_elements import Merge
 
-# from sycamore.transforms.extract_schema import (
-#     ExtractSchema,
-#     ExtractBatchSchema,
-#     SchemaExtractor,
-#     PropertyExtractor,
-# )
 from sycamore.transforms.random_sample import RandomSample
 from sycamore.transforms.split_elements import SplitElements
 from sycamore.transforms.query import Query
@@ -52,6 +46,8 @@ from sycamore.transforms.groupby_count import GroupByCount
 from sycamore.transforms.dataset_scan import DatasetScan
 
 
+# commented out bits can be removed after 2025-08-01; they are here to help people
+# find where things should be imported from
 __all__ = [
     "COALESCE_WHITESPACE",
     "Explode",

--- a/lib/sycamore/sycamore/transforms/__init__.py
+++ b/lib/sycamore/sycamore/transforms/__init__.py
@@ -1,3 +1,5 @@
+# Please don't add more to these; every one slows down importing transforms if they are unused.
+# Worse importing any transform forces importing all of them.
 from sycamore.transforms.embed import Embed, Embedder
 from sycamore.transforms.basics import Limit, Filter
 from sycamore.transforms.extract_document_structure import DocumentStructure, ExtractDocumentStructure
@@ -5,7 +7,8 @@ from sycamore.transforms.extract_entity import ExtractEntity, EntityExtractor
 from sycamore.transforms.explode import Explode
 from sycamore.transforms.map import Map, FlatMap, MapBatch
 from sycamore.transforms.partition import Partition, Partitioner
-from sycamore.transforms.extract_table import TableExtractor
+
+# from sycamore.transforms.extract_table import TableExtractor
 from sycamore.transforms.regex_replace import COALESCE_WHITESPACE, RegexReplace
 from sycamore.transforms.similarity import ScoreSimilarity
 from sycamore.transforms.sketcher import Sketcher, SketchUniquify, SketchDebug
@@ -32,12 +35,13 @@ from sycamore.transforms.mark_misc import (
     MarkBreakByTokens,
 )
 from sycamore.transforms.merge_elements import Merge
-from sycamore.transforms.extract_schema import (
-    ExtractSchema,
-    ExtractBatchSchema,
-    SchemaExtractor,
-    PropertyExtractor,
-)
+
+# from sycamore.transforms.extract_schema import (
+#     ExtractSchema,
+#     ExtractBatchSchema,
+#     SchemaExtractor,
+#     PropertyExtractor,
+# )
 from sycamore.transforms.random_sample import RandomSample
 from sycamore.transforms.split_elements import SplitElements
 from sycamore.transforms.query import Query
@@ -63,7 +67,7 @@ __all__ = [
     "ExtractDocumentStructure",
     "ExtractEntity",
     "EntityExtractor",
-    "TableExtractor",
+    #    "TableExtractor", # sycamore.transforms.extract_table
     "SpreadProperties",
     "RegexReplace",
     "Sketcher",
@@ -78,10 +82,10 @@ __all__ = [
     "MarkDropHeaderFooter",
     "Filter",
     "Merge",
-    "ExtractSchema",
-    "ExtractBatchSchema",
-    "SchemaExtractor",
-    "PropertyExtractor",
+    #    "ExtractSchema",  # sycamore.transforms.extract_schema
+    #    "ExtractBatchSchema",  # sycamore.transforms.extract_schema
+    #    "SchemaExtractor",  # sycamore.transforms.extract_schema
+    #    "PropertyExtractor",  # sycamore.transforms.extract_schema
     "RandomSample",
     "SplitElements",
     "Query",

--- a/lib/sycamore/sycamore/transforms/base.py
+++ b/lib/sycamore/sycamore/transforms/base.py
@@ -1,8 +1,6 @@
 import logging
 from typing import Any, Callable, Iterable, Optional, Union, TYPE_CHECKING
 
-import numpy as np
-
 from sycamore.data import Document, MetadataDocument
 from sycamore.utils.lineage_utils import update_lineage
 from sycamore.data.document import split_data_metadata
@@ -12,6 +10,7 @@ from sycamore.utils.thread_local import ThreadLocal, ADD_METADATA_TO_OUTPUT
 
 if TYPE_CHECKING:
     from ray.data import Dataset, Datasink
+    import numpy
 
 
 def take_separate(dataset: "Dataset", limit: Optional[int] = None) -> tuple[list[Document], list[MetadataDocument]]:
@@ -196,7 +195,7 @@ class BaseMapTransform(UnaryNode):
         enable_auto_metadata = self._enable_auto_metadata
 
         @rename(name)
-        def ray_callable(ray_input: dict[str, np.ndarray]) -> dict[str, list]:
+        def ray_callable(ray_input: dict[str, "numpy.ndarray"]) -> dict[str, list]:
             return BaseMapTransform._process_ray(ray_input, name, lambda d: f(d, *args, **kwargs), enable_auto_metadata)
 
         return ray_callable
@@ -211,7 +210,7 @@ class BaseMapTransform(UnaryNode):
         def ray_init(self):
             pass
 
-        def ray_callable(self, ray_input: dict[str, np.ndarray]) -> dict[str, list]:
+        def ray_callable(self, ray_input: dict[str, "numpy.ndarray"]) -> dict[str, list]:
             return BaseMapTransform._process_ray(ray_input, name, lambda d: f(d, *args, **kwargs), enable_auto_metadata)
 
         return type("BaseMapTransformCallable__" + name, (), {"__init__": ray_init, "__call__": ray_callable})
@@ -228,7 +227,7 @@ class BaseMapTransform(UnaryNode):
         def ray_init(self):
             self.base = c(*c_args, **c_kwargs)
 
-        def ray_callable(self, ray_input: dict[str, np.ndarray]) -> dict[str, list]:
+        def ray_callable(self, ray_input: dict[str, "numpy.ndarray"]) -> dict[str, list]:
             return BaseMapTransform._process_ray(
                 ray_input, name, lambda d: self.base(d, *args, **kwargs), enable_auto_metadata
             )
@@ -237,7 +236,7 @@ class BaseMapTransform(UnaryNode):
 
     @staticmethod
     def _process_ray(
-        ray_input: dict[str, np.ndarray],
+        ray_input: dict[str, "numpy.ndarray"],
         name: str,
         f: Callable[[list[Document]], list[Document]],
         enable_auto_metadata: bool,

--- a/lib/sycamore/sycamore/transforms/detr_partitioner.py
+++ b/lib/sycamore/sycamore/transforms/detr_partitioner.py
@@ -30,14 +30,16 @@ from sycamore.utils.time_trace import LogTime, timetrace
 from sycamore.transforms.text_extraction import TextExtractor, OcrModel, get_text_extractor
 from sycamore.transforms.text_extraction.pdf_miner import PdfMinerExtractor
 
+from sycamore.transforms.detr_partitioner_config import (
+    ARYN_DETR_MODEL,
+    DEFAULT_ARYN_PARTITIONER_ADDRESS,
+    DEFAULT_LOCAL_THRESHOLD,
+)
+
 logger = logging.getLogger(__name__)
 _VERSION = "0.2024.07.24"
 
-
-ARYN_DETR_MODEL = "Aryn/deformable-detr-DocLayNet"
-DEFAULT_ARYN_PARTITIONER_ADDRESS = "https://api.aryn.cloud/v1/document/partition"
 _TEN_MINUTES = 600
-DEFAULT_LOCAL_THRESHOLD = 0.35
 
 
 class ArynPDFPartitionerException(Exception):

--- a/lib/sycamore/sycamore/transforms/detr_partitioner_config.py
+++ b/lib/sycamore/sycamore/transforms/detr_partitioner_config.py
@@ -1,0 +1,3 @@
+ARYN_DETR_MODEL = "Aryn/deformable-detr-DocLayNet"
+DEFAULT_ARYN_PARTITIONER_ADDRESS = "https://api.aryn.cloud/v1/document/partition"
+DEFAULT_LOCAL_THRESHOLD = 0.35

--- a/lib/sycamore/sycamore/transforms/extract_graph_entities.py
+++ b/lib/sycamore/sycamore/transforms/extract_graph_entities.py
@@ -8,7 +8,7 @@ from sycamore.plan_nodes import Node
 from sycamore.transforms.map import Map
 from sycamore.data import HierarchicalDocument, mkdocid
 from sycamore.llms import LLM
-from sycamore.llms.prompts import GraphEntityExtractorPrompt
+from sycamore.llms.prompts.default_prompts import GraphEntityExtractorPrompt
 from PIL import Image
 from pydantic import BaseModel, create_model
 

--- a/lib/sycamore/sycamore/transforms/extract_graph_relationships.py
+++ b/lib/sycamore/sycamore/transforms/extract_graph_relationships.py
@@ -17,7 +17,7 @@ from sycamore.plan_nodes import Node
 from sycamore.transforms.map import Map
 from sycamore.data import HierarchicalDocument
 from sycamore.llms import LLM
-from sycamore.llms.prompts import GraphRelationshipExtractorPrompt
+from sycamore.llms.prompts.default_prompts import GraphRelationshipExtractorPrompt
 
 logger = logging.getLogger(__name__)
 

--- a/lib/sycamore/sycamore/transforms/extract_schema.py
+++ b/lib/sycamore/sycamore/transforms/extract_schema.py
@@ -18,8 +18,6 @@ from sycamore.transforms.base_llm import LLMMap
 from sycamore.utils.extract_json import extract_json
 from sycamore.utils.time_trace import timetrace
 
-import dateparser
-
 
 def element_list_formatter(elements: list[Element]) -> str:
     query = ""
@@ -187,6 +185,8 @@ class LLMPropertyExtractor(PropertyExtractor):
         return [jsonextract_node.run(d) for d in llm_map_node.run(docs)]
 
     def cast_types(self, fields: dict) -> dict:
+        import dateparser
+
         assert self._schema is not None, "Schema must be provided for property standardization."
         assert isinstance(self._schema, Schema), "Schema object must be provided for property standardization."
         result: dict = {}

--- a/lib/sycamore/sycamore/transforms/extract_table.py
+++ b/lib/sycamore/sycamore/transforms/extract_table.py
@@ -6,7 +6,6 @@ from collections import OrderedDict
 from typing import Optional, Any
 
 import pypdf
-import boto3
 from botocore.exceptions import ClientError
 from textractor import Textractor
 from textractor.data.constants import TextractFeatures
@@ -180,6 +179,8 @@ class CachedTextractTableExtractor(TextractTableExtractor):
         return cache_id
 
     def get_textract_result(self, document: Document):
+        import boto3
+
         s3 = boto3.client("s3")
         cache_id = self._cache_id(s3, document.properties["path"])
         try:

--- a/lib/sycamore/sycamore/transforms/extract_table_properties.py
+++ b/lib/sycamore/sycamore/transforms/extract_table_properties.py
@@ -6,7 +6,7 @@ from sycamore.plan_nodes import Node, SingleThreadUser, NonGPUUser
 from sycamore.transforms.map import Map
 from sycamore.utils.time_trace import timetrace
 from sycamore.llms import LLM
-from sycamore.llms.prompts import ExtractTablePropertiesPrompt
+from sycamore.llms.prompts.default_prompts import ExtractTablePropertiesPrompt
 from PIL import Image
 from sycamore.functions.document import split_and_convert_to_image
 

--- a/lib/sycamore/sycamore/transforms/partition.py
+++ b/lib/sycamore/sycamore/transforms/partition.py
@@ -1,15 +1,12 @@
 from abc import abstractmethod, ABC
 import io
-from typing import Any, Literal, Optional, Union
-
-from bs4 import BeautifulSoup, Tag
+from typing import Any, Literal, Optional, Union, TYPE_CHECKING
 
 from sycamore.functions import TextOverlapChunker, Chunker
 from sycamore.functions import CharacterTokenizer, Tokenizer
 from sycamore.data import BoundingBox, Document, Element, TableElement, Table
 from sycamore.plan_nodes import Node
 from sycamore.transforms.base import CompositeTransform
-from sycamore.transforms.extract_table import TableExtractor
 from sycamore.transforms.table_structure.extract import TableStructureExtractor
 from sycamore.transforms.map import Map
 from sycamore.utils.cache import Cache
@@ -18,11 +15,14 @@ from sycamore.utils import choose_device
 from sycamore.utils.aryn_config import ArynConfig
 from sycamore.utils.bbox_sort import bbox_sort_document
 
-from sycamore.transforms.detr_partitioner import (
+from sycamore.transforms.detr_partitioner_config import (
     ARYN_DETR_MODEL,
     DEFAULT_ARYN_PARTITIONER_ADDRESS,
     DEFAULT_LOCAL_THRESHOLD,
 )
+
+if TYPE_CHECKING:
+    from sycamore.transforms.extract_table import TableExtractor
 
 
 class Partitioner(ABC):
@@ -277,6 +277,8 @@ class HtmlPartitioner(Partitioner):
 
     @timetrace("beautSoup")
     def partition(self, document: Document) -> Document:
+        from bs4 import BeautifulSoup, Tag
+
         raw_html = document.binary_representation
 
         if raw_html is None:
@@ -605,7 +607,7 @@ class Partition(CompositeTransform):
     """
 
     def __init__(
-        self, child: Node, partitioner: Partitioner, table_extractor: Optional[TableExtractor] = None, **resource_args
+        self, child: Node, partitioner: Partitioner, table_extractor: Optional["TableExtractor"] = None, **resource_args
     ):
         ops = []
 

--- a/lib/sycamore/sycamore/transforms/standardizer.py
+++ b/lib/sycamore/sycamore/transforms/standardizer.py
@@ -3,7 +3,6 @@ from datetime import datetime
 import re
 from typing import Any, List, Optional
 
-import dateparser
 from sycamore.plan_nodes import Node
 from sycamore.data import Document
 from sycamore.transforms.map import Map
@@ -211,6 +210,8 @@ class DateTimeStandardizer(Standardizer):
             ValueError: If the input string cannot be parsed into a valid date-time.
             RuntimeError: For any other unexpected errors during the processing.
         """
+        import dateparser
+
         assert raw_dateTime is not None, "raw_dateTime is None"
         try:
             raw_dateTime = DateTimeStandardizer.fix_military(raw_dateTime)

--- a/lib/sycamore/sycamore/transforms/summarize_images.py
+++ b/lib/sycamore/sycamore/transforms/summarize_images.py
@@ -3,7 +3,7 @@ from typing import Optional
 from PIL import Image
 
 from sycamore.data import Document, Element
-from sycamore.llms import LLM
+from sycamore.llms.llms import LLM
 from sycamore.llms.openai import OpenAI, OpenAIClientWrapper, OpenAIModels
 from sycamore.llms.gemini import Gemini, GeminiModels
 from sycamore.llms.prompts.default_prompts import SummarizeImagesJinjaPrompt

--- a/lib/sycamore/sycamore/transforms/summarize_images.py
+++ b/lib/sycamore/sycamore/transforms/summarize_images.py
@@ -3,7 +3,9 @@ from typing import Optional
 from PIL import Image
 
 from sycamore.data import Document, Element
-from sycamore.llms import LLM, OpenAI, OpenAIClientWrapper, OpenAIModels, Gemini, GeminiModels
+from sycamore.llms import LLM
+from sycamore.llms.openai import OpenAI, OpenAIClientWrapper, OpenAIModels
+from sycamore.llms.gemini import Gemini, GeminiModels
 from sycamore.llms.prompts.default_prompts import SummarizeImagesJinjaPrompt
 from sycamore.llms.prompts.prompts import SycamorePrompt, RenderedMessage, RenderedPrompt
 from sycamore.plan_nodes import Node

--- a/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
@@ -9,9 +9,6 @@ from collections import OrderedDict, defaultdict
 from typing import Optional
 import xml.etree.ElementTree as ET
 
-import numpy as np
-import pandas as pd
-
 from sycamore.data.table import Table, TableCell
 from sycamore.data import BoundingBox
 
@@ -1199,6 +1196,9 @@ def structure_to_cells(table_structure, tokens, union_tokens):
 
 
 def cells_to_csv(cells):
+    import pandas
+    import numpy
+
     if len(cells) > 0:
         num_columns = max([max(cell["column_nums"]) for cell in cells]) + 1
         num_rows = max([max(cell["row_nums"]) for cell in cells]) + 1
@@ -1211,7 +1211,7 @@ def cells_to_csv(cells):
     else:
         max_header_row = -1
 
-    table_array = np.empty([num_rows, num_columns], dtype="object")
+    table_array = numpy.empty([num_rows, num_columns], dtype="object")
     if len(cells) > 0:
         for cell in cells:
             for row_num in cell["row_nums"]:
@@ -1225,7 +1225,7 @@ def cells_to_csv(cells):
     for col in header.transpose():
         flattened_header.append(" | ".join(OrderedDict.fromkeys(col)))
 
-    df = pd.DataFrame(table_array[max_header_row + 1 :, :], index=None, columns=flattened_header)
+    df = pandas.DataFrame(table_array[max_header_row + 1 :, :], index=None, columns=flattened_header)
 
     return df.to_csv(index=None)
 

--- a/notebooks/default-prep-script.ipynb
+++ b/notebooks/default-prep-script.ipynb
@@ -24,7 +24,7 @@
     "\n",
     "import sycamore\n",
     "from sycamore.functions import HuggingFaceTokenizer, TextOverlapChunker\n",
-    "from sycamore.llms import OpenAI, OpenAIModels\n",
+    "from sycamore.llms.openai import OpenAI, OpenAIModels\n",
     "from sycamore.transforms.embed import SentenceTransformerEmbedder\n",
     "from sycamore.transforms.extract_entity import OpenAIEntityExtractor\n",
     "from sycamore.transforms.merge_elements import GreedyTextElementMerger\n",

--- a/notebooks/duckdb-writer.ipynb
+++ b/notebooks/duckdb-writer.ipynb
@@ -19,7 +19,7 @@
     "import sycamore\n",
     "import json\n",
     "from sycamore.functions.tokenizer import HuggingFaceTokenizer\n",
-    "from sycamore.llms import OpenAIModels, OpenAI\n",
+    "from sycamore.llms.openai import OpenAIModels, OpenAI\n",
     "from sycamore.transforms import COALESCE_WHITESPACE\n",
     "from sycamore.transforms.merge_elements import MarkedMerger\n",
     "from sycamore.transforms.partition import ArynPartitioner\n",

--- a/notebooks/elasticsearch-writer.ipynb
+++ b/notebooks/elasticsearch-writer.ipynb
@@ -29,7 +29,7 @@
     "import sycamore\n",
     "from elasticsearch import Elasticsearch\n",
     "from sycamore.functions.tokenizer import HuggingFaceTokenizer\n",
-    "from sycamore.llms import OpenAIModels, OpenAI\n",
+    "from sycamore.llms.openai import OpenAIModels, OpenAI\n",
     "from sycamore.transforms import COALESCE_WHITESPACE\n",
     "from sycamore.transforms.merge_elements import MarkedMerger\n",
     "from sycamore.transforms.partition import ArynPartitioner\n",

--- a/notebooks/jupyter_dev_example.ipynb
+++ b/notebooks/jupyter_dev_example.ipynb
@@ -41,7 +41,7 @@
     "from sycamore.data import Document\n",
     "from sycamore.transforms.embed import SentenceTransformerEmbedder\n",
     "from sycamore.transforms.extract_entity import OpenAIEntityExtractor\n",
-    "from sycamore.llms import OpenAIModels, OpenAI\n",
+    "from sycamore.llms.openai import OpenAIModels, OpenAI\n",
     "from sycamore.transforms.partition import ArynPartitioner\n",
     "from sycamore.functions.document import split_and_convert_to_image, DrawBoxes\n",
     "from sycamore.transforms.merge_elements import GreedyTextElementMerger\n",

--- a/notebooks/metadata-extraction.ipynb
+++ b/notebooks/metadata-extraction.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "from sycamore.data import Document\n",
     "from sycamore.functions import HuggingFaceTokenizer\n",
-    "from sycamore.llms import OpenAI, OpenAIModels\n",
+    "from sycamore.llms.openai import OpenAI, OpenAIModels\n",
     "from sycamore.transforms.extract_schema import OpenAISchemaExtractor, OpenAIPropertyExtractor\n",
     "from sycamore.transforms.merge_elements import GreedyTextElementMerger\n",
     "from sycamore.transforms.partition import ArynPartitioner\n",

--- a/notebooks/ntsb-demo.ipynb
+++ b/notebooks/ntsb-demo.ipynb
@@ -39,7 +39,7 @@
     "from sycamore.transforms.summarize_images import SummarizeImages\n",
     "from sycamore.transforms import AssignDocProperties, ExtractTableProperties, USStateStandardizer, DateTimeStandardizer\n",
     "\n",
-    "from sycamore.llms import OpenAI\n",
+    "from sycamore.llms.openai import OpenAI\n",
     "from sycamore.utils.aryn_config import ArynConfig, _DEFAULT_PATH\n",
     "from sycamore.utils.pdf_utils import show_pages, enumerate_images_and_tables, display_page_and_table_properties\n",
     "from sycamore.materialize import MaterializeSourceMode\n",

--- a/notebooks/opensearch-writer.ipynb
+++ b/notebooks/opensearch-writer.ipynb
@@ -18,7 +18,7 @@
     "import pyarrow.fs\n",
     "import sycamore\n",
     "from sycamore.functions.tokenizer import HuggingFaceTokenizer\n",
-    "from sycamore.llms import OpenAIModels, OpenAI\n",
+    "from sycamore.llms.openai import OpenAIModels, OpenAI\n",
     "from sycamore.transforms import COALESCE_WHITESPACE\n",
     "from sycamore.transforms.merge_elements import MarkedMerger\n",
     "from sycamore.transforms.partition import ArynPartitioner\n",

--- a/notebooks/opensearch_docs_etl.ipynb
+++ b/notebooks/opensearch_docs_etl.ipynb
@@ -18,7 +18,7 @@
     "import sycamore\n",
     "from sycamore.transforms.partition import ArynPartitioner\n",
     "from sycamore.utils.aryn_config import ArynConfig, _DEFAULT_PATH\n",
-    "from sycamore.llms import OpenAIModels, OpenAI\n",
+    "from sycamore.llms.openai import OpenAIModels, OpenAI\n",
     "from sycamore.transforms.extract_entity import OpenAIEntityExtractor\n",
     "from sycamore.transforms.embed import SentenceTransformerEmbedder\n",
     "from sycamore.transforms.merge_elements import GreedySectionMerger\n",

--- a/notebooks/pinecone-writer.ipynb
+++ b/notebooks/pinecone-writer.ipynb
@@ -19,7 +19,7 @@
     "import pyarrow.fs\n",
     "import sycamore\n",
     "from sycamore.functions.tokenizer import HuggingFaceTokenizer\n",
-    "from sycamore.llms import OpenAIModels, OpenAI\n",
+    "from sycamore.llms.openai import OpenAIModels, OpenAI\n",
     "from sycamore.transforms import COALESCE_WHITESPACE\n",
     "from sycamore.transforms.merge_elements import MarkedMerger\n",
     "from sycamore.transforms.partition import ArynPartitioner\n",

--- a/notebooks/subtask-sample.ipynb
+++ b/notebooks/subtask-sample.ipynb
@@ -15,7 +15,7 @@
     "from sycamore.transforms.query import OpenSearchQueryExecutor\n",
     "from sycamore.evaluation.subtasks import SubtaskExecutor\n",
     "from sycamore.functions import HuggingFaceTokenizer\n",
-    "from sycamore.llms import OpenAI, OpenAIModels\n",
+    "from sycamore.llms.openai import OpenAI, OpenAIModels\n",
     "from sycamore.transforms import COALESCE_WHITESPACE\n",
     "from sycamore.transforms.merge_elements import GreedyTextElementMerger\n",
     "from sycamore.transforms.partition import ArynPartitioner\n",

--- a/notebooks/sycamore-tutorial-intermediate-etl.ipynb
+++ b/notebooks/sycamore-tutorial-intermediate-etl.ipynb
@@ -167,7 +167,7 @@
    "outputs": [],
    "source": [
     "from sycamore.transforms.extract_schema import OpenAIPropertyExtractor\n",
-    "from sycamore.llms import OpenAI, OpenAIModels\n",
+    "from sycamore.llms.openai import OpenAI, OpenAIModels\n",
     "\n",
     "llm = OpenAI(OpenAIModels.GPT_4O.value)\n",
     "\n",

--- a/notebooks/sycamore_demo.ipynb
+++ b/notebooks/sycamore_demo.ipynb
@@ -27,7 +27,7 @@
     "from sycamore.data import Document\n",
     "from sycamore.transforms.embed import SentenceTransformerEmbedder\n",
     "from sycamore.transforms.extract_entity import OpenAIEntityExtractor\n",
-    "from sycamore.llms import OpenAIModels, OpenAI\n",
+    "from sycamore.llms.openai import OpenAIModels, OpenAI\n",
     "from sycamore.transforms.partition import ArynPartitioner\n",
     "from sycamore.functions.document import split_and_convert_to_image, DrawBoxes\n",
     "from sycamore.tests.config import TEST_DIR"

--- a/notebooks/tutorial.ipynb
+++ b/notebooks/tutorial.ipynb
@@ -90,7 +90,7 @@
    "outputs": [],
    "source": [
     "from sycamore.transforms.extract_entity import OpenAIEntityExtractor\n",
-    "from sycamore.llms import OpenAIModels, OpenAI\n",
+    "from sycamore.llms.openai import OpenAIModels, OpenAI\n",
     "\n",
     "\n",
     "# The following prompt templates will be used to extract the relevant entities\n",

--- a/notebooks/weaviate-writer.ipynb
+++ b/notebooks/weaviate-writer.ipynb
@@ -139,7 +139,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sycamore.llms import OpenAI, OpenAIModels\n",
+    "from sycamore.llms.openai import OpenAI, OpenAIModels\n",
     "from sycamore.transforms.extract_schema import OpenAIPropertyExtractor\n",
     "\n",
     "# Specifies a schema name and type that direct the LLM what properties to extract.\n",

--- a/poetry.lock
+++ b/poetry.lock
@@ -3761,6 +3761,20 @@ files = [
 markers = {main = "extra == \"docs\""}
 
 [[package]]
+name = "import-timer"
+version = "0.0.1"
+description = "Import timing library"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = []
+develop = true
+
+[package.source]
+type = "directory"
+url = "lib/import_timer"
+
+[[package]]
 name = "importlib-metadata"
 version = "8.6.1"
 description = "Read metadata from Python packages"
@@ -12212,4 +12226,4 @@ docs = ["enum-tools", "furo", "myst-parser", "sphinx", "sphinx-toolbox"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9.2,<3.9.7 || >3.9.7,<3.13"
-content-hash = "2bb7a77b833f19d4a7e7f16cd9e5133383f0a653f087dd65ea14f31e23cd49aa"
+content-hash = "d7f99a6de97cecf7837861be69f559c8b723312ff4b43d9a002e5156981d3550"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ remote-processors = { path = "lib/remote-processors", develop = true }
 integration = { path = "apps/integration", develop = true }
 sycamore-poetry-lock = { path = "lib/poetry-lock", develop = true }
 aryn-sdk = { path = "lib/aryn-sdk", develop = true }
+import_timer = { path = "lib/import_timer", develop = true }
 ruff = ">=0.11.2"
 black = ">=25.1"
 pre-commit = ">=4.2.0"


### PR DESCRIPTION
Went from ~1.2s to ~0.1s to execute import sycamore. on my laptop.

Remaining work is all around improving llm import time, that import is about 90% of the remaining time.

lib/import_timer is the new library for doing import timing. See the file for instructions.
  Thanks to Claude for an initial version.