### PR TITLE
Add OpenAI reasoning models.

### DIFF
--- a/lib/sycamore/sycamore/llms/config.py
+++ b/lib/sycamore/sycamore/llms/config.py
@@ -93,6 +93,9 @@ class OpenAIModels(Enum):
     GPT_4_1_MINI = OpenAIModel(name="gpt-4.1-mini", is_chat=True)
     GPT_4_1_NANO = OpenAIModel(name="gpt-4.1-nano", is_chat=True)
 
+    O4_MINI = OpenAIModel(name="o4-mini", is_chat=True)
+    O3 = OpenAIModel(name="o3", is_chat=True)
+
     @classmethod
     def from_name(cls, name: str):
         for m in iter(cls):

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -319,9 +319,12 @@ class OpenAI(LLM):
 
     def _get_generate_kwargs(self, prompt: RenderedPrompt, llm_kwargs: Optional[dict] = None) -> dict:
         kwargs = {
-            "temperature": 0,
             **(llm_kwargs or {}),
         }
+
+        if not self.model.name.startswith("o"):
+            kwargs["temperature"] = 0
+
         if "SYCAMORE_OPENAI_USER" in os.environ:
             kwargs.update({"user": os.environ.get("SYCAMORE_OPENAI_USER")})
 

--- a/lib/sycamore/sycamore/tests/integration/llms/test_openai.py
+++ b/lib/sycamore/sycamore/tests/integration/llms/test_openai.py
@@ -240,6 +240,12 @@ def test_default_llm_kwargs():
     assert num_tokens <= 5, f"Expected max_tokens to be 5, but got {num_tokens} tokens in the response: {res}"
 
 
+def test_reasoning_model():
+    llm = OpenAI(OpenAIModels.O4_MINI)
+    res = llm.generate(prompt=TestPrompt().render_generic())
+    assert len(res) > 0
+
+
 @pytest.fixture(scope="module")
 def azure_llm():
     # Note this deployment name is different from the official model name, which has a '.'


### PR DESCRIPTION
Adds o4-mini and o3. These models don't accept the temperature parameter, so we omit it for the o* series.