### PR TITLE
Change Schema serialization to support backwards compatibility.

### DIFF
--- a/lib/sycamore/sycamore/schema.py
+++ b/lib/sycamore/sycamore/schema.py
@@ -320,7 +320,7 @@ class SchemaV2(BaseModel):
             fields.append(
                 {
                     "name": p.name,
-                    "property_type": p.type.custom_type if p.type.type == DataType.CUSTOM else p.type.type,
+                    "property_type": p.type.custom_type if p.type.type == DataType.CUSTOM else p.type.type.value,
                     "default": p.type.default,
                     "description": p.type.description,
                     "examples": p.type.examples,


### PR DESCRIPTION
This ensures that old versions of the code can read serialized schemas, as long as they don't make use of any of the new incompatible features.