### PR TITLE
Upgrade Gemini 2.5 Flash Lite, which is now GA.

### DIFF
--- a/lib/sycamore/sycamore/llms/config.py
+++ b/lib/sycamore/sycamore/llms/config.py
@@ -63,7 +63,8 @@ class GeminiModels(Enum):
     GEMINI_2_5_PRO = GeminiModel(name="gemini-2.5-pro", is_chat=True)
     GEMINI_2_5_PRO_PREVIEW = GEMINI_2_5_PRO  # Alias for the preview model
 
-    GEMINI_2_5_FLASH_LITE_PREVIEW = GeminiModel(name="gemini-2.5-flash-lite-preview-06-17", is_chat=True)
+    GEMINI_2_5_FLASH_LITE = GeminiModel(name="gemini-2.5-flash-lite", is_chat=True)
+    GEMINI_2_5_FLASH_LITE_PREVIEW = GEMINI_2_5_FLASH_LITE  # Alias for the preview model
 
     GEMINI_2_FLASH = GeminiModel(name="gemini-2.0-flash", is_chat=True)
     GEMINI_2_FLASH_LITE = GeminiModel(name="gemini-2.0-flash-lite", is_chat=True)

--- a/lib/sycamore/sycamore/tests/integration/llms/test_gemini.py
+++ b/lib/sycamore/sycamore/tests/integration/llms/test_gemini.py
@@ -173,7 +173,7 @@ def test_metadata():
 
 
 def test_default_llm_kwargs():
-    llm = Gemini(GeminiModels.GEMINI_2_FLASH_LITE, default_llm_kwargs={"max_output_tokens": 5})
+    llm = Gemini(GeminiModels.GEMINI_2_5_FLASH_LITE, default_llm_kwargs={"max_output_tokens": 5})
     res = llm.generate_metadata(
         prompt=RenderedPrompt(
             messages=[RenderedMessage(role="user", content="Write a limerick about large language models.")]


### PR DESCRIPTION
Switches from GEMINI_2_5_FLASH_LITE_PREVIEW to GEMINI_2_5_FLASH_LITE and retains the former as an alias to the latter for backwards compatibility.