### PR TITLE
Convert "str" to "string" when handling old schema format.

### DIFF
--- a/lib/sycamore/sycamore/schema.py
+++ b/lib/sycamore/sycamore/schema.py
@@ -229,6 +229,10 @@ def _convert_to_named_property(schema_prop: SchemaField) -> NamedProperty:
         "examples": schema_prop.examples,
     }
 
+    # Convert common type names to corresponding DataType
+    if prop_type_dict["type"] == "str":
+        prop_type_dict["type"] = DataType.STRING
+
     if (declared_type := prop_type_dict["type"]) not in DataType.values():
         prop_type_dict["custom_type"] = declared_type
         prop_type_dict["type"] = DataType.CUSTOM


### PR DESCRIPTION
We previously tended to use "str" as the type in our schemas. This change just makes things more robust.