### PR TITLE
Fix issue with nested_lookup utility.

### DIFF
--- a/lib/sycamore/sycamore/tests/unit/data/test_element.py
+++ b/lib/sycamore/sycamore/tests/unit/data/test_element.py
@@ -1,4 +1,5 @@
-from sycamore.data.element import create_element, Element, ImageElement
+from sycamore.data.element import create_element, Element, ImageElement, TableElement
+from sycamore.data.table import Table, TableCell
 
 
 def test_create_element_bad_type():
@@ -10,3 +11,23 @@ def test_create_element_bad_type():
 
     e = create_element(type="iMaGE")
     assert isinstance(e, ImageElement)
+
+
+def test_field_to_value_table():
+    table = Table(
+        [
+            TableCell(content="head1", rows=[0], cols=[0], is_header=True),
+            TableCell(content="head2", rows=[0], cols=[1], is_header=True),
+            TableCell(content="3", rows=[1], cols=[0], is_header=False),
+            TableCell(content="4", rows=[1], cols=[1], is_header=False),
+        ]
+    )
+
+    elem = create_element(type="table", table=table, properties={"parent": {"child1": 1, "child2": 2}})
+    assert isinstance(elem, TableElement)
+
+    assert elem.field_to_value("properties.parent.child1") == 1
+    assert elem.field_to_value("properties.parent.child2") == 2
+    assert elem.field_to_value("properties.parent.child3") is None
+
+    assert elem.field_to_value("text_representation") == "head1,head2\n3,4\n"

--- a/lib/sycamore/sycamore/utils/nested.py
+++ b/lib/sycamore/sycamore/utils/nested.py
@@ -7,7 +7,14 @@ def nested_lookup(d: Any, keys: list[str]) -> Any:
         if d is None:
             return None
         try:
-            d = d.get(keys[0])
+            if isinstance(d, str) and hasattr(d, keys[0]):
+                # This is necessary to handle attributes with a property
+                # getter that returns something different than what's in the
+                # underlying dict. For example the text_representation for
+                # a TableElement.
+                d = getattr(d, keys[0])
+            else:
+                d = d.get(keys[0])
         except AttributeError:
             return None
 


### PR DESCRIPTION
This method is used in some of the Jinja prompt formatters via Element::field_to_value. It previously assumed the object it was traversing was a dict and used the get method to look up values. In elements, this bypassed the @property getters, which could lead to incorrect values. I observed the text_representation of a TableElement being null, because the value is set to the csv representation of the table in the getter.