### PR TITLE
Add basic gpt-5 support.

### DIFF
--- a/lib/sycamore/sycamore/llms/config.py
+++ b/lib/sycamore/sycamore/llms/config.py
@@ -103,6 +103,10 @@ class OpenAIModels(Enum):
     O4_MINI = OpenAIModel(name="o4-mini", is_chat=True)
     O3 = OpenAIModel(name="o3", is_chat=True)
 
+    GPT_5 = OpenAIModel(name="gpt-5", is_chat=True)
+    GPT_5_MINI = OpenAIModel(name="gpt-5-mini", is_chat=True)
+    GPT_5_NANO = OpenAIModel(name="gpt-5-nano", is_chat=True)
+
     @classmethod
     def from_name(cls, name: str):
         for m in iter(cls):

--- a/lib/sycamore/sycamore/llms/openai.py
+++ b/lib/sycamore/sycamore/llms/openai.py
@@ -322,7 +322,7 @@ class OpenAI(LLM):
             **(llm_kwargs or {}),
         }
 
-        if not self.model.name.startswith("o"):
+        if not self.model.name.startswith("o") and not self.model.name.startswith("gpt-5"):
             kwargs["temperature"] = 0
 
         if "SYCAMORE_OPENAI_USER" in os.environ:

--- a/lib/sycamore/sycamore/tests/integration/llms/test_openai.py
+++ b/lib/sycamore/sycamore/tests/integration/llms/test_openai.py
@@ -246,6 +246,13 @@ def test_reasoning_model():
     assert len(res) > 0
 
 
+def test_gpt_5():
+    llm = OpenAI(OpenAIModels.GPT_5_MINI)
+    res = llm.generate(prompt=TestPrompt().render_generic())
+    print(res)
+    assert len(res) > 0
+
+
 @pytest.fixture(scope="module")
 def azure_llm():
     # Note this deployment name is different from the official model name, which has a '.'


### PR DESCRIPTION
This commit adds basic support for gpt-5, gpt-5-mini, and gpt-5-nano. More work will be required to support the verbosity and reasoning effort parameters.