### PR TITLE
Fix use of Huggingface

### DIFF
--- a/lib/sycamore/sycamore/tests/conftest.py
+++ b/lib/sycamore/sycamore/tests/conftest.py
@@ -1,3 +1,5 @@
+import shutil
+
 import pytest
 from pyarrow.fs import LocalFileSystem
 
@@ -30,3 +32,23 @@ def exec_mode(request):
                 ...
     """
     return request.param
+
+@pytest.fixture(scope="function", autouse=True)
+def check_huggingface_hub(request):
+    """
+    Use this to find tests that download a model from Huggingface.
+    """
+
+    import os
+    hf_cache_dir = os.path.expanduser("~/.cache/huggingface/hub")
+    curr_test = request.node.name
+    if os.path.exists(hf_cache_dir):
+        # try2 = os.environ.get('PYTEST_CURRENT_TEST').split(':')[-1].split(' ')[0]
+        print(f"!!!!!! BEFORE: {curr_test} Hugging Face Hub cache exists.")
+        shutil.rmtree(hf_cache_dir)
+
+    yield
+
+    if os.path.exists(hf_cache_dir):
+        print(f"!!!!!! AFTER: {curr_test} Hugging Face Hub cache exists.")
+        shutil.rmtree(hf_cache_dir)

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_bbox_merge.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_bbox_merge.py
@@ -10,7 +10,7 @@ from sycamore.transforms import (
     SortByPageBbox,
 )
 from sycamore.transforms.merge_elements import Merge, MarkedMerger
-from sycamore.functions.tokenizer import HuggingFaceTokenizer
+from sycamore.functions.tokenizer import CharacterTokenizer
 from sycamore.plan_nodes import Node
 
 
@@ -66,7 +66,7 @@ class TestBboxMerge:
             ],
         }
     )
-    tokenizer = HuggingFaceTokenizer("sentence-transformers/all-MiniLM-L6-v2")
+    tokenizer = CharacterTokenizer()
 
     def testMergeElements(self):
         doc = Document(self.doc)
@@ -78,14 +78,14 @@ class TestBboxMerge:
         doc = MarkBreakByTokens(None, self.tokenizer, 512).run(doc)
         doc = MarkedMerger().merge_elements(doc)
         merged = doc.elements
-        assert len(merged) == 5
+        assert len(merged) == 6
 
         assert merged[0].text_representation.startswith("previous page")
         assert merged[0].properties["page_number"] == 1
         assert merged[0].properties["page_numbers"] == [1]
         assert merged[1].text_representation.startswith("top of page")
-        assert merged[2].text_representation.startswith("wide text")
-        assert merged[4].text_representation.startswith("next page")
+        assert merged[3].text_representation.startswith("wide text")
+        assert merged[5].text_representation.startswith("next page")
 
         for elem in merged:
             assert "0" not in elem.text_representation
@@ -100,19 +100,19 @@ class TestBboxMerge:
         doc = MarkBreakByTokens(None, self.tokenizer, 512).run(doc)
         doc = MarkedMerger().merge_elements(doc)
         merged = doc.elements
-        assert len(merged) == 3
+        assert len(merged) == 4
 
         assert merged[0].text_representation.startswith("previous page")
         assert merged[0].properties["page_number"] == 1
         assert merged[0].properties["page_numbers"] == [1, 2]
 
-        assert merged[1].text_representation.startswith("wide text")
-        assert merged[1].properties["page_number"] == 2
-        assert merged[1].properties["page_numbers"] == [2]
-
-        assert merged[2].text_representation.startswith("lorem")
+        assert merged[2].text_representation.startswith("wide text")
         assert merged[2].properties["page_number"] == 2
-        assert merged[2].properties["page_numbers"] == [2, 3]
+        assert merged[2].properties["page_numbers"] == [2]
+
+        assert merged[3].text_representation.startswith("lorem")
+        assert merged[3].properties["page_number"] == 2
+        assert merged[3].properties["page_numbers"] == [2, 3]
 
         for elem in merged:
             assert "0" not in elem.text_representation


### PR DESCRIPTION
I used the pytest hook in this PR to find all unit tests that download a model from Huggingface:

test_infer
test_partition
test_partition_with_ocr_instance
test_table_extraction_order
test_detr_pdfminer_object_type
test_sentence_transformer[sentence-transformers/all-MiniLM-L6-v2-384-texts0]
test_sentence_transformer[sentence-transformers/all-MiniLM-L6-v2-384-texts1]
test_sentence_transformer[sentence-transformers/all-mpnet-base-v2-768-texts2]
test_sentence_transformer_embedding
test_sentence_transformer_batch_size
test_merge_elements
test_merge_elements_via_execute
test_docset_greedy
test_merge_elements
test_merge_elements_image_summarize
test_merge_elements_via_execute
test_docset_greedy
test_merge_empty_text_works
test_merge_elements
test_merge_elements_via_execute
test_docset_augmented
test_transformers_similarity_scorer
test_transformers_similarity_scorer_no_doc_structure
test_transformers_similarity_scorer_no_element_id
test_transformers_score_similarity
test_split_elements
test_via_execute
test_tf_with_bert_tokenizer
test_tf_with_bert_tokenizer_with_token_ids

I think some of these can be rewritten not to use a model from HF and some of them should be moved to /integration.