### PR TITLE
Update Sycamore to leverage new Schema model.

### DIFF
--- a/lib/sycamore/sycamore/llms/prompts/default_prompts.py
+++ b/lib/sycamore/sycamore/llms/prompts/default_prompts.py
@@ -13,7 +13,6 @@ from sycamore.llms.prompts.prompts import (
 from sycamore.llms.prompts.jinja_fragments import (
     J_DYNAMIC_DOC_TEXT,
     J_FIELD_VALUE_MACRO,
-    J_FORMAT_SCHEMA_MACRO,
     J_SET_ENTITY,
     J_SET_SCHEMA,
     J_ELEMENT_BATCHED_LIST,
@@ -415,11 +414,10 @@ PropertiesFromSchemaJinjaPrompt = JinjaPrompt(
         "You are a helpful property extractor. You have to return your response as a JSON that"
         "can be parsed with json.loads(<response>) in Python. Do not return any other text."
     ),
-    user=(
-        J_FORMAT_SCHEMA_MACRO
-        + """\
+    user=textwrap.dedent(
+        """\
 Extract values for the following fields:
-{{ format_schema(schema) }}
+{{ schema_string }}
 
 Document text:"""
         + J_DYNAMIC_DOC_TEXT

--- a/lib/sycamore/sycamore/query/client.py
+++ b/lib/sycamore/sycamore/query/client.py
@@ -18,7 +18,7 @@ import structlog
 import yaml
 from rich.console import Console
 
-from sycamore.schema import Schema
+from sycamore.schema import SchemaV2 as Schema
 
 import sycamore
 from sycamore import Context, ExecMode
@@ -30,7 +30,7 @@ from sycamore.query.execution.sycamore_executor import SycamoreExecutor
 from sycamore.query.logical_plan import LogicalPlan
 from sycamore.query.planner import LlmPlanner, PlannerExample, Planner
 from sycamore.query.result import SycamoreQueryResult
-from sycamore.query.schema import OpenSearchSchema, OpenSearchSchemaFetcher
+from sycamore.query.schema import OpenSearchSchemaFetcher
 from sycamore.query.strategy import DefaultQueryPlanStrategy, QueryPlanStrategy
 from sycamore.transforms.embed import SentenceTransformerEmbedder
 from sycamore.transforms.query import OpenSearchQueryExecutor
@@ -177,13 +177,13 @@ class SycamoreQueryClient:
         from opensearchpy.client.indices import IndicesClient
 
         schema_provider = OpenSearchSchemaFetcher(IndicesClient(self._os_client), index, self._os_query_executor)
-        return schema_provider.get_schema().to_schema()
+        return schema_provider.get_schema()
 
     def generate_plan(
         self,
         query: str,
         index: str,
-        schema: Union[Schema, OpenSearchSchema, None] = None,
+        schema: Optional[Schema] = None,
         examples: Optional[List[PlannerExample]] = None,
         natural_language_response: bool = False,
         **kwargs,

--- a/lib/sycamore/sycamore/query/planner.py
+++ b/lib/sycamore/sycamore/query/planner.py
@@ -1,16 +1,15 @@
 import logging
 import typing
 from abc import abstractmethod
-from typing import List, Optional, Union
+from typing import List, Optional
 
-from sycamore.schema import Schema
+from sycamore.schema import SchemaV2 as Schema
 
 from sycamore.llms.llms import LLM
 from sycamore.llms.prompts.prompts import RenderedPrompt
 from sycamore.llms.openai import OpenAI, OpenAIModels
 from sycamore.query.logical_plan import LogicalPlan
 from sycamore.query.planner_prompt import PlannerPrompt, PlannerExample, PLANNER_EXAMPLES
-from sycamore.query.schema import OpenSearchSchema
 from sycamore.query.strategy import QueryPlanStrategy, ALL_OPERATORS
 from sycamore.utils.extract_json import extract_json
 
@@ -53,7 +52,7 @@ class LlmPlanner(Planner):
     def __init__(
         self,
         index: str,
-        data_schema: Union[OpenSearchSchema, Schema],
+        data_schema: Schema,
         os_config: Optional[dict[str, str]] = None,
         os_client: Optional["OpenSearch"] = None,
         strategy: QueryPlanStrategy = QueryPlanStrategy(ALL_OPERATORS, []),
@@ -71,10 +70,7 @@ class LlmPlanner(Planner):
         self._examples = PLANNER_EXAMPLES if examples is None else examples
         self._natural_language_response = natural_language_response
         self._prompt = prompt
-
-        self._data_schema: Schema = (
-            data_schema.to_schema() if isinstance(data_schema, OpenSearchSchema) else data_schema
-        )
+        self._data_schema = data_schema
 
     def generate_prompt(self, question: str, **kwargs) -> RenderedPrompt:
         if self._prompt is None:

--- a/lib/sycamore/sycamore/query/planner_prompt.py
+++ b/lib/sycamore/sycamore/query/planner_prompt.py
@@ -3,8 +3,7 @@ from sycamore.llms.prompts.prompts import (
     RenderedPrompt,
     RenderedMessage,
 )
-from sycamore.schema import Schema, SchemaField
-from sycamore.query.schema import OpenSearchSchema
+from sycamore.schema import SchemaV2 as Schema, make_named_property
 from sycamore.query.logical_plan import LogicalPlan, Node
 
 from sycamore.query.operators.query_database import QueryVectorDatabase, QueryDatabase
@@ -17,7 +16,7 @@ from sycamore.query.operators.math import Math
 from sycamore.query.operators.limit import Limit
 from sycamore.query.operators.sort import Sort
 
-from typing import Optional, Union, List, Type
+from typing import Optional, List, Type
 from dataclasses import dataclass
 
 
@@ -56,51 +55,51 @@ PLANNER_NATURAL_LANGUAGE_PROMPT = (
 class PlannerExample:
     """Represents an example query and query plan for the planner."""
 
-    def __init__(self, schema: Union[OpenSearchSchema, Schema], plan: LogicalPlan) -> None:
+    def __init__(self, schema: Schema, plan: LogicalPlan) -> None:
         super().__init__()
         self.plan = plan
-        self.schema: Schema = schema.to_schema() if isinstance(schema, OpenSearchSchema) else schema
+        self.schema = schema
 
 
 # Example schema and planner examples for the NTSB and financial datasets.
 EXAMPLE_NTSB_SCHEMA = Schema(
-    fields=[
-        SchemaField(
+    properties=[
+        make_named_property(
             name="properties.path",
-            field_type="str",
+            type="string",
             examples=["/docs/incident1.pdf", "/docs/incident2.pdf", "/docs/incident3.pdf"],
         ),
-        SchemaField(name="properties.entity.date", field_type="date", examples=["2023-07-01", "2024-09-01"]),
-        SchemaField(name="properties.entity.accidentNumber", field_type="str", examples=["1234", "5678", "91011"]),
-        SchemaField(
+        make_named_property(name="properties.entity.date", type="date", examples=["2023-07-01", "2024-09-01"]),
+        make_named_property(name="properties.entity.accidentNumber", type="string", examples=["1234", "5678", "91011"]),
+        make_named_property(
             name="properties.entity.location",
-            field_type="str",
+            type="string",
             examples=["Atlanta, Georgia", "Miami, Florida", "San Diego, California"],
         ),
-        SchemaField(name="properties.entity.aircraft", field_type="str", examples=["Cessna", "Boeing", "Airbus"]),
-        SchemaField(name="properties.entity.city", field_type="str", examples=["Atlanta", "Savannah", "Augusta"]),
-        SchemaField(
-            name="text_representation", field_type="str", examples=["Can be assumed to have all other details"]
+        make_named_property(name="properties.entity.aircraft", type="string", examples=["Cessna", "Boeing", "Airbus"]),
+        make_named_property(name="properties.entity.city", type="string", examples=["Atlanta", "Savannah", "Augusta"]),
+        make_named_property(
+            name="text_representation", type="string", examples=["Can be assumed to have all other details"]
         ),
     ]
 )
 
 EXAMPLE_FINANCIAL_SCHEMA = Schema(
-    fields=[
-        SchemaField(name="properties.path", field_type="str", examples=["doc1.pdf", "doc2.pdf", "doc3.pdf"]),
-        SchemaField(
-            name="properties.entity.date", field_type="str", examples=["2022-01-01", "2022-12-31", "2023-01-01"]
+    properties=[
+        make_named_property(name="properties.path", type="string", examples=["doc1.pdf", "doc2.pdf", "doc3.pdf"]),
+        make_named_property(
+            name="properties.entity.date", type="string", examples=["2022-01-01", "2022-12-31", "2023-01-01"]
         ),
-        SchemaField(
-            name="properties.entity.revenue", field_type="float", examples=["1000000.0", "2000000.0", "3000000.0"]
+        make_named_property(
+            name="properties.entity.revenue", type="float", examples=["1000000.0", "2000000.0", "3000000.0"]
         ),
-        SchemaField(
+        make_named_property(
             name="properties.entity.firmName",
-            field_type="str",
+            type="string",
             examples=["Dewey, Cheatem, and Howe", "Saul Goodman & Associates", "Wolfram & Hart"],
         ),
-        SchemaField(
-            name="text_representation", field_type="str", examples=["Can be assumed to have all other details"]
+        make_named_property(
+            name="text_representation", type="string", examples=["Can be assumed to have all other details"]
         ),
     ]
 )
@@ -394,7 +393,7 @@ class PlannerPrompt(SycamorePrompt):
     @staticmethod
     def make_schema_prompt(schema: Schema) -> str:
         """Generate the prompt fragment for the provided schema."""
-        return schema.model_dump_json(indent=2)
+        return schema.render_flattened()
 
     def make_examples_prompt(self) -> str:
         """Generate the prompt fragment for the query examples."""

--- a/lib/sycamore/sycamore/query/schema.py
+++ b/lib/sycamore/sycamore/query/schema.py
@@ -129,7 +129,7 @@ class OpenSearchSchemaFetcher:
 
                     kwargs = {
                         "name": key,
-                        "type": DataType.from_python_type(sample_type),
+                        "type": DataType.from_python_type(sample_type or str),
                         "examples": sample_list,
                     }
 

--- a/lib/sycamore/sycamore/schema.py
+++ b/lib/sycamore/sycamore/schema.py
@@ -112,6 +112,9 @@ class Property(BaseModel):
     description: Optional[str] = None
     """A brief description of the property."""
 
+    default: Optional[Any] = None
+    """The default value for the property."""
+
     extraction_instructions: Optional[str] = None
     """Additional instructions (prompts) to use when extracting the property."""
 
@@ -277,7 +280,7 @@ class SchemaV2(BaseModel):
                         new_p.name = f"{prefix}.{p.name}"
                     out_props.append(new_p)
 
-        flattened_properties = []
+        flattened_properties: list[NamedProperty] = []
         flatten_object("", self.properties, flattened_properties)
         return SchemaV2(properties=flattened_properties)
 

--- a/lib/sycamore/sycamore/tests/integration/query/test_planner.py
+++ b/lib/sycamore/sycamore/tests/integration/query/test_planner.py
@@ -1,7 +1,7 @@
 from sycamore.connectors.opensearch.utils import OpenSearchClientWithLogging
 from sycamore.tests.integration.query.conftest import OS_CLIENT_ARGS, OS_CONFIG
 from sycamore.query.planner import LlmPlanner
-from sycamore.query.schema import OpenSearchSchema, OpenSearchSchemaField
+from sycamore.schema import SchemaV2 as Schema, make_named_property
 
 
 def test_simple_llm_planner(query_integration_test_index: str):
@@ -11,11 +11,11 @@ def test_simple_llm_planner(query_integration_test_index: str):
     """
     os_client = OpenSearchClientWithLogging(OS_CLIENT_ARGS)
 
-    schema = OpenSearchSchema(
-        fields={
-            "location": OpenSearchSchemaField(field_type="string", examples=["New York", "Seattle"]),
-            "airplaneType": OpenSearchSchemaField(field_type="string", examples=["Boeing 747", "Airbus A380"]),
-        }
+    schema = Schema(
+        properties=[
+            make_named_property(name="location", type="string", examples=["New York", "Seattle"]),
+            make_named_property(name="airplaneType", type="string", examples=["Boeing 747", "Airbus A380"]),
+        ]
     )
     planner = LlmPlanner(query_integration_test_index, data_schema=schema, os_config=OS_CONFIG, os_client=os_client)
     plan = planner.plan("How many locations did incidents happen in?")

--- a/lib/sycamore/sycamore/tests/integration/query/test_planner.py
+++ b/lib/sycamore/sycamore/tests/integration/query/test_planner.py
@@ -27,7 +27,5 @@ def test_simple_llm_planner(query_integration_test_index: str):
     assert [plan.nodes[0]] == plan.nodes[1].input_nodes()
 
     # Just ensure we can run the planner with a Schema object as well
-    planner = LlmPlanner(
-        query_integration_test_index, data_schema=schema.to_schema(), os_config=OS_CONFIG, os_client=os_client
-    )
+    planner = LlmPlanner(query_integration_test_index, data_schema=schema, os_config=OS_CONFIG, os_client=os_client)
     planner.plan("How many locations did incidents happen in?")

--- a/lib/sycamore/sycamore/tests/integration/transforms/test_data_extraction.py
+++ b/lib/sycamore/sycamore/tests/integration/transforms/test_data_extraction.py
@@ -2,7 +2,14 @@ import pytest
 import sycamore
 from sycamore import ExecMode
 from sycamore.data import Document, Element
-from sycamore.schema import NamedProperty, Schema, SchemaField, SchemaV2, StringProperty, IntProperty, DateProperty
+from sycamore.schema import (
+    NamedProperty,
+    SchemaV2,
+    StringProperty,
+    IntProperty,
+    DateProperty,
+    make_named_property,
+)
 from sycamore.llms.openai import OpenAI, OpenAIModels
 from sycamore.llms.anthropic import Anthropic, AnthropicModels
 from sycamore.transforms.extract_schema import LLMPropertyExtractor
@@ -62,21 +69,25 @@ def test_extract_properties_from_dict_schema(llm):
 def test_extract_metadata(llm):
     docs = get_docs()[:1]
 
-    field1 = SchemaField(
-        name="person_name",
-        field_type="string",
-        description="name of the person, return a tuple with value and pagenumber",
+    schema = SchemaV2(
+        properties=[
+            make_named_property(
+                name="person_name",
+                type="string",
+                description="name of the person, return a tuple with value and pagenumber",
+            ),
+            make_named_property(
+                name="profession",
+                type="string",
+                description="profession of the person, return a tuple of value and pagenumber",
+            ),
+        ]
     )
-    field2 = SchemaField(
-        name="profession",
-        field_type="string",
-        description="profession of the person, return a tuple of value and pagenumber",
-    )
+
     llm = OpenAI(OpenAIModels.GPT_4_1)
     embedder = OpenAIEmbedder("text-embedding-3-small")
 
     # Create schema
-    schema = Schema(fields=[field1, field2])
     property_extractor = LLMPropertyExtractor(
         llm,
         schema=schema,
@@ -110,22 +121,22 @@ def test_extract_metadata(llm):
 def test_extract_properties_from_schema(llm):
     docs = get_docs()
 
-    schema = Schema(
-        fields=[
-            SchemaField(
+    schema = SchemaV2(
+        properties=[
+            make_named_property(
                 name="name",
-                field_type="str",
+                type="string",
                 description="This is the name of an entity",
                 examples=["Mark", "Ollie", "Winston"],
                 default="null",
             ),
-            SchemaField(name="age", field_type="int", default=999),
-            SchemaField(
-                name="date", field_type="str", description="Any date in the doc, extracted in YYYY-MM-DD format"
+            make_named_property(name="age", type="int", default=999),
+            make_named_property(
+                name="date", type="string", description="Any date in the doc, extracted in YYYY-MM-DD format"
             ),
-            SchemaField(
+            make_named_property(
                 name="from_location",
-                field_type="str",
+                type="string",
                 description="This is the location the entity is from. "
                 "If it's a US location and explicitly states a city and state, format it as 'City, State' "
                 "The state is abbreviated in it's standard 2 letter form.",

--- a/lib/sycamore/sycamore/tests/unit/query/test_planner.py
+++ b/lib/sycamore/sycamore/tests/unit/query/test_planner.py
@@ -6,7 +6,7 @@ from sycamore.query.operators.count import Count
 from sycamore.query.operators.query_database import QueryDatabase
 from sycamore.query.planner import LlmPlanner
 from sycamore.query.planner_prompt import PlannerPrompt
-from sycamore.query.schema import OpenSearchSchema, OpenSearchSchemaField
+from sycamore.schema import SchemaV2 as Schema, make_named_property
 
 
 @pytest.fixture
@@ -25,12 +25,12 @@ def mock_llm_client():
 
 
 @pytest.fixture
-def mock_schema() -> OpenSearchSchema:
-    return OpenSearchSchema(
-        fields={
-            "incidentId": OpenSearchSchemaField(field_type="str", examples=["A1234, B1234, C1234"]),
-            "date": OpenSearchSchemaField(field_type="str", examples=["2022-01-01", "2024-02-10"]),
-        }
+def mock_schema() -> Schema:
+    return Schema(
+        properties=[
+            make_named_property(name="incidentId", type="string", examples=["A1234, B1234, C1234"]),
+            make_named_property(name="date", type="string", examples=["2022-01-01", "2024-02-10"]),
+        ]
     )
 
 

--- a/lib/sycamore/sycamore/tests/unit/test_schema.py
+++ b/lib/sycamore/sycamore/tests/unit/test_schema.py
@@ -1,4 +1,4 @@
-from sycamore.schema import SchemaV2
+from sycamore.schema import SchemaV2, make_property, make_named_property
 
 single_property_dict_old = {
     "name": "state",
@@ -60,3 +60,106 @@ def test_read_old_custom_type():
 def test_read_new_custom_type():
     schema = SchemaV2.model_validate(custom_type_schema_new)
     assert schema.model_dump(exclude_unset=True, exclude_none=True) == custom_type_schema_new, "Schemas should match"
+
+
+nested_schema_dict = {
+    "properties": [
+        make_named_property(name="user_id", type="string", description="User ID"),
+        make_named_property(
+            name="location",
+            type="object",
+            properties=[
+                make_named_property(name="city", type="string", description="City name"),
+                make_named_property(name="state", type="string", description="State name"),
+                make_named_property(name="country", type="string", description="Country name"),
+                make_named_property(
+                    name="years_resident",
+                    type="object",
+                    properties=[
+                        make_named_property(name="start", type="int", description="Year residency started"),
+                        make_named_property(name="end", type="int", description="Year residency ended"),
+                    ],
+                ),
+            ],
+        ),
+        make_named_property(
+            name="settings", type="array", item_type=make_property(type="string"), description="User settings"
+        ),
+        make_named_property(
+            name="billing_status",
+            type="choice",
+            choices=["paid", "free", "trial"],
+            description="Billing status of the user",
+        ),
+    ]
+}
+
+nested_schema = SchemaV2.model_validate(nested_schema_dict)
+
+
+def test_flatten():
+
+    expected = [
+        ("user_id", "string"),
+        ("location.city", "string"),
+        ("location.state", "string"),
+        ("location.country", "string"),
+        ("location.years_resident.start", "int"),
+        ("location.years_resident.end", "int"),
+        ("billing_status", "choice"),
+    ]
+
+    flat_schema = nested_schema.flatten()
+    flat_properties = [(prop.name, prop.type.type) for prop in flat_schema.properties]
+    assert flat_properties == expected, "Flattened schema properties should match expected structure"
+
+
+expected_flattened = """{
+  "properties": [
+    {
+      "name": "user_id",
+      "type": "string",
+      "description": "User ID"
+    },
+    {
+      "name": "location.city",
+      "type": "string",
+      "description": "City name"
+    },
+    {
+      "name": "location.state",
+      "type": "string",
+      "description": "State name"
+    },
+    {
+      "name": "location.country",
+      "type": "string",
+      "description": "Country name"
+    },
+    {
+      "name": "location.years_resident.start",
+      "type": "int",
+      "description": "Year residency started"
+    },
+    {
+      "name": "location.years_resident.end",
+      "type": "int",
+      "description": "Year residency ended"
+    },
+    {
+      "name": "billing_status",
+      "type": "choice",
+      "description": "Billing status of the user",
+      "choices": [
+        "paid",
+        "free",
+        "trial"
+      ]
+    }
+  ]
+}"""
+
+
+def test_render_flattened():
+    flat_str = nested_schema.render_flattened()
+    assert flat_str == expected_flattened, "Flattened schema string should match expected output"

--- a/lib/sycamore/sycamore/tests/unit/test_schema.py
+++ b/lib/sycamore/sycamore/tests/unit/test_schema.py
@@ -43,7 +43,7 @@ custom_type_schema_new = {"properties": [custom_type_dict_new]}
 def test_read_old_schema():
     schema = SchemaV2.model_validate(single_property_schema_old)
     assert (
-        schema.model_dump(exclude_unset=True) == single_property_schema_new
+        schema.model_dump(exclude_unset=True, exclude_none=True) == single_property_schema_new
     ), "Old schema should match the new schema format"
 
 

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_schema.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_schema.py
@@ -9,7 +9,7 @@ from sycamore.data import Document, Element
 from sycamore.llms.llms import LLM, FakeLLM, LLMMode
 from sycamore.llms.prompts import RenderedPrompt
 from sycamore.plan_nodes import Node
-from sycamore.schema import Schema, SchemaField
+from sycamore.schema import SchemaV2 as Schema, make_named_property
 from sycamore.transforms.base_llm import LLMMap
 from sycamore.transforms.map import Map
 from sycamore.transforms.extract_schema import ExtractBatchSchema, SchemaExtractor
@@ -281,13 +281,13 @@ class TestSchema:
         doc.elements = [element1, element2]
 
         schema = Schema(
-            fields=[
-                SchemaField(name="startDate", field_type="datetime"),
-                SchemaField(name="endDate", field_type="date"),
-                SchemaField(name="accidentNumber", field_type="str"),
-                SchemaField(name="injuryCount", field_type="int"),
-                SchemaField(name="latitude", field_type="float"),
-                SchemaField(name="location", field_type="list"),
+            properties=[
+                make_named_property(name="startDate", type="datetime"),
+                make_named_property(name="endDate", type="date"),
+                make_named_property(name="accidentNumber", type="string"),
+                make_named_property(name="injuryCount", type="int"),
+                make_named_property(name="latitude", type="float"),
+                make_named_property(name="location", type="array", item_type={"type": "string"}),
             ]
         )
         property_extractor = LLMPropertyExtractor(llm, schema=schema)

--- a/lib/sycamore/sycamore/transforms/property_extraction/prompts.py
+++ b/lib/sycamore/sycamore/transforms/property_extraction/prompts.py
@@ -34,6 +34,8 @@ def format_property(prop: Property, indent=0) -> str:
         assert isinstance(prop, ChoiceProperty)
         return 'enum { "' + '", "'.join(map(str, prop.choices)) + '" }'
     basic_str = f"{{ type: {prop.type.value}"
+    if prop.default is not None:
+        basic_str += f", default={prop.default}"
     if prop.description is not None:
         basic_str += f", description: {prop.description}"
     if prop.extraction_instructions is not None:


### PR DESCRIPTION
This change is a follow-up to the previous change adding SchemaV2. It migrates the existing transforms and query logic to use the new Schema model and update the tests to match.

Once this is in. We can go back and rename SchemaV2 back to Schema.