### PR TITLE
Minor fixups from testing with managed-service.

### DIFF
--- a/lib/sycamore/sycamore/llms/__init__.py
+++ b/lib/sycamore/sycamore/llms/__init__.py
@@ -4,42 +4,53 @@ from sycamore.llms.llms import LLM
 from sycamore.llms.config import AnthropicModels, BedrockModels, GeminiModels, OpenAIModels
 
 
-def Anthropic(name, **kwargs):
-    from sycamore.llms.anthropic import Anthropic as AnthropicReal
+def AnthropicTrampoline(name, **kwargs):
+    from sycamore.llms.anthropic import Anthropic
 
-    return AnthropicReal(name, **kwargs)
-
-
-def Bedrock(name, **kwargs):
-    from sycamore.llms.bedrock import Bedrock as BedrockReal
-
-    return BedrockReal(name, **kwargs)
+    return Anthropic(name, **kwargs)
 
 
-def Gemini(name, **kwargs):
-    from sycamore.llms.gemini import Gemini as GeminiReal
+def BedrockTrampoline(name, **kwargs):
+    from sycamore.llms.bedrock import Bedrock
 
-    return GeminiReal(name, **kwargs)
+    return Bedrock(name, **kwargs)
 
 
-def OpenAI(name, **kwargs):
-    from sycamore.llms.openai import OpenAI as OpenAIReal
+def GeminiTrampoline(name, **kwargs):
+    from sycamore.llms.gemini import Gemini
 
-    return OpenAIReal(name, **kwargs)
+    return Gemini(name, **kwargs)
+
+
+def OpenAITrampoline(name, **kwargs):
+    from sycamore.llms.openai import OpenAI
+
+    return OpenAI(name, **kwargs)
 
 
 # Register the model constructors.
 MODELS: Dict[str, Callable[..., LLM]] = {}
 MODELS.update(
-    {f"openai.{model.value.name}": lambda **kwargs: OpenAI(model.value.name, **kwargs) for model in OpenAIModels}
+    {
+        f"openai.{model.value.name}": lambda **kwargs: OpenAITrampoline(model.value.name, **kwargs)
+        for model in OpenAIModels
+    }
 )
 MODELS.update(
-    {f"bedrock.{model.value.name}": lambda **kwargs: Bedrock(model.value.name, **kwargs) for model in BedrockModels}
+    {
+        f"bedrock.{model.value.name}": lambda **kwargs: BedrockTrampoline(model.value.name, **kwargs)
+        for model in BedrockModels
+    }
 )
 MODELS.update(
-    {f"anthropic.{model.value}": lambda **kwargs: Anthropic(model.value, **kwargs) for model in AnthropicModels}
+    {
+        f"anthropic.{model.value}": lambda **kwargs: AnthropicTrampoline(model.value, **kwargs)
+        for model in AnthropicModels
+    }
 )
-MODELS.update({f"gemini.{model.value}": lambda **kwargs: Gemini(model.value.name, **kwargs) for model in GeminiModels})
+MODELS.update(
+    {f"gemini.{model.value}": lambda **kwargs: GeminiTrampoline(model.value.name, **kwargs) for model in GeminiModels}
+)
 
 
 def get_llm(model_name: str) -> Callable[..., LLM]:
@@ -55,15 +66,15 @@ __all__ = [
     "MODELS",
     "get_llm",
     "LLM",
-    "OpenAI",
     "OpenAIModels",
+    #   "OpenAI", # sycamore.llms.openai
     #   "OpenAIClientType", # sycamore.llms.openai
     #   "OpenAIClientParameters", # sycamore.llms.openai
     #   "OpenAIClientWrapper", # sycamore.llms.openai
-    "Bedrock",
+    #   "Bedrock", # sycamore.llms.bedrock
     "BedrockModels",
-    "Anthropic",
+    # "Anthropic", # sycamore.llms.anthropic
     "AnthropicModels",
-    "Gemini",
+    # "Gemini", # sycamore.llms.gemini
     "GeminiModels",
 ]

--- a/lib/sycamore/sycamore/query/execution/operations.py
+++ b/lib/sycamore/sycamore/query/execution/operations.py
@@ -21,12 +21,15 @@ from sycamore.transforms.summarize import (
 )
 
 log = structlog.get_logger(__name__)
+
+# making this takes 0.4s; see if we can delay
+_DEFAULT_TOKENIZER = OpenAITokenizer("gpt-4o", max_tokens=128_000)
 # multistep
 _MULTISTEP_SUMMARIZE: tuple[type[Summarizer], dict[str, Any]] = (
     MultiStepDocumentSummarizer,
     {
         "fields": [EtCetera],
-        "tokenizer": OpenAITokenizer("gpt-4o", max_tokens=128_000),
+        "tokenizer": _DEFAULT_TOKENIZER,
         "llm_mode": LLMMode.ASYNC,
     },
 )
@@ -35,7 +38,7 @@ _ONESTEP_SUMMARIZE: tuple[type[Summarizer], dict[str, Any]] = (
     OneStepDocumentSummarizer,
     {
         "fields": [EtCetera],
-        "tokenizer": OpenAITokenizer("gpt-4o", max_tokens=128_000),
+        "tokenizer": _DEFAULT_TOKENIZER,
     },
 )
 

--- a/lib/sycamore/sycamore/query/execution/sycamore_operator.py
+++ b/lib/sycamore/sycamore/query/execution/sycamore_operator.py
@@ -2,7 +2,6 @@ import copy
 from abc import abstractmethod
 from typing import Any, Optional, List, Dict, Tuple
 
-from sycamore.connectors.opensearch.utils import get_knn_query
 from sycamore.context import get_val_from_context, OperationTypes
 from sycamore.functions.basic_filters import MatchFilter, RangeFilter
 from sycamore.llms import LLM
@@ -178,6 +177,8 @@ class SycamoreQueryVectorDatabase(SycamoreOperator):
         self.rerank = rerank
 
     def execute(self) -> Any:
+        from sycamore.connectors.opensearch.utils import get_knn_query
+
         assert isinstance(self.logical_node, QueryVectorDatabase)
         embedder = get_val_from_context(context=self.context, val_key="text_embedder", param_names=["opensearch"])
         assert embedder and isinstance(embedder, Embedder), "QueryVectorDatabase requires an Embedder in the context"

--- a/lib/sycamore/sycamore/tests/integration/llms/test_anthropic.py
+++ b/lib/sycamore/sycamore/tests/integration/llms/test_anthropic.py
@@ -3,7 +3,7 @@ from typing import Any
 import base64
 import pickle
 
-from sycamore.llms import Anthropic, AnthropicModels
+from sycamore.llms.anthropic import Anthropic, AnthropicModels
 from sycamore.llms.prompts.prompts import RenderedPrompt, RenderedMessage
 from sycamore.utils.cache import DiskCache
 

--- a/lib/sycamore/sycamore/tests/integration/llms/test_bedrock.py
+++ b/lib/sycamore/sycamore/tests/integration/llms/test_bedrock.py
@@ -3,7 +3,7 @@ from typing import Any
 import pickle
 import base64
 
-from sycamore.llms import Bedrock, BedrockModels
+from sycamore.llms.bedrock import Bedrock, BedrockModels
 from sycamore.llms.prompts import RenderedPrompt, RenderedMessage
 from sycamore.utils.cache import DiskCache
 

--- a/lib/sycamore/sycamore/tests/integration/llms/test_gemini.py
+++ b/lib/sycamore/sycamore/tests/integration/llms/test_gemini.py
@@ -3,7 +3,7 @@ from typing import Any
 import base64
 import pickle
 
-from sycamore.llms import Gemini, GeminiModels
+from sycamore.llms.gemini import Gemini, GeminiModels
 from sycamore.llms.prompts.prompts import RenderedPrompt, RenderedMessage
 from sycamore.utils.cache import DiskCache
 

--- a/lib/sycamore/sycamore/tests/unit/llms/test_bedrock.py
+++ b/lib/sycamore/sycamore/tests/unit/llms/test_bedrock.py
@@ -3,8 +3,7 @@ from unittest.mock import patch
 import tempfile
 
 from sycamore.llms.prompts import RenderedPrompt, RenderedMessage
-from sycamore.llms import Bedrock, BedrockModels
-from sycamore.llms.bedrock import DEFAULT_ANTHROPIC_VERSION, DEFAULT_MAX_TOKENS
+from sycamore.llms.bedrock import Bedrock, BedrockModels, DEFAULT_ANTHROPIC_VERSION, DEFAULT_MAX_TOKENS
 from sycamore.utils.cache import DiskCache
 
 

--- a/lib/sycamore/sycamore/utils/__init__.py
+++ b/lib/sycamore/sycamore/utils/__init__.py
@@ -3,8 +3,6 @@ from typing import Optional
 
 from itertools import islice
 
-from sycamore.utils.import_utils import requires_modules
-
 __all__ = [
     "batched",
     "choose_device",
@@ -16,13 +14,15 @@ def batched(iterable, chunk_size):
     return iter(lambda: list(islice(iterator, chunk_size)), list())
 
 
-@requires_modules("torch.cuda", extra="local-inference")
 def choose_device(want: Optional[str], *, detr=False) -> str:
     if os.environ.get("DISABLE_GPU") == "1":
         return "cpu"
     if want:
         return want
 
+    from sycamore.utils.import_utils import import_modules
+
+    import_modules("torch.cuda", extra="local-inference")
     import torch.cuda
 
     if torch.cuda.is_available():


### PR DESCRIPTION
llms/__init__.py: Remove exporting the "models". Some uses expected them to be classes, and
  inherited. That didn't work so switch to not exporting.

operations.py: only make one tokenizer. Making them is kinda slow.

sycamore_operator.py: importing get_knn_query is slow. Only do it on demand

utils/__init__.py: Move the requires module logic inside the fucntion so that if
  someone specifies the device they want we don't end up loading torch.