### PR TITLE
Fix fast notebook tests

### DIFF
--- a/lib/sycamore/sycamore/transforms/base_llm.py
+++ b/lib/sycamore/sycamore/transforms/base_llm.py
@@ -1,3 +1,4 @@
+import threading
 from typing import Optional, Sequence, Callable, Union
 
 from sycamore.llms.llms import LLM, LLMMode
@@ -13,6 +14,11 @@ async def _infer_prompts_async(prompts: list[RenderedPrompt], llm: LLM) -> list[
     awaitables = [llm.generate_async(prompt=p, llm_kwargs={}) for p in prompts]
     tasks = [el.create_task(aw) for aw in awaitables]
     return await asyncio.gather(*tasks)
+
+
+def _run_new_thread(loop: asyncio.AbstractEventLoop) -> None:
+    asyncio.set_event_loop(loop)
+    loop.run_forever()
 
 
 def _infer_prompts(
@@ -32,8 +38,25 @@ def _infer_prompts(
     elif llm_mode == LLMMode.ASYNC:
         nonempty = [(i, p) for i, p in enumerate(prompts) if len(p.messages) > 0]
         res = [""] * len(prompts)
-        rsps = asyncio.run(_infer_prompts_async([p for _, p in nonempty], llm))
-        for (i, _), rs in zip(nonempty, rsps):
+
+        # Previously we would use asyncio.run here, but that causes issues in
+        # environments like Jupyter notebooks where an event loop is already
+        # running. To workaround this we create a separate event loop on a new
+        # thread and run the tasks there.
+        new_loop = asyncio.new_event_loop()
+        t = threading.Thread(target=_run_new_thread, args=(new_loop,), daemon=True)
+        t.start()
+
+        fut = asyncio.run_coroutine_threadsafe(_infer_prompts_async([p for _, p in nonempty], llm), new_loop)
+
+        responses = fut.result()
+        print(responses)
+
+        new_loop.call_soon_threadsafe(new_loop.stop)
+        t.join()
+        new_loop.close()
+
+        for (i, _), rs in zip(nonempty, responses):
             res[i] = rs
         return res
     elif llm_mode == LLMMode.BATCH:

--- a/lib/sycamore/sycamore/transforms/base_llm.py
+++ b/lib/sycamore/sycamore/transforms/base_llm.py
@@ -50,7 +50,6 @@ def _infer_prompts(
         fut = asyncio.run_coroutine_threadsafe(_infer_prompts_async([p for _, p in nonempty], llm), new_loop)
 
         responses = fut.result()
-        print(responses)
 
         new_loop.call_soon_threadsafe(new_loop.stop)
         t.join()

--- a/notebooks/default-prep-script.ipynb
+++ b/notebooks/default-prep-script.ipynb
@@ -216,7 +216,7 @@
     "        print(\"WARNING: import_pdf called with empty directory\")\n",
     "        return\n",
     "\n",
-    "    openai_llm = OpenAI(OpenAIModels.GPT_3_5_TURBO_INSTRUCT.value)\n",
+    "    openai_llm = OpenAI(OpenAIModels.GPT_4O_MINI.value)\n",
     "    tokenizer = HuggingFaceTokenizer(\"sentence-transformers/all-MiniLM-L6-v2\")\n",
     "    merger = GreedyTextElementMerger(tokenizer, 256)\n",
     "\n",
@@ -346,7 +346,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/notebooks/run-notebook-tests.sh
+++ b/notebooks/run-notebook-tests.sh
@@ -76,6 +76,12 @@ config() {
         unpickle_query.ipynb # looking for uncommitted file
         weaviate-writer.ipynb # path not set to files
         aryn-opensearch-bedrock-rag-example.ipynb
+
+        earnings_calls_notebooks/workshop_nb_0.ipynb
+        earnings_calls_notebooks/workshop_nb_1.ipynb
+        earnings_calls_notebooks/workshop_nb_2.ipynb
+        earnings_calls_notebooks/workshop_nb_3.ipynb
+        earnings_calls_notebooks/workshop_nb_4.ipynb
     )
 }
 


### PR DESCRIPTION
This PR combines two commits in an attempt to the get the fast notebook tests to pass. 

Previously the _infer_prompt method would call asyncio.run to start up an
event loop in the case that an LLM was in async mode. This causes issues in
environments like Jupyter notebooks that already have a running event loop. To
avoid conflicts, we modify this to start a new thread and run the new event
loop there.

I also switched from GPT_3_5_TURBO_INSTRUCT to GPT_4O_MINI to avoid context errors. 