### PR TITLE
allow planner customization via prompt specification

### DIFF
--- a/lib/sycamore/sycamore/llms/prompts/prompts.py
+++ b/lib/sycamore/sycamore/llms/prompts/prompts.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Any, Union, Optional, Callable, TYPE_CHECKING
+from typing_extensions import Self
 import copy
 
 import pydantic
@@ -101,7 +102,7 @@ class SycamorePrompt:
             A fully rendered prompt that can be sent to an LLM for inference"""
         raise NotImplementedError(f"render_multiple_documents is not implemented for {self.__class__.__name__}")
 
-    def fork(self, **kwargs: Any) -> "SycamorePrompt":
+    def fork(self, **kwargs: Any) -> Self:
         """Create a new prompt with some fields changed.
 
         Args:

--- a/lib/sycamore/sycamore/query/client.py
+++ b/lib/sycamore/sycamore/query/client.py
@@ -183,7 +183,7 @@ class SycamoreQueryClient:
         self,
         query: str,
         index: str,
-        schema: Union[Schema, OpenSearchSchema],
+        schema: Union[Schema, OpenSearchSchema, None] = None,
         examples: Optional[List[PlannerExample]] = None,
         natural_language_response: bool = False,
     ) -> LogicalPlan:
@@ -199,6 +199,7 @@ class SycamoreQueryClient:
         """
         planner: Planner
         if self.query_planner is None:
+            schema = schema or self.get_opensearch_schema(index)
             llm_client = self.context.params.get("default", {}).get("llm")
             if not llm_client:
                 llm_client = OpenAI(OpenAIModels.GPT_4O.value, cache=cache_from_path(self.llm_cache_dir))
@@ -243,8 +244,7 @@ class SycamoreQueryClient:
         codegen_mode: bool = False,
     ) -> SycamoreQueryResult:
         """Run a query against the given index."""
-        schema = self.get_opensearch_schema(index)
-        plan = self.generate_plan(query, index, schema)
+        plan = self.generate_plan(query, index)
         return self.run_plan(plan, dry_run=dry_run, codegen_mode=codegen_mode)
 
     def dump_traces(self, result: SycamoreQueryResult, limit: int = 5):

--- a/lib/sycamore/sycamore/query/planner.py
+++ b/lib/sycamore/sycamore/query/planner.py
@@ -1,7 +1,7 @@
 import logging
 import typing
 from abc import abstractmethod
-from typing import List, Optional, Union, cast
+from typing import List, Optional, Union
 
 from sycamore.schema import Schema
 
@@ -88,8 +88,8 @@ class LlmPlanner(Planner):
             )
         else:
             prompt = self._prompt.fork(query=question)
-            # Typechecking.
-            prompt = cast(PlannerPrompt, prompt)
+            if prompt.data_schema is None:
+                prompt = prompt.fork(data_schema=self._data_schema)
 
         for preprocessor in self._strategy.prompt_processors:
             prompt = preprocessor(prompt)

--- a/lib/sycamore/sycamore/query/planner_prompt.py
+++ b/lib/sycamore/sycamore/query/planner_prompt.py
@@ -358,7 +358,7 @@ PLANNER_EXAMPLES: List[PlannerExample] = [
 class PlannerPrompt(SycamorePrompt):
     def __init__(
         self,
-        query: str,
+        query: Optional[str] = None,
         examples: List[PlannerExample] = [],
         natural_language_response: bool = True,
         operators: List[Type[Node]] = [],
@@ -471,6 +471,7 @@ class PlannerPrompt(SycamorePrompt):
         return prompt
 
     def render(self) -> RenderedPrompt:
+        assert self.query is not None, "Query is not set. Please set it with prompt.fork(query=...)"
         sys = self.generate_system_prompt(self.query)
         usr = self.generate_user_prompt(self.query)
         return RenderedPrompt(


### PR DESCRIPTION
Upstreaming(ish)
This will let me instantiate the prompt on my own terms, which is preferable to hacky prompt processors that simply replace bits because python lets you do that.
- Planner can hold a base prompt rather than constructing it from scratch at runtime
- Factor out the llm_output parsing code. This should help with converging other planners if we get to that.
- Only get the opensearch schema if I absolutely need it.
