### PR TITLE
[extract] default to datatype.string if prediction is none

### DIFF
--- a/lib/sycamore/sycamore/transforms/property_extraction/types.py
+++ b/lib/sycamore/sycamore/transforms/property_extraction/types.py
@@ -66,7 +66,7 @@ class RichProperty(BaseModel):
             )
         return RichProperty(
             name=name,
-            type=DataType.from_python(prediction),
+            type=DataType.from_python(prediction) if prediction is not None else DataType.STRING,
             value=prediction,
             attribution=AttributionValue(
                 element_indices=[e.element_index for e in attributable_elements if e.element_index is not None]


### PR DESCRIPTION
otherwise I get a bunch of logs saying "Warning: NoneType is not a data type, defaulting to string"