### PR TITLE
refactor planner to add query preprocessor functionality

### DIFF
--- a/lib/sycamore/sycamore/query/planner.py
+++ b/lib/sycamore/sycamore/query/planner.py
@@ -83,7 +83,7 @@ class LlmPlanner(Planner):
             index=self._index,
             data_schema=self._data_schema,
         )
-        for preprocessor in self._strategy.pre_processors:
+        for preprocessor in self._strategy.prompt_processors:
             prompt = preprocessor(prompt)
         return prompt.render()
 
@@ -93,7 +93,7 @@ class LlmPlanner(Planner):
         llm_plan = self._llm_client.generate(prompt=llm_prompt, llm_kwargs={"temperature": 0})
         try:
             plan = process_json_plan(llm_plan)
-            for processor in self._strategy.post_processors:
+            for processor in self._strategy.plan_processors:
                 plan = processor(plan)
         except Exception as e:
             logging.error(f"Error processing LLM-generated query plan: {e}\nPlan is:\n{llm_plan}")

--- a/lib/sycamore/sycamore/query/planner.py
+++ b/lib/sycamore/sycamore/query/planner.py
@@ -1,60 +1,21 @@
 import logging
 import typing
 from abc import abstractmethod
-from dataclasses import dataclass
-from typing import Any, List, Optional, Tuple, Type, Union
+from typing import List, Optional, Union
 
-from sycamore.schema import Schema, SchemaField
+from sycamore.schema import Schema
 
 from sycamore.llms.llms import LLM
+from sycamore.llms.prompts.prompts import RenderedPrompt
 from sycamore.llms.openai import OpenAI, OpenAIModels
-from sycamore.query.logical_plan import LogicalPlan, Node
-from sycamore.query.operators.basic_filter import BasicFilter
-from sycamore.query.operators.count import Count
-from sycamore.query.operators.limit import Limit
-from sycamore.query.operators.llm_extract_entity import LlmExtractEntity
-from sycamore.query.operators.llm_filter import LlmFilter
-from sycamore.query.operators.math import Math
-from sycamore.query.operators.query_database import QueryDatabase, QueryVectorDatabase
-from sycamore.query.operators.sort import Sort
-from sycamore.query.operators.top_k import TopK
+from sycamore.query.logical_plan import LogicalPlan
+from sycamore.query.planner_prompt import PlannerPrompt, PlannerExample, PLANNER_EXAMPLES
 from sycamore.query.schema import OpenSearchSchema
 from sycamore.query.strategy import QueryPlanStrategy, ALL_OPERATORS
 from sycamore.utils.extract_json import extract_json
 
 if typing.TYPE_CHECKING:
     from opensearchpy import OpenSearch
-
-
-# This is the base prompt for the planner.
-PLANNER_SYSTEM_PROMPT = """You are a helpful agent that translates the user's question into a
-query plan, using a predefined set of query operators. Please adhere to the following
-guidelines when generating a plan:
-
-        1. Return your answer as a JSON dictionary containing a query plan in the format shown below.
-        2. Do not return any information except a single JSON object. This means not repeating the question
-            or providing any text outside the json block.
-        3. Only use the query operators described below.
-        4. Only use EXACT field names from the DATA_SCHEMA described below and fields created
-            from *LlmExtractEntity*. Any new fields created by *LlmExtractEntity* will be nested in properties.
-            e.g. if a new field called "state" is added, when referencing it in another operation,
-            you should use "properties.state". A database returned from *TopK* operation only has
-            "properties.key" or "properties.count"; you can only reference one of those fields.
-            Other than those, DO NOT USE ANY OTHER FIELD NAMES.
-        5. If an optional field does not have a value in the query plan, return null in its place.
-        6. The first step of each plan MUST be a **QueryDatabase** or **QueryVectorDatabase" operation.
-            Whenever possible, include all possible filtering operations in the first step.
-           That is, you should strive to construct an OpenSearch query that filters the data as
-           much as possible, reducing the need for further query operations. If using a QueryVectorDatabase, always
-              follow it with an LlmFilter operation to ensure the final results are accurate.
-"""
-
-# Variants on the last step in the query plan, based on whether the user has requested raw data
-# or a natural language response.
-PLANNER_RAW_DATA_PROMPT = "7. The last step of each plan should return the raw data associated with the response."
-PLANNER_NATURAL_LANGUAGE_PROMPT = (
-    "7. The last step of each plan *MUST* be a **SummarizeData** operation that returns a natural language response."
-)
 
 
 def process_json_plan(json_plan: str) -> LogicalPlan:
@@ -64,309 +25,6 @@ def process_json_plan(json_plan: str) -> LogicalPlan:
     if not isinstance(parsed_plan, dict):
         raise ValueError(f"Expected LLM query plan to contain a dict, got f{type(parsed_plan)}")
     return LogicalPlan.model_validate(parsed_plan)
-
-
-@dataclass
-class PlannerExample:
-    """Represents an example query and query plan for the planner."""
-
-    def __init__(self, schema: Union[OpenSearchSchema, Schema], plan: LogicalPlan) -> None:
-        super().__init__()
-        self.plan = plan
-        self.schema: Schema = schema.to_schema() if isinstance(schema, OpenSearchSchema) else schema
-
-
-# Example schema and planner examples for the NTSB and financial datasets.
-EXAMPLE_NTSB_SCHEMA = Schema(
-    fields=[
-        SchemaField(
-            name="properties.path",
-            field_type="str",
-            examples=["/docs/incident1.pdf", "/docs/incident2.pdf", "/docs/incident3.pdf"],
-        ),
-        SchemaField(name="properties.entity.date", field_type="date", examples=["2023-07-01", "2024-09-01"]),
-        SchemaField(name="properties.entity.accidentNumber", field_type="str", examples=["1234", "5678", "91011"]),
-        SchemaField(
-            name="properties.entity.location",
-            field_type="str",
-            examples=["Atlanta, Georgia", "Miami, Florida", "San Diego, California"],
-        ),
-        SchemaField(name="properties.entity.aircraft", field_type="str", examples=["Cessna", "Boeing", "Airbus"]),
-        SchemaField(name="properties.entity.city", field_type="str", examples=["Atlanta", "Savannah", "Augusta"]),
-        SchemaField(
-            name="text_representation", field_type="str", examples=["Can be assumed to have all other details"]
-        ),
-    ]
-)
-
-EXAMPLE_FINANCIAL_SCHEMA = Schema(
-    fields=[
-        SchemaField(name="properties.path", field_type="str", examples=["doc1.pdf", "doc2.pdf", "doc3.pdf"]),
-        SchemaField(
-            name="properties.entity.date", field_type="str", examples=["2022-01-01", "2022-12-31", "2023-01-01"]
-        ),
-        SchemaField(
-            name="properties.entity.revenue", field_type="float", examples=["1000000.0", "2000000.0", "3000000.0"]
-        ),
-        SchemaField(
-            name="properties.entity.firmName",
-            field_type="str",
-            examples=["Dewey, Cheatem, and Howe", "Saul Goodman & Associates", "Wolfram & Hart"],
-        ),
-        SchemaField(
-            name="text_representation", field_type="str", examples=["Can be assumed to have all other details"]
-        ),
-    ]
-)
-
-PLANNER_EXAMPLES: List[PlannerExample] = [
-    PlannerExample(
-        schema=EXAMPLE_NTSB_SCHEMA,
-        plan=LogicalPlan(
-            query="Were there any incidents in Georgia?",
-            result_node=1,
-            nodes={
-                0: QueryDatabase(
-                    node_id=0,
-                    description="Get all the incident reports",
-                    index="ntsb",
-                    query={"match_phrase": {"properties.entity.location": "Georgia"}},
-                )
-            },
-        ),
-    ),
-    PlannerExample(
-        schema=EXAMPLE_NTSB_SCHEMA,
-        plan=LogicalPlan(
-            query="Count the number of incidents containing 'foo' in the filename.",
-            result_node=1,
-            nodes={
-                0: QueryDatabase(
-                    node_id=0,
-                    description="Get all the incident reports matching 'foo' in the filename",
-                    index="ntsb",
-                    query={"match": {"properties.path.keyword": "*foo*"}},
-                ),
-                1: Count(
-                    node_id=1,
-                    description="Count the number of incidents",
-                    distinct_field="properties.entity.accidentNumber",
-                    inputs=[0],
-                ),
-            },
-        ),
-    ),
-    PlannerExample(
-        schema=EXAMPLE_NTSB_SCHEMA,
-        plan=LogicalPlan(
-            query="""Show incidents between July 1, 2023 and September 1, 2024 with an accident
- .         number containing 'K1234N' that occurred in New Mexico.""",
-            result_node=0,
-            nodes={
-                0: QueryDatabase(
-                    node_id=0,
-                    description="Get all the incident reports in the specified date range matching the accident number",
-                    index="ntsb",
-                    query={
-                        "bool": {
-                            "must": [
-                                {
-                                    "range": {
-                                        "properties.entity.isoDateTime": {
-                                            "gte": "2023-07-01T00:00:00",
-                                            "lte": "2024-09-30T23:59:59",
-                                            "format": "strict_date_optional_time",
-                                        }
-                                    }
-                                },
-                                {"match": {"properties.entity.accidentNumber.keyword": "*K1234N*"}},
-                                {"match_phrase": {"properties.entity.location": "New Mexico"}},
-                            ]
-                        }
-                    },
-                )
-            },
-        ),
-    ),
-    PlannerExample(
-        schema=EXAMPLE_NTSB_SCHEMA,
-        plan=LogicalPlan(
-            query="How many cities did Cessna aircrafts have incidents in?",
-            result_node=1,
-            nodes={
-                0: QueryDatabase(
-                    node_id=0,
-                    description="Get all the incident reports involving Cessna aircrafts",
-                    index="ntsb",
-                    query={"match_phrase": {"properties.entity.aircraft": "Cessna"}},
-                ),
-                1: Count(
-                    node_id=1,
-                    description="Count the number of cities that accidents occured in",
-                    distinct_field="properties.entity.city",
-                    inputs=[0],
-                ),
-            },
-        ),
-    ),
-    PlannerExample(
-        schema=EXAMPLE_NTSB_SCHEMA,
-        plan=LogicalPlan(
-            query="Which 5 pilots were responsible for the most incidents?",
-            result_node=2,
-            nodes={
-                0: QueryDatabase(
-                    node_id=0,
-                    description="Get all the NTSB incident reports",
-                    index="ntsb",
-                ),
-                1: LlmExtractEntity(
-                    node_id=1,
-                    description="Extract the pilot",
-                    question="Who was the pilot of this aircraft?",
-                    field="text_representation",
-                    new_field="pilot",
-                    new_field_type="str",
-                    inputs=[0],
-                ),
-                2: TopK(
-                    node_id=2,
-                    description="Return top 5 pilot names",
-                    field="properties.pilot",
-                    primary_field="properties.entity.accidentNumber",
-                    K=5,
-                    descending=True,
-                    llm_cluster=False,
-                    inputs=[1],
-                ),
-            },
-        ),
-    ),
-    PlannerExample(
-        schema=EXAMPLE_NTSB_SCHEMA,
-        plan=LogicalPlan(
-            query="What percent of incidents occurred in 2023?",
-            result_node=4,
-            nodes={
-                0: QueryDatabase(
-                    node_id=0,
-                    description="Get all the incident reports",
-                    index="ntsb",
-                ),
-                1: Count(
-                    node_id=1,
-                    description="Count the number of total incidents",
-                    distinct_field="properties.entity.accidentNumber",
-                    inputs=[0],
-                ),
-                2: BasicFilter(
-                    node_id=2,
-                    description="Filter to only include incidents in 2023",
-                    range_filter=True,
-                    query=None,
-                    start="01-01-2023",
-                    end="12-31-2023",
-                    field="properties.entity.date",
-                    is_date=True,
-                    inputs=[0],
-                ),
-                3: Count(
-                    node_id=3,
-                    description="Count the number of incidents in 2023",
-                    distinct_field="properties.entity.accidentNumber",
-                    inputs=[2],
-                ),
-                4: Math(
-                    node_id=4,
-                    description="Divide the number of incidents in 2023 by the total number",
-                    operation="divide",
-                    inputs=[3, 1],
-                ),
-            },
-        ),
-    ),
-    PlannerExample(
-        schema=EXAMPLE_NTSB_SCHEMA,
-        plan=LogicalPlan(
-            query="Were there any incidents because of sudden weather changes?",
-            result_node=0,
-            nodes={
-                0: QueryVectorDatabase(
-                    node_id=0,
-                    description="Get some incidents relating to sudden weather changes",
-                    index="ntsb",
-                    query_phrase="sudden weather changes",
-                ),
-                1: LlmFilter(
-                    node_id=1,
-                    description="Filter to only include incidents caused due to sudden weather changes",
-                    question="Did this incident occur due to sudden weather changes?",
-                    field="text_representation",
-                    inputs=[0],
-                ),
-            },
-        ),
-    ),
-    PlannerExample(
-        schema=EXAMPLE_NTSB_SCHEMA,
-        plan=LogicalPlan(
-            query="Show me some incidents relating to water causes",
-            result_node=0,
-            nodes={
-                0: QueryVectorDatabase(
-                    node_id=0,
-                    description="Get some incidents relating to water causes",
-                    index="ntsb",
-                    query_phrase="water causes",
-                ),
-                1: LlmFilter(
-                    node_id=1,
-                    description="Filter to only include incidents that occur due to water causes",
-                    question="Did this incident occur because of water causes",
-                    field="text_representation",
-                    inputs=[0],
-                ),
-            },
-        ),
-    ),
-    PlannerExample(
-        schema=EXAMPLE_FINANCIAL_SCHEMA,
-        plan=LogicalPlan(
-            query="Which 2 law firms had the highest revenue in 2022?",
-            result_node=2,
-            nodes={
-                0: QueryDatabase(
-                    node_id=0,
-                    description="Get all the financial documents from 2022",
-                    index="finance",
-                    query={
-                        "range": {
-                            "properties.entity.isoDateTime": {
-                                "gte": "2022-01-01T00:00:00",
-                                "lte": "2022-12-31T23:59:59",
-                                "format": "strict_date_optional_time",
-                            }
-                        }
-                    },
-                ),
-                1: Sort(
-                    node_id=1,
-                    description="Sort in descending order by revenue",
-                    descending=True,
-                    field="properties.entity.revenue",
-                    default_value=0,
-                    inputs=[0],
-                ),
-                2: Limit(
-                    node_id=2,
-                    description="Get the 2 law firms with highest revenue",
-                    num_records=2,
-                    inputs=[1],
-                ),
-            },
-        ),
-    ),
-]
 
 
 class Planner:
@@ -416,121 +74,23 @@ class LlmPlanner(Planner):
             data_schema.to_schema() if isinstance(data_schema, OpenSearchSchema) else data_schema
         )
 
-    @staticmethod
-    def make_operator_prompt(operator: Type[Node]) -> str:
-        """Generate the prompt fragment for the given Node."""
-
-        prompt = operator.usage() + "\n\nInput schema:\n"
-        schema = operator.input_schema()
-        for field_name, value in schema.items():
-            prompt += f"- {field_name} ({value.type_hint}): {value.description}\n"
-        prompt += "\n------------\n"
-        return prompt
-
-    @staticmethod
-    def make_schema_prompt(schema: Schema) -> str:
-        """Generate the prompt fragment for the provided schema."""
-        return schema.model_dump_json(indent=2)
-
-    def make_examples_prompt(self) -> str:
-        """Generate the prompt fragment for the query examples."""
-        prompt = "\n\nThe following examples demonstrate how to construct query plans.\n\n-- BEGIN EXAMPLES --\n\n"
-        schemas_shown = set()
-        for example_index, example in enumerate(self._examples):
-            # Avoid showing schema multiple times.
-            schema_prompt = self.make_schema_prompt(example.schema)
-            if schema_prompt not in schemas_shown:
-                prompt += f"""
-                The following is the data schema for the example queries below:
-                -- Begin example schema --\n
-                {schema_prompt}
-                \n-- End of example schema --\n
-                """
-                schemas_shown.add(schema_prompt)
-
-            prompt += f"EXAMPLE {example_index + 1}:\n"
-
-            # Get the index name for the example from the first query node that references it.
-            index_name_options = [
-                example.plan.nodes[x].index  # type: ignore
-                for x in example.plan.nodes.keys()
-                if hasattr(example.plan.nodes[x], "index")
-            ]
-            if len(index_name_options) > 0:
-                index_name = index_name_options[0]
-                prompt += f"INDEX NAME: {index_name}\n"
-            prompt += f"USER QUESTION: {example.plan.query}\n"
-            prompt += f"Answer:\n{example.plan.model_dump_json(indent=2)}\n\n"
-        prompt += "-- END EXAMPLES --\n\n"
-        return prompt
-
-    def generate_system_prompt(self, _query: str) -> str:
-        """Generate the LLM system prompt for the given query."""
-
-        # Initial prompt.
-        prompt = PLANNER_SYSTEM_PROMPT
-
-        if self._natural_language_response:
-            prompt += PLANNER_NATURAL_LANGUAGE_PROMPT
-        else:
-            prompt += PLANNER_RAW_DATA_PROMPT
-        prompt += "\n\n"
-
-        # Few-shot examples.
-        if self._examples:
-            prompt += self.make_examples_prompt()
-
-        # Operator definitions.
-        prompt += """
-        You may use the following operators to construct your query plan:
-
-        OPERATORS:
-        """
-        for operator in self._strategy.operators:
-            prompt += self.make_operator_prompt(operator)
-
-        # Data schema.
-        prompt += f"""\n\nThe following represents the schema of the data you should return a query plan for:
-
-        INDEX_NAME: {self._index}
-        DATA_SCHEMA:\n\n{self.make_schema_prompt(self._data_schema)}
-        """
-
-        return prompt
-
-    def generate_user_prompt(self, query: str) -> str:
-        """Generate the LLM user prompt for the given query."""
-
-        prompt = f"""
-        INDEX_NAME: {self._index}
-        USER QUESTION: {query}
-        Answer: """
-        return prompt
-
-    def generate_from_llm(self, question: str) -> Tuple[Any, str]:
-        """Use LLM to generate a query plan for the given question.
-
-        Returns the prompt sent to the LLM, and the plan.
-        """
-
-        messages = [
-            {
-                "role": "system",
-                "content": self.generate_system_prompt(question),
-            },
-            {
-                "role": "user",
-                "content": self.generate_user_prompt(question),
-            },
-        ]
-
-        prompt_kwargs = {"messages": messages}
-        chat_completion = self._llm_client.generate_old(prompt_kwargs=prompt_kwargs, llm_kwargs={"temperature": 0})
-        return prompt_kwargs, chat_completion
+    def generate_prompt(self, question) -> RenderedPrompt:
+        prompt = PlannerPrompt(
+            query=question,
+            examples=self._examples,
+            natural_language_response=self._natural_language_response,
+            operators=self._strategy.operators,
+            index=self._index,
+            data_schema=self._data_schema,
+        )
+        for preprocessor in self._strategy.pre_processors:
+            prompt = preprocessor(prompt)
+        return prompt.render()
 
     def plan(self, question: str) -> LogicalPlan:
         """Given a question from the user, generate a logical query plan."""
-        llm_prompt, llm_plan = self.generate_from_llm(question)
+        llm_prompt = self.generate_prompt(question)
+        llm_plan = self._llm_client.generate(prompt=llm_prompt, llm_kwargs={"temperature": 0})
         try:
             plan = process_json_plan(llm_plan)
             for processor in self._strategy.post_processors:

--- a/lib/sycamore/sycamore/query/planner_prompt.py
+++ b/lib/sycamore/sycamore/query/planner_prompt.py
@@ -1,0 +1,481 @@
+from sycamore.llms.prompts.prompts import (
+    SycamorePrompt,
+    RenderedPrompt,
+    RenderedMessage,
+)
+from sycamore.schema import Schema, SchemaField
+from sycamore.query.schema import OpenSearchSchema
+from sycamore.query.logical_plan import LogicalPlan, Node
+
+from sycamore.query.operators.query_database import QueryVectorDatabase, QueryDatabase
+from sycamore.query.operators.count import Count
+from sycamore.query.operators.llm_extract_entity import LlmExtractEntity
+from sycamore.query.operators.llm_filter import LlmFilter
+from sycamore.query.operators.basic_filter import BasicFilter
+from sycamore.query.operators.top_k import TopK
+from sycamore.query.operators.math import Math
+from sycamore.query.operators.limit import Limit
+from sycamore.query.operators.sort import Sort
+
+from typing import Optional, Union, List, Type
+from dataclasses import dataclass
+
+
+# This is the base prompt for the planner.
+PLANNER_SYSTEM_PROMPT = """You are a helpful agent that translates the user's question into a
+query plan, using a predefined set of query operators. Please adhere to the following
+guidelines when generating a plan:
+
+        1. Return your answer as a JSON dictionary containing a query plan in the format shown below.
+        2. Do not return any information except a single JSON object. This means not repeating the question
+            or providing any text outside the json block.
+        3. Only use the query operators described below.
+        4. Only use EXACT field names from the DATA_SCHEMA described below and fields created
+            from *LlmExtractEntity*. Any new fields created by *LlmExtractEntity* will be nested in properties.
+            e.g. if a new field called "state" is added, when referencing it in another operation,
+            you should use "properties.state". A database returned from *TopK* operation only has
+            "properties.key" or "properties.count"; you can only reference one of those fields.
+            Other than those, DO NOT USE ANY OTHER FIELD NAMES.
+        5. If an optional field does not have a value in the query plan, return null in its place.
+        6. The first step of each plan MUST be a **QueryDatabase** or **QueryVectorDatabase" operation.
+            Whenever possible, include all possible filtering operations in the first step.
+           That is, you should strive to construct an OpenSearch query that filters the data as
+           much as possible, reducing the need for further query operations. If using a QueryVectorDatabase, always
+              follow it with an LlmFilter operation to ensure the final results are accurate.
+"""
+
+# Variants on the last step in the query plan, based on whether the user has requested raw data
+# or a natural language response.
+PLANNER_RAW_DATA_PROMPT = "7. The last step of each plan should return the raw data associated with the response."
+PLANNER_NATURAL_LANGUAGE_PROMPT = (
+    "7. The last step of each plan *MUST* be a **SummarizeData** operation that returns a natural language response."
+)
+
+
+@dataclass
+class PlannerExample:
+    """Represents an example query and query plan for the planner."""
+
+    def __init__(self, schema: Union[OpenSearchSchema, Schema], plan: LogicalPlan) -> None:
+        super().__init__()
+        self.plan = plan
+        self.schema: Schema = schema.to_schema() if isinstance(schema, OpenSearchSchema) else schema
+
+
+# Example schema and planner examples for the NTSB and financial datasets.
+EXAMPLE_NTSB_SCHEMA = Schema(
+    fields=[
+        SchemaField(
+            name="properties.path",
+            field_type="str",
+            examples=["/docs/incident1.pdf", "/docs/incident2.pdf", "/docs/incident3.pdf"],
+        ),
+        SchemaField(name="properties.entity.date", field_type="date", examples=["2023-07-01", "2024-09-01"]),
+        SchemaField(name="properties.entity.accidentNumber", field_type="str", examples=["1234", "5678", "91011"]),
+        SchemaField(
+            name="properties.entity.location",
+            field_type="str",
+            examples=["Atlanta, Georgia", "Miami, Florida", "San Diego, California"],
+        ),
+        SchemaField(name="properties.entity.aircraft", field_type="str", examples=["Cessna", "Boeing", "Airbus"]),
+        SchemaField(name="properties.entity.city", field_type="str", examples=["Atlanta", "Savannah", "Augusta"]),
+        SchemaField(
+            name="text_representation", field_type="str", examples=["Can be assumed to have all other details"]
+        ),
+    ]
+)
+
+EXAMPLE_FINANCIAL_SCHEMA = Schema(
+    fields=[
+        SchemaField(name="properties.path", field_type="str", examples=["doc1.pdf", "doc2.pdf", "doc3.pdf"]),
+        SchemaField(
+            name="properties.entity.date", field_type="str", examples=["2022-01-01", "2022-12-31", "2023-01-01"]
+        ),
+        SchemaField(
+            name="properties.entity.revenue", field_type="float", examples=["1000000.0", "2000000.0", "3000000.0"]
+        ),
+        SchemaField(
+            name="properties.entity.firmName",
+            field_type="str",
+            examples=["Dewey, Cheatem, and Howe", "Saul Goodman & Associates", "Wolfram & Hart"],
+        ),
+        SchemaField(
+            name="text_representation", field_type="str", examples=["Can be assumed to have all other details"]
+        ),
+    ]
+)
+
+PLANNER_EXAMPLES: List[PlannerExample] = [
+    PlannerExample(
+        schema=EXAMPLE_NTSB_SCHEMA,
+        plan=LogicalPlan(
+            query="Were there any incidents in Georgia?",
+            result_node=1,
+            nodes={
+                0: QueryDatabase(
+                    node_id=0,
+                    description="Get all the incident reports",
+                    index="ntsb",
+                    query={"match_phrase": {"properties.entity.location": "Georgia"}},
+                )
+            },
+        ),
+    ),
+    PlannerExample(
+        schema=EXAMPLE_NTSB_SCHEMA,
+        plan=LogicalPlan(
+            query="Count the number of incidents containing 'foo' in the filename.",
+            result_node=1,
+            nodes={
+                0: QueryDatabase(
+                    node_id=0,
+                    description="Get all the incident reports matching 'foo' in the filename",
+                    index="ntsb",
+                    query={"match": {"properties.path.keyword": "*foo*"}},
+                ),
+                1: Count(
+                    node_id=1,
+                    description="Count the number of incidents",
+                    distinct_field="properties.entity.accidentNumber",
+                    inputs=[0],
+                ),
+            },
+        ),
+    ),
+    PlannerExample(
+        schema=EXAMPLE_NTSB_SCHEMA,
+        plan=LogicalPlan(
+            query="""Show incidents between July 1, 2023 and September 1, 2024 with an accident
+ .         number containing 'K1234N' that occurred in New Mexico.""",
+            result_node=0,
+            nodes={
+                0: QueryDatabase(
+                    node_id=0,
+                    description="Get all the incident reports in the specified date range matching the accident number",
+                    index="ntsb",
+                    query={
+                        "bool": {
+                            "must": [
+                                {
+                                    "range": {
+                                        "properties.entity.isoDateTime": {
+                                            "gte": "2023-07-01T00:00:00",
+                                            "lte": "2024-09-30T23:59:59",
+                                            "format": "strict_date_optional_time",
+                                        }
+                                    }
+                                },
+                                {"match": {"properties.entity.accidentNumber.keyword": "*K1234N*"}},
+                                {"match_phrase": {"properties.entity.location": "New Mexico"}},
+                            ]
+                        }
+                    },
+                )
+            },
+        ),
+    ),
+    PlannerExample(
+        schema=EXAMPLE_NTSB_SCHEMA,
+        plan=LogicalPlan(
+            query="How many cities did Cessna aircrafts have incidents in?",
+            result_node=1,
+            nodes={
+                0: QueryDatabase(
+                    node_id=0,
+                    description="Get all the incident reports involving Cessna aircrafts",
+                    index="ntsb",
+                    query={"match_phrase": {"properties.entity.aircraft": "Cessna"}},
+                ),
+                1: Count(
+                    node_id=1,
+                    description="Count the number of cities that accidents occured in",
+                    distinct_field="properties.entity.city",
+                    inputs=[0],
+                ),
+            },
+        ),
+    ),
+    PlannerExample(
+        schema=EXAMPLE_NTSB_SCHEMA,
+        plan=LogicalPlan(
+            query="Which 5 pilots were responsible for the most incidents?",
+            result_node=2,
+            nodes={
+                0: QueryDatabase(
+                    node_id=0,
+                    description="Get all the NTSB incident reports",
+                    index="ntsb",
+                ),
+                1: LlmExtractEntity(
+                    node_id=1,
+                    description="Extract the pilot",
+                    question="Who was the pilot of this aircraft?",
+                    field="text_representation",
+                    new_field="pilot",
+                    new_field_type="str",
+                    inputs=[0],
+                ),
+                2: TopK(
+                    node_id=2,
+                    description="Return top 5 pilot names",
+                    field="properties.pilot",
+                    primary_field="properties.entity.accidentNumber",
+                    K=5,
+                    descending=True,
+                    llm_cluster=False,
+                    inputs=[1],
+                ),
+            },
+        ),
+    ),
+    PlannerExample(
+        schema=EXAMPLE_NTSB_SCHEMA,
+        plan=LogicalPlan(
+            query="What percent of incidents occurred in 2023?",
+            result_node=4,
+            nodes={
+                0: QueryDatabase(
+                    node_id=0,
+                    description="Get all the incident reports",
+                    index="ntsb",
+                ),
+                1: Count(
+                    node_id=1,
+                    description="Count the number of total incidents",
+                    distinct_field="properties.entity.accidentNumber",
+                    inputs=[0],
+                ),
+                2: BasicFilter(
+                    node_id=2,
+                    description="Filter to only include incidents in 2023",
+                    range_filter=True,
+                    query=None,
+                    start="01-01-2023",
+                    end="12-31-2023",
+                    field="properties.entity.date",
+                    is_date=True,
+                    inputs=[0],
+                ),
+                3: Count(
+                    node_id=3,
+                    description="Count the number of incidents in 2023",
+                    distinct_field="properties.entity.accidentNumber",
+                    inputs=[2],
+                ),
+                4: Math(
+                    node_id=4,
+                    description="Divide the number of incidents in 2023 by the total number",
+                    operation="divide",
+                    inputs=[3, 1],
+                ),
+            },
+        ),
+    ),
+    PlannerExample(
+        schema=EXAMPLE_NTSB_SCHEMA,
+        plan=LogicalPlan(
+            query="Were there any incidents because of sudden weather changes?",
+            result_node=0,
+            nodes={
+                0: QueryVectorDatabase(
+                    node_id=0,
+                    description="Get some incidents relating to sudden weather changes",
+                    index="ntsb",
+                    query_phrase="sudden weather changes",
+                ),
+                1: LlmFilter(
+                    node_id=1,
+                    description="Filter to only include incidents caused due to sudden weather changes",
+                    question="Did this incident occur due to sudden weather changes?",
+                    field="text_representation",
+                    inputs=[0],
+                ),
+            },
+        ),
+    ),
+    PlannerExample(
+        schema=EXAMPLE_NTSB_SCHEMA,
+        plan=LogicalPlan(
+            query="Show me some incidents relating to water causes",
+            result_node=0,
+            nodes={
+                0: QueryVectorDatabase(
+                    node_id=0,
+                    description="Get some incidents relating to water causes",
+                    index="ntsb",
+                    query_phrase="water causes",
+                ),
+                1: LlmFilter(
+                    node_id=1,
+                    description="Filter to only include incidents that occur due to water causes",
+                    question="Did this incident occur because of water causes",
+                    field="text_representation",
+                    inputs=[0],
+                ),
+            },
+        ),
+    ),
+    PlannerExample(
+        schema=EXAMPLE_FINANCIAL_SCHEMA,
+        plan=LogicalPlan(
+            query="Which 2 law firms had the highest revenue in 2022?",
+            result_node=2,
+            nodes={
+                0: QueryDatabase(
+                    node_id=0,
+                    description="Get all the financial documents from 2022",
+                    index="finance",
+                    query={
+                        "range": {
+                            "properties.entity.isoDateTime": {
+                                "gte": "2022-01-01T00:00:00",
+                                "lte": "2022-12-31T23:59:59",
+                                "format": "strict_date_optional_time",
+                            }
+                        }
+                    },
+                ),
+                1: Sort(
+                    node_id=1,
+                    description="Sort in descending order by revenue",
+                    descending=True,
+                    field="properties.entity.revenue",
+                    default_value=0,
+                    inputs=[0],
+                ),
+                2: Limit(
+                    node_id=2,
+                    description="Get the 2 law firms with highest revenue",
+                    num_records=2,
+                    inputs=[1],
+                ),
+            },
+        ),
+    ),
+]
+
+
+class PlannerPrompt(SycamorePrompt):
+    def __init__(
+        self,
+        query: str,
+        examples: List[PlannerExample] = [],
+        natural_language_response: bool = True,
+        operators: List[Type[Node]] = [],
+        index: Optional[str] = None,
+        data_schema: Optional[Schema] = None,
+        planner_system_prompt: str = PLANNER_SYSTEM_PROMPT,
+        planner_natural_language_prompt: str = PLANNER_NATURAL_LANGUAGE_PROMPT,
+        planner_raw_data_prompt: str = PLANNER_RAW_DATA_PROMPT,
+    ):
+        self.query = query
+        self.examples = examples
+        self.natural_language_response = natural_language_response
+        self.operators = operators
+        self.index = index
+        self.data_schema = data_schema
+        self.planner_system_prompt = planner_system_prompt
+        self.planner_natural_language_prompt = planner_natural_language_prompt
+        self.planner_raw_data_prompt = planner_raw_data_prompt
+
+    @staticmethod
+    def make_operator_prompt(operator: type[Node]) -> str:
+        """Generate the prompt fragment for the given Node."""
+
+        prompt = operator.usage() + "\n\nInput schema:\n"
+        schema = operator.input_schema()
+        for field_name, value in schema.items():
+            prompt += f"- {field_name} ({value.type_hint}): {value.description}\n"
+        prompt += "\n------------\n"
+        return prompt
+
+    @staticmethod
+    def make_schema_prompt(schema: Schema) -> str:
+        """Generate the prompt fragment for the provided schema."""
+        return schema.model_dump_json(indent=2)
+
+    def make_examples_prompt(self) -> str:
+        """Generate the prompt fragment for the query examples."""
+        prompt = "\n\nThe following examples demonstrate how to construct query plans.\n\n-- BEGIN EXAMPLES --\n\n"
+        schemas_shown = set()
+        for example_index, example in enumerate(self.examples):
+            # Avoid showing schema multiple times.
+            schema_prompt = self.make_schema_prompt(example.schema)
+            if schema_prompt not in schemas_shown:
+                prompt += f"""
+                The following is the data schema for the example queries below:
+                -- Begin example schema --\n
+                {schema_prompt}
+                \n-- End of example schema --\n
+                """
+                schemas_shown.add(schema_prompt)
+
+            prompt += f"EXAMPLE {example_index + 1}:\n"
+
+            # Get the index name for the example from the first query node that references it.
+            index_name_options = [
+                example.plan.nodes[x].index  # type: ignore
+                for x in example.plan.nodes.keys()
+                if hasattr(example.plan.nodes[x], "index")
+            ]
+            if len(index_name_options) > 0:
+                index_name = index_name_options[0]
+                prompt += f"INDEX NAME: {index_name}\n"
+            prompt += f"USER QUESTION: {example.plan.query}\n"
+            prompt += f"Answer:\n{example.plan.model_dump_json(indent=2)}\n\n"
+        prompt += "-- END EXAMPLES --\n\n"
+        return prompt
+
+    def generate_system_prompt(self, _query: str) -> str:
+        """Generate the LLM system prompt for the given query."""
+        assert self.data_schema is not None, "data_schema is not set yet, cannot generate prompt"
+
+        # Initial prompt.
+        prompt = self.planner_system_prompt
+
+        if self.natural_language_response:
+            prompt += self.planner_natural_language_prompt
+        else:
+            prompt += self.planner_raw_data_prompt
+        prompt += "\n\n"
+
+        # Few-shot examples.
+        if self.examples:
+            prompt += self.make_examples_prompt()
+
+        # Operator definitions.
+        prompt += """
+        You may use the following operators to construct your query plan:
+
+        OPERATORS:
+        """
+        for operator in self.operators:
+            prompt += self.make_operator_prompt(operator)
+
+        # Data schema.
+        prompt += f"""\n\nThe following represents the schema of the data you should return a query plan for:
+
+        INDEX_NAME: {self.index}
+        DATA_SCHEMA:\n\n{self.make_schema_prompt(self.data_schema)}
+        """
+
+        return prompt
+
+    def generate_user_prompt(self, query: str) -> str:
+        """Generate the LLM user prompt for the given query."""
+
+        prompt = f"""
+        INDEX_NAME: {self.index}
+        USER QUESTION: {query}
+        Answer: """
+        return prompt
+
+    def render(self) -> RenderedPrompt:
+        sys = self.generate_system_prompt(self.query)
+        usr = self.generate_user_prompt(self.query)
+        return RenderedPrompt(
+            messages=[
+                RenderedMessage(role="system", content=sys),
+                RenderedMessage(role="user", content=usr),
+            ]
+        )

--- a/lib/sycamore/sycamore/query/strategy.py
+++ b/lib/sycamore/sycamore/query/strategy.py
@@ -178,13 +178,13 @@ class QueryPlanStrategy:
     def __init__(
         self,
         operators: Optional[list[Type[Node]]] = None,
-        post_processors: Optional[list[LogicalPlanProcessor]] = None,
-        pre_processors: Optional[list[PlannerPromptProcessor]] = None,
+        plan_processors: Optional[list[LogicalPlanProcessor]] = None,
+        prompt_processors: Optional[list[PlannerPromptProcessor]] = None,
     ) -> None:
         super().__init__()
         self.operators: list[Type[Node]] = operators or []
-        self.post_processors: list[LogicalPlanProcessor] = post_processors or []
-        self.pre_processors: list[PlannerPromptProcessor] = pre_processors or []
+        self.plan_processors: list[LogicalPlanProcessor] = plan_processors or []
+        self.prompt_processors: list[PlannerPromptProcessor] = prompt_processors or []
 
 
 class DefaultQueryPlanStrategy(QueryPlanStrategy):
@@ -192,8 +192,12 @@ class DefaultQueryPlanStrategy(QueryPlanStrategy):
     Default strategy that uses all available tools and optimizes result correctness.
     """
 
-    def __init__(self, post_processors: Optional[list[LogicalPlanProcessor]] = None) -> None:
-        super().__init__(ALL_OPERATORS, post_processors)
+    def __init__(
+        self,
+        plan_processors: Optional[list[LogicalPlanProcessor]] = None,
+        prompt_processors: Optional[list[PlannerPromptProcessor]] = None,
+    ) -> None:
+        super().__init__(ALL_OPERATORS, plan_processors, prompt_processors)
 
 
 class VectorSearchOnlyStrategy(QueryPlanStrategy):
@@ -202,5 +206,11 @@ class VectorSearchOnlyStrategy(QueryPlanStrategy):
     is smaller and vector search retrievals are sufficient to provide answers.
     """
 
-    def __init__(self, post_processors: Optional[list[LogicalPlanProcessor]] = None) -> None:
-        super().__init__([op for op in ALL_OPERATORS if op not in {QueryDatabase}], post_processors or [])
+    def __init__(
+        self,
+        plan_processors: Optional[list[LogicalPlanProcessor]] = None,
+        prompt_processors: Optional[list[PlannerPromptProcessor]] = None,
+    ) -> None:
+        super().__init__(
+            [op for op in ALL_OPERATORS if op not in {QueryDatabase}], plan_processors or [], prompt_processors
+        )

--- a/lib/sycamore/sycamore/query/strategy.py
+++ b/lib/sycamore/sycamore/query/strategy.py
@@ -14,6 +14,7 @@ from sycamore.query.operators.query_database import QueryDatabase, QueryVectorDa
 from sycamore.query.operators.sort import Sort
 from sycamore.query.operators.summarize_data import SummarizeData
 from sycamore.query.operators.top_k import TopK
+from sycamore.query.planner_prompt import PlannerPrompt
 
 ALL_OPERATORS: list[type[Node]] = [
     QueryDatabase,
@@ -35,6 +36,12 @@ class LogicalPlanProcessor:
         """Given the LogicalPlan query plan, postprocess it using a set of rules that modify the plan for
         optimizing or other purposes."""
         return plan
+
+
+class PlannerPromptProcessor:
+    def __call__(self, prompt: PlannerPrompt) -> PlannerPrompt:
+        """Apply code to change the prompt used by the planner"""
+        return prompt
 
 
 class DefaultPlanValidator(LogicalPlanProcessor):
@@ -169,11 +176,15 @@ class QueryPlanStrategy:
     """
 
     def __init__(
-        self, operators: Optional[list[Type[Node]]] = None, post_processors: Optional[list[LogicalPlanProcessor]] = None
+        self,
+        operators: Optional[list[Type[Node]]] = None,
+        post_processors: Optional[list[LogicalPlanProcessor]] = None,
+        pre_processors: Optional[list[PlannerPromptProcessor]] = None,
     ) -> None:
         super().__init__()
         self.operators: list[Type[Node]] = operators or []
         self.post_processors: list[LogicalPlanProcessor] = post_processors or []
+        self.pre_processors: list[PlannerPromptProcessor] = pre_processors or []
 
 
 class DefaultQueryPlanStrategy(QueryPlanStrategy):

--- a/lib/sycamore/sycamore/tests/integration/query/execution/test_operations.py
+++ b/lib/sycamore/sycamore/tests/integration/query/execution/test_operations.py
@@ -15,7 +15,7 @@ from sycamore.transforms.partition import UnstructuredPdfPartitioner
 
 @pytest.fixture(scope="class")
 def llm():
-    llm = OpenAI(OpenAIModels.GPT_3_5_TURBO)
+    llm = OpenAI(OpenAIModels.GPT_4_1_MINI)
 
     yield llm
 

--- a/lib/sycamore/sycamore/tests/unit/query/test_planner.py
+++ b/lib/sycamore/sycamore/tests/unit/query/test_planner.py
@@ -43,8 +43,9 @@ def test_generate_system_prompt(mock_schema):
         llm_client=mock_llm_client,
         natural_language_response=True,
     )
-    prompt = planner.generate_system_prompt("Test query")
-    assert "The last step of each plan *MUST* be a **SummarizeData** operation" in prompt
+    prompt = planner.generate_prompt("Test query")
+    system = prompt.messages[0].content
+    assert "The last step of each plan *MUST* be a **SummarizeData** operation" in system
 
     planner = LlmPlanner(
         index,
@@ -54,8 +55,10 @@ def test_generate_system_prompt(mock_schema):
         llm_client=mock_llm_client,
         natural_language_response=False,
     )
-    prompt = planner.generate_system_prompt("Test query")
-    assert "The last step of each plan should return the raw data" in prompt
+
+    prompt = planner.generate_prompt("Test query")
+    system = prompt.messages[0].content
+    assert "The last step of each plan should return the raw data" in system
 
 
 def test_llm_planner(mock_os_config, mock_os_client, mock_llm_client, mock_schema, monkeypatch):
@@ -74,18 +77,15 @@ def test_llm_planner(mock_os_config, mock_os_client, mock_llm_client, mock_schem
             1: Count(
                 node_id=1,
                 description="Count the number of incidents",
-                field=None,
+                distinct_field=None,
                 inputs=[0],
             ),
         },
     )
     llm_plan.llm_plan = llm_plan.model_dump_json()
 
-    # Mock the generate_from_llm method to return a static JSON object
-    def mock_generate_from_llm(_self, _query):
-        return "Dummy LLM prompt", llm_plan.model_dump_json()
-
-    monkeypatch.setattr(LlmPlanner, "generate_from_llm", mock_generate_from_llm)
+    # Mock the llm to return a static JSON object
+    mock_llm_client.generate.return_value = llm_plan.model_dump_json()
 
     planner = LlmPlanner(
         index,

--- a/lib/sycamore/sycamore/tests/unit/query/test_strategy.py
+++ b/lib/sycamore/sycamore/tests/unit/query/test_strategy.py
@@ -26,21 +26,21 @@ class DummyLLMClient(LLM):
 class TestStrategies(unittest.TestCase):
     def test_default(self):
         processor = RemoveVectorSearchForAnalytics(DummyLLMClient("test_model", LLMMode.SYNC))
-        strategy = DefaultQueryPlanStrategy(post_processors=[processor])
+        strategy = DefaultQueryPlanStrategy(plan_processors=[processor])
 
-        assert len(strategy.post_processors) == 1
-        assert isinstance(strategy.post_processors[0], RemoveVectorSearchForAnalytics)
+        assert len(strategy.plan_processors) == 1
+        assert isinstance(strategy.plan_processors[0], RemoveVectorSearchForAnalytics)
         assert strategy.operators == ALL_OPERATORS
 
     def test_vector_search_only(self):
         processor = RemoveVectorSearchForAnalytics(DummyLLMClient("test_model", LLMMode.SYNC))
 
-        strategy = VectorSearchOnlyStrategy(post_processors=[])
-        assert strategy.post_processors == []
+        strategy = VectorSearchOnlyStrategy(plan_processors=[])
+        assert strategy.plan_processors == []
         assert QueryDatabase not in strategy.operators
 
-        strategy = VectorSearchOnlyStrategy(post_processors=[processor])
-        assert strategy.post_processors == [processor]
+        strategy = VectorSearchOnlyStrategy(plan_processors=[processor])
+        assert strategy.plan_processors == [processor]
         assert QueryDatabase not in strategy.operators
 
 
@@ -50,8 +50,8 @@ class TestRemoveVectorSearchForAnalytics(unittest.TestCase):
 
     def test_operators(self):
         processor = RemoveVectorSearchForAnalytics(DummyLLMClient("test_model", default_mode=LLMMode.SYNC))
-        strategy = VectorSearchOnlyStrategy(post_processors=[processor])
-        assert strategy.post_processors == [processor]
+        strategy = VectorSearchOnlyStrategy(plan_processors=[processor])
+        assert strategy.plan_processors == [processor]
         assert QueryDatabase not in strategy.operators
 
     @staticmethod


### PR DESCRIPTION
1. Turns the planner prompt generation into a sycamore prompt object - i.e. separate prompt construction time from prompt rendering time
2. This lets us stick additional processing steps in between for intermediate mutations, e.g. rewrite question

p.s. do I need to make this work in the private planner too?