### PR TITLE
add initial extract transform + interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ apps/timetrace/ttviz
 notebooks/pc-tutorial
 notebooks/tmp
 notebooks/data
+pyrightconfig.json

--- a/lib/sycamore/sycamore/data/table.py
+++ b/lib/sycamore/sycamore/data/table.py
@@ -1,4 +1,3 @@
-from bs4 import BeautifulSoup, Tag
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import Any, Optional, TypeVar, Union, List, Sequence, TYPE_CHECKING
@@ -192,6 +191,8 @@ class Table:
         Extracts the first <table>...</table> block from the given HTML string.
         Returns the table block as a Tag.
         """
+        from bs4 import BeautifulSoup
+
         parsed = BeautifulSoup(html_str, "html.parser")
         return parsed.find("table")
 
@@ -208,6 +209,7 @@ class Table:
           html_str: The html string to parse. Must be enclosed in <table></table> tags.
           html_tag: A BeatifulSoup tag corresponding to the table. One of html_str or html_tag must be set.
         """
+        from bs4 import BeautifulSoup, Tag
 
         # TODO: This doesn't account for rowgroup/colgroup handling, which can get quite tricky.
 

--- a/lib/sycamore/sycamore/llms/prompts/prompts.py
+++ b/lib/sycamore/sycamore/llms/prompts/prompts.py
@@ -102,6 +102,18 @@ class SycamorePrompt:
             A fully rendered prompt that can be sent to an LLM for inference"""
         raise NotImplementedError(f"render_multiple_documents is not implemented for {self.__class__.__name__}")
 
+    def render_multiple_elements(self, elts: list[Element], doc: Document) -> RenderedPrompt:
+        """Render this prompt, given a list of elements from a document as context.
+
+        Args:
+            elts: The list of elements to use to populate the prompt
+            doc: The parent document of the elements
+
+        Returns:
+            A fully rendered prompt that can be sent to an LLM for inference
+        """
+        raise NotImplementedError(f"render_multiple_elements is not implemented for {self.__class__.__name__}")
+
     def fork(self, **kwargs: Any) -> Self:
         """Create a new prompt with some fields changed.
 

--- a/lib/sycamore/sycamore/tests/unit/transforms/property_extraction/test_extract.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/property_extraction/test_extract.py
@@ -1,0 +1,106 @@
+import random
+from typing import Optional
+
+from sycamore.data.document import MetadataDocument, Document
+from sycamore.data.element import Element
+from sycamore.llms.llms import LLM, LLMMode
+from sycamore.llms.prompts.prompts import SycamorePrompt, RenderedPrompt, RenderedMessage
+from sycamore.transforms.property_extraction.extract import Extract, _run_coros_threadsafe
+from sycamore.transforms.property_extraction.strategy import NoSchemaSplitting, OneElementAtATime
+from sycamore.utils.thread_local import ThreadLocal, ThreadLocalAccess, ADD_METADATA_TO_OUTPUT
+from sycamore.schema import Schema, SchemaField
+
+
+def test_run_coros():
+    async def sometimes_recurse(n: int, tries: int = 0) -> int:
+        if random.random() < 0.5:
+            ThreadLocalAccess(ADD_METADATA_TO_OUTPUT).get().append(MetadataDocument(tries=tries))
+            return n
+        else:
+            return await sometimes_recurse(n, tries + 1)
+
+    nums = list(range(10))
+    coros = [sometimes_recurse(n) for n in nums]
+    meta = []
+    with ThreadLocal(ADD_METADATA_TO_OUTPUT, meta):
+        results = _run_coros_threadsafe(coros)
+
+    assert results == nums
+    assert len(meta) == 10
+
+
+class FakeExtractionPrompt(SycamorePrompt):
+    def render_multiple_elements(self, elts: list[Element], doc: Document) -> RenderedPrompt:
+        return RenderedPrompt(
+            messages=[
+                RenderedMessage(role="user", content=f"docid={doc.doc_id}"),
+                RenderedMessage(role="user", content=f"nelts={len(elts)}"),
+                RenderedMessage(role="user", content=f"telts={len(doc.elements)}"),
+            ]
+        )
+
+
+class FakeLLM(LLM):
+    def __init__(self):
+        super().__init__(model_name="fake", default_mode=LLMMode.ASYNC)
+
+    def is_chat_mode(self):
+        return True
+
+    def generate(self, *, prompt: RenderedPrompt, llm_kwargs: Optional[dict] = None) -> str:
+        return f"""{{
+            "doc_id": "{prompt.messages[0].content[6:]}",
+            "nelts": {prompt.messages[1].content[6:]},
+            "telts": {prompt.messages[2].content[6:]}
+        }}
+        """
+
+    async def generate_async(self, *, prompt: RenderedPrompt, llm_kwargs: Optional[dict] = None) -> str:
+        return self.generate(prompt=prompt, llm_kwargs=llm_kwargs)
+
+
+class TestExtract:
+    def test_extract(self):
+        docs = [
+            Document(
+                doc_id="0",
+                elements=[
+                    Element(text_representation="d0e0"),
+                    Element(text_representation="d0e1"),
+                    Element(text_representation="d0e2"),
+                ],
+            ),
+            Document(
+                doc_id="1",
+                elements=[
+                    Element(text_representation="d1e0"),
+                    Element(text_representation="d1e1"),
+                ],
+            ),
+        ]
+
+        schema = Schema(
+            fields=[
+                SchemaField(name="doc_id", field_type="str"),
+                SchemaField(name="missing", field_type="str", default="Missing"),
+                SchemaField(name="telts", field_type="int"),
+            ]
+        )
+
+        extract = Extract(
+            None,
+            schema=schema,
+            step_through_strategy=OneElementAtATime(),
+            schema_partition_strategy=NoSchemaSplitting(),
+            llm=FakeLLM(),
+            prompt=FakeExtractionPrompt(),
+        )
+
+        extracted = extract.run(docs)
+        assert extracted[0].field_to_value("properties.entity.doc_id") == docs[0].doc_id
+        assert extracted[0].field_to_value("properties.entity.telts") == 3
+        assert extracted[0].field_to_value("properties.entity.missing") == "Missing"
+
+        assert extracted[1].field_to_value("properties.entity.doc_id") == docs[1].doc_id
+        assert extracted[1].field_to_value("properties.entity.telts") == 2
+        assert extracted[1].field_to_value("properties.entity.missing") == "Missing"

--- a/lib/sycamore/sycamore/tests/unit/transforms/property_extraction/test_extract.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/property_extraction/test_extract.py
@@ -1,32 +1,12 @@
-import random
 from typing import Optional
 
-from sycamore.data.document import MetadataDocument, Document
+from sycamore.data.document import Document
 from sycamore.data.element import Element
 from sycamore.llms.llms import LLM, LLMMode
 from sycamore.llms.prompts.prompts import SycamorePrompt, RenderedPrompt, RenderedMessage
-from sycamore.transforms.property_extraction.extract import Extract, _run_coros_threadsafe
+from sycamore.transforms.property_extraction.extract import Extract
 from sycamore.transforms.property_extraction.strategy import NoSchemaSplitting, OneElementAtATime
-from sycamore.utils.thread_local import ThreadLocal, ThreadLocalAccess, ADD_METADATA_TO_OUTPUT
 from sycamore.schema import Schema, SchemaField
-
-
-def test_run_coros():
-    async def sometimes_recurse(n: int, tries: int = 0) -> int:
-        if random.random() < 0.5:
-            ThreadLocalAccess(ADD_METADATA_TO_OUTPUT).get().append(MetadataDocument(tries=tries))
-            return n
-        else:
-            return await sometimes_recurse(n, tries + 1)
-
-    nums = list(range(10))
-    coros = [sometimes_recurse(n) for n in nums]
-    meta = []
-    with ThreadLocal(ADD_METADATA_TO_OUTPUT, meta):
-        results = _run_coros_threadsafe(coros)
-
-    assert results == nums
-    assert len(meta) == 10
 
 
 class FakeExtractionPrompt(SycamorePrompt):

--- a/lib/sycamore/sycamore/tests/unit/utils/test_threading.py
+++ b/lib/sycamore/sycamore/tests/unit/utils/test_threading.py
@@ -1,0 +1,22 @@
+import random
+from sycamore.data import MetadataDocument
+from sycamore.utils.thread_local import ThreadLocalAccess, ThreadLocal, ADD_METADATA_TO_OUTPUT
+from sycamore.utils.threading import run_coros_threadsafe
+
+
+def test_run_coros():
+    async def sometimes_recurse(n: int, tries: int = 0) -> int:
+        if random.random() < 0.5:
+            ThreadLocalAccess(ADD_METADATA_TO_OUTPUT).get().append(MetadataDocument(tries=tries))
+            return n
+        else:
+            return await sometimes_recurse(n, tries + 1)
+
+    nums = list(range(10))
+    coros = [sometimes_recurse(n) for n in nums]
+    meta = []
+    with ThreadLocal(ADD_METADATA_TO_OUTPUT, meta):
+        results = run_coros_threadsafe(coros)
+
+    assert results == nums
+    assert len(meta) == 10

--- a/lib/sycamore/sycamore/transforms/base_llm.py
+++ b/lib/sycamore/sycamore/transforms/base_llm.py
@@ -1,4 +1,3 @@
-import threading
 from typing import Optional, Sequence, Callable, Union
 
 from sycamore.llms.llms import LLM, LLMMode
@@ -6,6 +5,7 @@ from sycamore.llms.prompts.prompts import SycamorePrompt, RenderedPrompt
 from sycamore.plan_nodes import Node
 from sycamore.transforms.map import MapBatch
 from sycamore.data import Document, Element
+from sycamore.utils.threading import run_coros_threadsafe
 import asyncio
 
 
@@ -38,22 +38,8 @@ def _infer_prompts(
     elif llm_mode == LLMMode.ASYNC:
         nonempty = [(i, p) for i, p in enumerate(prompts) if len(p.messages) > 0]
         res = [""] * len(prompts)
-
-        # Previously we would use asyncio.run here, but that causes issues in
-        # environments like Jupyter notebooks where an event loop is already
-        # running. To workaround this we create a separate event loop on a new
-        # thread and run the tasks there.
-        new_loop = asyncio.new_event_loop()
-        t = threading.Thread(target=_run_new_thread, args=(new_loop,), daemon=True)
-        t.start()
-
-        fut = asyncio.run_coroutine_threadsafe(_infer_prompts_async([p for _, p in nonempty], llm), new_loop)
-
-        responses = fut.result()
-
-        new_loop.call_soon_threadsafe(new_loop.stop)
-        t.join()
-        new_loop.close()
+        coroutines = [llm.generate_async(prompt=p, llm_kwargs={}) for _, p in nonempty]
+        responses = run_coros_threadsafe(coroutines)
 
         for (i, _), rs in zip(nonempty, responses):
             res[i] = rs

--- a/lib/sycamore/sycamore/transforms/property_extraction/extract.py
+++ b/lib/sycamore/sycamore/transforms/property_extraction/extract.py
@@ -1,0 +1,106 @@
+from typing import Optional, Any
+import threading
+import asyncio
+import logging
+
+from sycamore.data.document import Document
+from sycamore.plan_nodes import Node
+from sycamore.schema import Schema
+from sycamore.transforms.map import MapBatch
+from sycamore.transforms.property_extraction.strategy import SchemaPartitionStrategy, StepThroughStrategy
+from sycamore.llms.llms import LLM
+from sycamore.llms.prompts.prompts import SycamorePrompt
+from sycamore.transforms.base_llm import _run_new_thread
+from sycamore.utils.extract_json import extract_json
+from sycamore.utils.thread_local import ThreadLocal, ADD_METADATA_TO_OUTPUT, ThreadLocalAccess
+
+_logger = logging.getLogger(__name__)
+
+
+def _run_coros_threadsafe(coros):
+    new_loop = asyncio.new_event_loop()
+    t = threading.Thread(target=_run_new_thread, args=(new_loop,), daemon=True)
+    t.start()
+
+    metadata = []
+
+    async def _gather_coros(coros):
+        # Exfiltrate metadata documents from inner thread
+        with ThreadLocal(ADD_METADATA_TO_OUTPUT, metadata):
+            tasks = [new_loop.create_task(c) for c in coros]
+            return await asyncio.gather(*tasks)
+
+    fut = asyncio.run_coroutine_threadsafe(_gather_coros(coros), loop=new_loop)
+    results = fut.result()
+    new_loop.call_soon_threadsafe(new_loop.stop)
+    t.join()
+    new_loop.close()
+    tls = ThreadLocalAccess(ADD_METADATA_TO_OUTPUT)
+    if tls.present():
+        tls.get().extend(metadata)
+    return results
+
+
+class Extract(MapBatch):
+
+    def __init__(
+        self,
+        node: Optional[Node],
+        *,
+        schema: Schema,
+        step_through_strategy: StepThroughStrategy,
+        schema_partition_strategy: SchemaPartitionStrategy,
+        llm: LLM,
+        prompt: SycamorePrompt,
+        put_in_properties_dot_entity: bool = True,
+    ):
+        if put_in_properties_dot_entity:
+            _logger.warning("Really? You're putting the results in properties.entity???")
+        super().__init__(node, f=self.extract)
+        self._schema = schema
+        self._step_through = step_through_strategy
+        self._schema_partition = schema_partition_strategy
+        self._llm = llm
+        self._prompt = prompt
+        # Try calling the render method I need at constructor to make sure it's implemented
+        self._prompt.render_multiple_elements(elts=[], doc=Document())
+        self._pipde = put_in_properties_dot_entity
+
+    def extract(self, documents: list[Document]) -> list[Document]:
+        schema_parts = self._schema_partition.partition_schema(self._schema)
+        coros = [self.extract_schema_partition(documents, sp) for sp in schema_parts]
+        results = _run_coros_threadsafe(coros)
+        assert all(isinstance(r, dict) for result_set in results for r in result_set)
+        for partial_result in results:
+            for props, doc in zip(partial_result, documents):
+                if self._pipde:
+                    if "entity" not in doc.properties:
+                        doc.properties["entity"] = props
+                    else:
+                        doc.properties["entity"].update(props)
+                else:
+                    doc.properties.update(props)
+
+        return documents
+
+    async def extract_schema_partition(self, documents: list[Document], schema_part: Schema) -> list[dict[str, Any]]:
+        coros = [self.extract_schema_partition_from_document(d, schema_part) for d in documents]
+        return await asyncio.gather(*coros)
+
+    async def extract_schema_partition_from_document(self, document: Document, schema_part: Schema) -> dict[str, Any]:
+        prompt = self._prompt.fork(schema=schema_part)
+        expected_fields = sorted(f.name for f in schema_part.fields)
+        result_dict = dict()
+        for elements in self._step_through.step_through(document):
+            rendered = prompt.render_multiple_elements(elements, document)
+            result = await self._llm.generate_async(prompt=rendered)
+            rd = extract_json(result)
+            for k, v in rd.items():
+                if v is not None and k not in result_dict and k in expected_fields:
+                    result_dict[k] = v
+            if sorted(result_dict.keys()) == expected_fields:
+                return result_dict
+        for sf in schema_part.fields:
+            if sf.default is not None and sf.name not in result_dict:
+                result_dict[sf.name] = sf.default
+        return result_dict

--- a/lib/sycamore/sycamore/transforms/property_extraction/extract.py
+++ b/lib/sycamore/sycamore/transforms/property_extraction/extract.py
@@ -29,7 +29,7 @@ class Extract(MapBatch):
         put_in_properties_dot_entity: bool = True,
     ):
         if put_in_properties_dot_entity:
-            _logger.warning("Really? You're putting the results in properties.entity???")
+            _logger.warning("Extraction results will go in properties.entity")
         super().__init__(node, f=self.extract)
         self._schema = schema
         self._step_through = step_through_strategy

--- a/lib/sycamore/sycamore/transforms/property_extraction/prompts.py
+++ b/lib/sycamore/sycamore/transforms/property_extraction/prompts.py
@@ -1,0 +1,94 @@
+from typing import Optional
+import copy
+from sycamore.data import Element, Document
+from sycamore.llms.prompts.prompts import (
+    ResponseFormat,
+    SycamorePrompt,
+    RenderedMessage,
+    RenderedPrompt,
+    compile_templates,
+)
+from sycamore.llms.prompts.jinja_fragments import J_FORMAT_SCHEMA_MACRO
+from sycamore.schema import Schema
+
+
+class ExtractionJinjaPrompt(SycamorePrompt):
+    def __init__(
+        self,
+        schema: Optional[Schema] = None,
+        system: Optional[str] = None,
+        user_pre_elements: Optional[str] = None,
+        element_template: Optional[str] = None,
+        user_post_elements: Optional[str] = None,
+        response_format: Optional[ResponseFormat] = None,
+        **kwargs,
+    ):
+        from jinja2.sandbox import SandboxedEnvironment
+        from jinja2 import Template
+
+        self.schema = schema
+        self.system = system
+        self.user_pre_elements = user_pre_elements
+        self.user_post_elements = user_post_elements
+        self.element_template = element_template
+        self.response_format = response_format
+        self.kwargs = kwargs
+        self._env = SandboxedEnvironment(extensions=["jinja2.ext.loopcontrols"])
+        self._sys_template: Optional[Template] = None
+        self._user_template_1: Optional[Template] = None
+        self._elt_template: Optional[Template] = None
+        self._user_template_2: Optional[Template] = None
+
+    def __reduce__(self):
+        def make(
+            schema, system, user_pre_elements, element_template, user_post_elements, response_format, kwargs
+        ) -> "ExtractionJinjaPrompt":
+            return ExtractionJinjaPrompt(
+                schema, system, user_pre_elements, element_template, user_post_elements, response_format, **kwargs
+            )
+
+        return make, (
+            self.schema,
+            self.system,
+            self.user_pre_elements,
+            self.element_template,
+            self.user_post_elements,
+            self.response_format,
+            self.kwargs,
+        )
+
+    def render_multiple_elements(self, elts: list[Element], doc: Document) -> RenderedPrompt:
+        if self._elt_template is None:
+            templates = compile_templates(
+                [self.system, self.user_pre_elements, self.element_template, self.user_post_elements], self._env
+            )
+            self._sys_template = templates[0]
+            self._user_template_1 = templates[1]
+            self._elt_template = templates[2]
+            self._user_template_2 = templates[3]
+
+        assert self._elt_template is not None, "Unreachable, type narrowing"
+        render_args = copy.deepcopy(self.kwargs)
+        render_args["schema"] = self.schema
+        render_args["doc"] = doc
+
+        messages = []
+        if self._sys_template is not None:
+            messages.append(RenderedMessage(role="system", content=self._sys_template.render(render_args)))
+        if self._user_template_1 is not None:
+            messages.append(RenderedMessage(role="user", content=self._user_template_1.render(render_args)))
+        for elt in elts:
+            messages.append(RenderedMessage(role="user", content=self._elt_template.render(render_args | {"elt": elt})))
+        if self._user_template_2 is not None:
+            messages.append(RenderedMessage(role="user", content=self._user_template_2.render(render_args)))
+
+        return RenderedPrompt(messages=messages, response_format=self.response_format)
+
+
+_elt_at_a_time_full_schema = ExtractionJinjaPrompt(
+    system="You are a helpful metadata extraction agent. You output only JSON",
+    user_pre_elements="""You are provided an element of a document and a schema. Extract all the fields in the
+schema as JSON. If a field is not present in the element, output `null` in the output result.""",
+    element_template="Element: {{ elt.text_representation }}",
+    user_post_elements=J_FORMAT_SCHEMA_MACRO + "Schema: {{ format_schema(schema) }}",
+)

--- a/lib/sycamore/sycamore/transforms/property_extraction/strategy.py
+++ b/lib/sycamore/sycamore/transforms/property_extraction/strategy.py
@@ -1,0 +1,29 @@
+from abc import ABC, abstractmethod
+from typing import Iterable
+
+from sycamore.data.document import Document
+from sycamore.data.element import Element
+from sycamore.schema import Schema
+
+
+class StepThroughStrategy(ABC):
+    @abstractmethod
+    def step_through(self, document: Document) -> Iterable[list[Element]]:
+        pass
+
+
+class OneElementAtATime(StepThroughStrategy):
+    def step_through(self, document: Document) -> Iterable[list[Element]]:
+        for elt in document.elements:
+            yield [elt]
+
+
+class SchemaPartitionStrategy(ABC):
+    @abstractmethod
+    def partition_schema(self, schema: Schema) -> list[Schema]:
+        pass
+
+
+class NoSchemaSplitting(SchemaPartitionStrategy):
+    def partition_schema(self, schema: Schema) -> list[Schema]:
+        return [schema]

--- a/lib/sycamore/sycamore/transforms/summarize.py
+++ b/lib/sycamore/sycamore/transforms/summarize.py
@@ -345,6 +345,7 @@ class MultiStepDocumentSummarizer(Summarizer):
                 to_infer.append(base_prompt.render_document(document))
 
         # Invoke the llm and attach summaries
+        # TODO: Use run_coros_threadsafe here instead
         summaries = _infer_prompts(prompts=to_infer, llm=self.llm, llm_mode=self.llm_mode)
         for e, s in zip(final_elements, summaries):
             e.properties["summary"] = s

--- a/lib/sycamore/sycamore/utils/threading.py
+++ b/lib/sycamore/sycamore/utils/threading.py
@@ -1,0 +1,32 @@
+import asyncio
+import threading
+from sycamore.utils.thread_local import ThreadLocal, ThreadLocalAccess, ADD_METADATA_TO_OUTPUT
+
+
+def _run_new_thread(loop: asyncio.AbstractEventLoop) -> None:
+    asyncio.set_event_loop(loop)
+    loop.run_forever()
+
+
+def run_coros_threadsafe(coros):
+    new_loop = asyncio.new_event_loop()
+    t = threading.Thread(target=_run_new_thread, args=(new_loop,), daemon=True)
+    t.start()
+
+    metadata = []
+
+    async def _gather_coros(coros):
+        # Exfiltrate metadata documents from inner thread
+        with ThreadLocal(ADD_METADATA_TO_OUTPUT, metadata):
+            tasks = [new_loop.create_task(c) for c in coros]
+            return await asyncio.gather(*tasks)
+
+    fut = asyncio.run_coroutine_threadsafe(_gather_coros(coros), loop=new_loop)
+    results = fut.result()
+    new_loop.call_soon_threadsafe(new_loop.stop)
+    t.join()
+    new_loop.close()
+    tls = ThreadLocalAccess(ADD_METADATA_TO_OUTPUT)
+    if tls.present():
+        tls.get().extend(metadata)
+    return results

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,4 @@
+{
+  "venvPath": ".",
+  "venv": ".venv"
+}

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,4 +1,0 @@
-{
-  "venvPath": ".",
-  "venv": ".venv"
-}


### PR DESCRIPTION
Minimum extract thingy

+ render_multiple_elements interface to prompts to be able to make a prompt out of a chunk of elements
+ stepthrough strategy interface to define how to step through a large document
+ schema partition strategy interface to allow me to break up a schema (e.g. if too big, if source hints are divergent)

+ some threading code to run a bunch of asyncio coroutines in another thread, block on them, and get metadata docs out