### PR TITLE
Rewrite union_dropped_token_with_cells and update tests.

### DIFF
--- a/lib/sycamore/sycamore/tests/unit/transforms/test_table_transfomers.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_table_transfomers.py
@@ -408,10 +408,22 @@ class TestStructureToCells:
             {"text": "Dropped Token Above", "bbox": [5, 5, 45, 8], "span_num": 0, "line_num": 0, "block_num": 0},
             {"text": "Cell 1", "bbox": [5, 5, 45, 15], "span_num": 1, "line_num": 0, "block_num": 0},
             {"text": "Dropped Token Between", "bbox": [5, 25, 45, 35], "span_num": 2, "line_num": 0, "block_num": 0},
-            {"text": "Dropped Token Intersecting", "bbox": [5, 15, 45, 35], "span_num": 3, "line_num": 0, "block_num": 0},
+            {
+                "text": "Dropped Token Intersecting",
+                "bbox": [5, 15, 45, 35],
+                "span_num": 3,
+                "line_num": 0,
+                "block_num": 0,
+            },
             {"text": "Cell 2", "bbox": [5, 45, 45, 55], "span_num": 3, "line_num": 0, "block_num": 0},
             {"text": "Dropped Token Below", "bbox": [5, 65, 45, 70], "span_num": 4, "line_num": 0, "block_num": 0},
-            {"text": "Dropped Token Below and Spanning", "bbox": [40, 75, 60, 85], "span_num": 5, "line_num": 0, "block_num": 0},
+            {
+                "text": "Dropped Token Below and Spanning",
+                "bbox": [40, 75, 60, 85],
+                "span_num": 5,
+                "line_num": 0,
+                "block_num": 0,
+            },
         ]
 
         cells, confidence_score = structure_to_cells(table_structure, tokens, union_tokens=True)

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_table_transfomers.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_table_transfomers.py
@@ -4,7 +4,6 @@ from sycamore.transforms.table_structure.table_transformers import (
     resolve_overlaps_func,
     structure_to_cells,
 )
-import pytest
 import torch
 import numpy as np
 import copy

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_table_transfomers.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_table_transfomers.py
@@ -392,7 +392,7 @@ class TestStructureToCells:
         assert not self._has_degenerate_cell(cells)
         assert not self._has_cell_overlap(cells)
 
-    @pytest.mark.skip(reason="TODO: Fix degenerate cell issue when union_tokens=True")
+    # @pytest.mark.skip(reason="TODO: Fix degenerate cell issue when union_tokens=True")
     def test_union_tokens(self):
         """Test table structure with union_tokens=True."""
         table_structure = {
@@ -401,28 +401,53 @@ class TestStructureToCells:
                 # Gap between rows
                 {"bbox": [0, 40, 100, 60], "column header": False},
             ],
-            "columns": [{"bbox": [0, 0, 50, 40]}, {"bbox": [50, 0, 100, 40]}],
+            "columns": [{"bbox": [0, 0, 50, 60]}, {"bbox": [50, 0, 100, 60]}],
             "spanning cells": [],
             "column headers": [],
         }
 
         tokens = [
-            {"text": "Dropped Token Above", "bbox": [2, 5, 45, 8], "span_num": 0, "line_num": 0, "block_num": 0},
+            {"text": "Dropped Token Above", "bbox": [5, 5, 45, 8], "span_num": 0, "line_num": 0, "block_num": 0},
             {"text": "Cell 1", "bbox": [5, 5, 45, 15], "span_num": 1, "line_num": 0, "block_num": 0},
-            {"text": "Cell 2", "bbox": [5, 45, 45, 55], "span_num": 2, "line_num": 0, "block_num": 0},
-            {"text": "Dropped Token Between", "bbox": [5, 25, 45, 35], "span_num": 3, "line_num": 0, "block_num": 0},
+            {"text": "Dropped Token Between", "bbox": [5, 25, 45, 35], "span_num": 2, "line_num": 0, "block_num": 0},
+            {"text": "Cell 2", "bbox": [5, 45, 45, 55], "span_num": 3, "line_num": 0, "block_num": 0},
+            {"text": "Dropped Token Below", "bbox": [5, 65, 45, 70], "span_num": 4, "line_num": 0, "block_num": 0},
         ]
 
         cells, confidence_score = structure_to_cells(table_structure, tokens, union_tokens=True)
-
+        print(cells)
         assert len(cells) >= 4
 
-        cell_1 = next(cell for cell in cells if cell["row_nums"] == [0] and cell["column_nums"] == [0])
-        assert cell_1["cell text"] == "Cell 1"
-        assert cell_1["bbox"] == [0, 10, 50, 20]
+        # Test "Dropped Token Above" - should be in row 0, column 0
+        cell_above = next(cell for cell in cells if cell["row_nums"] == [0] and cell["column_nums"] == [0])
+        assert cell_above["cell text"] == "Dropped Token Above"
+        assert cell_above["bbox"] == [0, 5, 50, 10]
+
+        # Test "Dropped Token Between" - should be in row 2, column 0 (between the two existing rows)
+        cell_between = next(cell for cell in cells if cell["cell text"] == "Dropped Token Between")
+        assert cell_between["row_nums"] == [2]
+        assert cell_between["column_nums"] == [0]
+        assert cell_between["bbox"] == [0, 20, 50, 40]
+
+        # Test "Dropped Token Below" - should be in row 4, column 0 (below the last existing row)
+        cell_below = next(cell for cell in cells if cell["cell text"] == "Dropped Token Below")
+        assert cell_below["row_nums"] == [4]
+        assert cell_below["column_nums"] == [0]
+        # The bbox should extend from the last row's bottom to accommodate the token
+        assert cell_below["bbox"] == [0, 60, 50, 70]
+
+        cell_1_regular = next(cell for cell in cells if cell["cell text"] == "Cell 1")
+        assert cell_1_regular["row_nums"] == [1]
+        assert cell_1_regular["column_nums"] == [0]
+        assert cell_1_regular["bbox"] == [0, 10, 50, 20]
+
+        cell_below = next(cell for cell in cells if cell["cell text"] == "Cell 2")
+        assert cell_below["row_nums"] == [3]
+        assert cell_below["column_nums"] == [0]
+        assert cell_below["bbox"] == [0, 40, 50, 60]
 
         dropped_token_cells = [cell for cell in cells if "Dropped Token" in cell["cell text"]]
-        assert len(dropped_token_cells) == 2
+        assert len(dropped_token_cells) == 3
 
         assert not self._has_degenerate_cell(cells)
         assert not self._has_cell_overlap(cells)

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_table_transfomers.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_table_transfomers.py
@@ -427,7 +427,7 @@ class TestStructureToCells:
         ]
 
         cells, confidence_score = structure_to_cells(table_structure, tokens, union_tokens=True)
-        assert len(cells) >= 4
+        assert len(cells) == 11
 
         for cell in cells:
             if cell["cell text"] == "Dropped Token Above":

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_table_transfomers.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_table_transfomers.py
@@ -391,7 +391,6 @@ class TestStructureToCells:
         assert not self._has_degenerate_cell(cells)
         assert not self._has_cell_overlap(cells)
 
-    # @pytest.mark.skip(reason="TODO: Fix degenerate cell issue when union_tokens=True")
     def test_union_tokens(self):
         """Test table structure with union_tokens=True."""
         table_structure = {
@@ -414,7 +413,6 @@ class TestStructureToCells:
         ]
 
         cells, confidence_score = structure_to_cells(table_structure, tokens, union_tokens=True)
-        print(cells)
         assert len(cells) >= 4
 
         # Test "Dropped Token Above" - should be in row 0, column 0

--- a/lib/sycamore/sycamore/tests/unit/transforms/test_table_transfomers.py
+++ b/lib/sycamore/sycamore/tests/unit/transforms/test_table_transfomers.py
@@ -408,43 +408,47 @@ class TestStructureToCells:
             {"text": "Dropped Token Above", "bbox": [5, 5, 45, 8], "span_num": 0, "line_num": 0, "block_num": 0},
             {"text": "Cell 1", "bbox": [5, 5, 45, 15], "span_num": 1, "line_num": 0, "block_num": 0},
             {"text": "Dropped Token Between", "bbox": [5, 25, 45, 35], "span_num": 2, "line_num": 0, "block_num": 0},
+            {"text": "Dropped Token Intersecting", "bbox": [5, 15, 45, 35], "span_num": 3, "line_num": 0, "block_num": 0},
             {"text": "Cell 2", "bbox": [5, 45, 45, 55], "span_num": 3, "line_num": 0, "block_num": 0},
             {"text": "Dropped Token Below", "bbox": [5, 65, 45, 70], "span_num": 4, "line_num": 0, "block_num": 0},
+            {"text": "Dropped Token Below and Spanning", "bbox": [40, 75, 60, 85], "span_num": 5, "line_num": 0, "block_num": 0},
         ]
 
         cells, confidence_score = structure_to_cells(table_structure, tokens, union_tokens=True)
         assert len(cells) >= 4
 
-        # Test "Dropped Token Above" - should be in row 0, column 0
-        cell_above = next(cell for cell in cells if cell["row_nums"] == [0] and cell["column_nums"] == [0])
-        assert cell_above["cell text"] == "Dropped Token Above"
-        assert cell_above["bbox"] == [0, 5, 50, 10]
-
-        # Test "Dropped Token Between" - should be in row 2, column 0 (between the two existing rows)
-        cell_between = next(cell for cell in cells if cell["cell text"] == "Dropped Token Between")
-        assert cell_between["row_nums"] == [2]
-        assert cell_between["column_nums"] == [0]
-        assert cell_between["bbox"] == [0, 20, 50, 40]
-
-        # Test "Dropped Token Below" - should be in row 4, column 0 (below the last existing row)
-        cell_below = next(cell for cell in cells if cell["cell text"] == "Dropped Token Below")
-        assert cell_below["row_nums"] == [4]
-        assert cell_below["column_nums"] == [0]
-        # The bbox should extend from the last row's bottom to accommodate the token
-        assert cell_below["bbox"] == [0, 60, 50, 70]
-
-        cell_1_regular = next(cell for cell in cells if cell["cell text"] == "Cell 1")
-        assert cell_1_regular["row_nums"] == [1]
-        assert cell_1_regular["column_nums"] == [0]
-        assert cell_1_regular["bbox"] == [0, 10, 50, 20]
-
-        cell_below = next(cell for cell in cells if cell["cell text"] == "Cell 2")
-        assert cell_below["row_nums"] == [3]
-        assert cell_below["column_nums"] == [0]
-        assert cell_below["bbox"] == [0, 40, 50, 60]
+        for cell in cells:
+            if cell["cell text"] == "Dropped Token Above":
+                assert cell["row_nums"] == [0]
+                assert cell["column_nums"] == [0]
+                assert cell["bbox"] == [0, 5, 50, 10]
+            elif cell["cell text"] == "Dropped Token Between":
+                assert cell["row_nums"] == [2]
+                assert cell["column_nums"] == [0]
+                assert cell["bbox"] == [0, 20, 50, 40]
+            elif cell["cell text"] == "Dropped Token Below":
+                assert cell["row_nums"] == [4]
+                assert cell["column_nums"] == [0]
+                assert cell["bbox"] == [0, 60, 50, 70]
+            elif cell["cell text"] == "Cell 1":
+                assert cell["row_nums"] == [1]
+                assert cell["column_nums"] == [0]
+                assert cell["bbox"] == [0, 10, 50, 20]
+            elif cell["cell text"] == "Cell 2":
+                assert cell["row_nums"] == [3]
+                assert cell["column_nums"] == [0]
+                assert cell["bbox"] == [0, 40, 50, 60]
+            elif cell["cell text"] == "Dropped Token Intersecting":
+                assert cell["row_nums"] == [1]
+                assert cell["column_nums"] == [0]
+                assert cell["bbox"] == [0, 10, 50, 20]
+            elif cell["cell text"] == "Dropped Token Below and Spanning":
+                assert cell["row_nums"] == [5]
+                assert cell["column_nums"] == [0, 1]
+                assert cell["bbox"] == [0, 70, 100, 85]
 
         dropped_token_cells = [cell for cell in cells if "Dropped Token" in cell["cell text"]]
-        assert len(dropped_token_cells) == 3
+        assert len(dropped_token_cells) == 5
 
         assert not self._has_degenerate_cell(cells)
         assert not self._has_cell_overlap(cells)
@@ -496,11 +500,11 @@ class TestStructureToCells:
         tokens = [
             {"text": "Cell 1", "bbox": [5, 5, 45, 25], "span_num": 0, "line_num": 0, "block_num": 0},
             {"text": "Cell 2", "bbox": [55, 5, 95, 25], "span_num": 1, "line_num": 0, "block_num": 0},
-            {"text": "Cell 3", "bbox": [5, 35, 45, 55], "span_num": 2, "line_num": 0, "block_num": 0},
-            {"text": "Cell 4", "bbox": [55, 35, 95, 55], "span_num": 3, "line_num": 0, "block_num": 0},
-            {"text": "HorizOverlap", "bbox": [40, 10, 60, 20], "span_num": 4, "line_num": 0, "block_num": 0},
-            {"text": "VertOverlap", "bbox": [10, 20, 30, 40], "span_num": 5, "line_num": 0, "block_num": 0},
-            {"text": "DiagOverlap", "bbox": [45, 25, 95, 55], "span_num": 6, "line_num": 0, "block_num": 0},
+            {"text": "HorizOverlap", "bbox": [40, 10, 60, 20], "span_num": 2, "line_num": 0, "block_num": 0},
+            {"text": "VertOverlap", "bbox": [10, 20, 30, 40], "span_num": 3, "line_num": 0, "block_num": 0},
+            {"text": "DiagOverlap", "bbox": [45, 25, 95, 55], "span_num": 4, "line_num": 0, "block_num": 0},
+            {"text": "Cell 3", "bbox": [5, 35, 45, 55], "span_num": 5, "line_num": 0, "block_num": 0},
+            {"text": "Cell 4", "bbox": [55, 35, 95, 55], "span_num": 6, "line_num": 0, "block_num": 0},
         ]
 
         cells, confidence_score = structure_to_cells(table_structure, tokens, union_tokens=False)

--- a/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
@@ -927,7 +927,7 @@ def _find_or_create_structure_for_token(token_bbox, rows, columns, cells, is_row
     # Sanity check that the structures are sorted
     assert (
         cur_structs[0]["bbox"][start_coord_idx] < cur_structs[-1]["bbox"][start_coord_idx]
-    ), f"Structures are not sorted, first structure: {cur_structs[0]['bbox']} and last structure: {cur_structs[-1]['bbox']}"
+    ), f"Structures are not sorted, first structure: {cur_structs[0]['bbox']}, last structure: {cur_structs[-1]['bbox']}"
 
     # Find the best position to insert new structure
     insert_idx = 0

--- a/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
@@ -925,7 +925,9 @@ def _find_or_create_structure_for_token(token_bbox, rows, columns, cells, is_row
         return overlapping_struct_idxs
 
     # Sanity check that the structures are sorted
-    assert cur_structs[0]["bbox"][start_coord_idx] < cur_structs[-1]["bbox"][start_coord_idx]
+    assert (
+        cur_structs[0]["bbox"][start_coord_idx] < cur_structs[-1]["bbox"][start_coord_idx]
+    ), f"Structures are not sorted, first structure: {cur_structs[0]['bbox']} and last structure: {cur_structs[-1]['bbox']}"
 
     # Find the best position to insert new structure
     insert_idx = 0
@@ -945,9 +947,7 @@ def _find_or_create_structure_for_token(token_bbox, rows, columns, cells, is_row
                 insert_idx = idx + 1
                 break
 
-    # Create the new structure and update related structures
-
-    # This assumes that the rows and columns are properly aligned
+    # Create the new structure and update related structures. This assumes that the rows and columns are properly aligned.
     new_struct_bbox = [rows[0]["bbox"][0], columns[0]["bbox"][1], rows[0]["bbox"][2], columns[0]["bbox"][3]]
 
     if insert_idx == 0:
@@ -1030,8 +1030,8 @@ def union_dropped_tokens_with_cells(cells, dropped_tokens, rows, columns):
             ):
                 # These cells should be in a new structure created by _find_or_create_structure_for_token
                 # and should be empty.
-                assert cell["cell text"] == ""
-                assert len(cell["spans"]) == 0
+                assert cell["cell text"] == "", f"Cell for dropped token should have no text: {cell}"
+                assert len(cell["spans"]) == 0, f"Cell for dropped token should have no spans: {cell}"
 
                 cells_to_remove.append(cell)
 

--- a/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
@@ -924,8 +924,6 @@ def _find_or_create_structure_for_token(token_bbox, rows, columns, cells, is_row
     if len(overlapping_struct_idxs) > 0:
         return overlapping_struct_idxs
 
-    # If the token does not overlap with any existing structure, create a
-    # new structure and its corresponding cells
 
     # Sanity check that the structures are sorted
     assert cur_structs[0]["bbox"][start_coord_idx] < cur_structs[-1]["bbox"][start_coord_idx]
@@ -950,9 +948,7 @@ def _find_or_create_structure_for_token(token_bbox, rows, columns, cells, is_row
 
     # Create the new structure and update related structures
 
-    # NOTE: Intentionally ignoring the "column header" field. Creating a column header from a dropped token is
-    # unlikely to generate a correct header, and we don't want to modify an existing correct one.
-
+    
     # This assumes that the rows and columns are properly aligned
     new_struct_bbox = [rows[0]["bbox"][0], columns[0]["bbox"][1], rows[0]["bbox"][2], columns[0]["bbox"][3]]
 
@@ -973,6 +969,9 @@ def _find_or_create_structure_for_token(token_bbox, rows, columns, cells, is_row
 
         new_struct_bbox[start_coord_idx] = prev_struct["bbox"][end_coord_idx]
         new_struct_bbox[end_coord_idx] = next_struct["bbox"][start_coord_idx]
+
+    # NOTE: Intentionally ignoring the "column header" field of the structure. Creating a column header from a dropped token is
+    # unlikely to generate a correct header, and we don't want to modify an existing correct one.
 
     new_struct = {"bbox": new_struct_bbox}
     cur_structs.insert(insert_idx, new_struct)

--- a/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
@@ -133,7 +133,6 @@ def objects_to_table(
     structures = objects_to_structures(objects, tokens=tokens, class_thresholds=structure_class_thresholds)
 
     if len(structures) == 0:
-
         if not tokens:
             return None
 
@@ -157,7 +156,6 @@ def objects_to_table(
 
     table_cells = []
     for cell in cells:
-
         rows = sorted(cell["row_nums"])
         rows = list(range(rows[0], rows[-1] + 1))
 
@@ -175,7 +173,6 @@ def objects_to_table(
         )
 
     if len(table_cells) == 0:
-
         if not tokens:
             return None
 
@@ -966,7 +963,7 @@ def _find_or_create_row_for_token(token_rect, rows, cells, columns):
             ]
         }
         rows.insert(insert_idx, new_row)
-        
+
         # Update cell row numbers
         for cell in cells:
             for i, row_num in enumerate(cell["row_nums"]):
@@ -1082,6 +1079,7 @@ def _find_or_create_column_for_token(token_rect, columns, cells, rows):
         row["bbox"][2] = max(row["bbox"][2], new_col_right)
 
     return [new_idx]
+
 
 def union_dropped_tokens_with_cells(cells, dropped_tokens, rows, columns):
     """

--- a/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
@@ -913,6 +913,9 @@ def _find_or_create_structure_for_token(token_bbox, rows, columns, cells, is_row
         ):
             return [idx]
 
+    # Sanity check that the structures are sorted
+    assert cur_structs[0]["bbox"][start_coord_idx] <= cur_structs[-1]["bbox"][start_coord_idx]
+
     # Find the best position to insert new structure
     insert_idx = 0
 
@@ -1001,20 +1004,13 @@ def _find_or_create_structure_for_token(token_bbox, rows, columns, cells, is_row
 
         new_idx = insert_idx
 
-    if is_row:
-        # For rows, ensure all columns extend to cover the new row's vertical span
-        new_row_top = new_struct["bbox"][1]
-        new_row_bottom = new_struct["bbox"][3]
-        for col in other_structs:
-            col["bbox"][1] = min(col["bbox"][1], new_row_top)
-            col["bbox"][3] = max(col["bbox"][3], new_row_bottom)
-    else:
-        # For columns, ensure all rows extend to cover the new column's horizontal span
-        new_col_left = new_struct["bbox"][0]
-        new_col_right = new_struct["bbox"][2]
-        for row in other_structs:
-            row["bbox"][0] = min(row["bbox"][0], new_col_left)
-            row["bbox"][2] = max(row["bbox"][2], new_col_right)
+    # Update other structures to cover the new structure
+    new_start_coord = new_struct["bbox"][start_coord_idx]
+    new_end_coord = new_struct["bbox"][end_coord_idx]
+
+    for other_struct in other_structs:
+        other_struct["bbox"][start_coord_idx] = min(other_struct["bbox"][start_coord_idx], new_start_coord)
+        other_struct["bbox"][end_coord_idx] = max(other_struct["bbox"][end_coord_idx], new_end_coord)
 
     return [new_idx]
 

--- a/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
@@ -924,7 +924,6 @@ def _find_or_create_structure_for_token(token_bbox, rows, columns, cells, is_row
     if len(overlapping_struct_idxs) > 0:
         return overlapping_struct_idxs
 
-
     # Sanity check that the structures are sorted
     assert cur_structs[0]["bbox"][start_coord_idx] < cur_structs[-1]["bbox"][start_coord_idx]
 
@@ -948,7 +947,6 @@ def _find_or_create_structure_for_token(token_bbox, rows, columns, cells, is_row
 
     # Create the new structure and update related structures
 
-    
     # This assumes that the rows and columns are properly aligned
     new_struct_bbox = [rows[0]["bbox"][0], columns[0]["bbox"][1], rows[0]["bbox"][2], columns[0]["bbox"][3]]
 

--- a/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
@@ -1047,6 +1047,7 @@ def union_dropped_tokens_with_cells(cells, dropped_tokens, rows, columns):
             "row_nums": token_rows,
             "column header": False,
             "cell text": token["text"],
+            "spans": [token],
         }
         cells.append(cell)
 

--- a/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/table_transformers.py
@@ -874,13 +874,22 @@ def align_supercells(supercells, rows, columns):
 
 
 def _add_token_to_intersecting_cell(cells, token):
-    """Add token text to the first cell it intersects with. Returns True if intersection found."""
+    """Add token text to the cell it overlaps with the most. Returns True if overlap found."""
     token_rect = BoundingBox(*token["bbox"])
+    max_overlap = 0
+    max_overlap_cell = None
+
     for cell in cells:
         cell_rect = BoundingBox(*cell["bbox"])
-        if cell_rect.intersect(token_rect).area > 0:
-            cell["cell text"] = cell.get("cell text", "") + extract_text_from_spans([token])
-            return True
+        overlap = cell_rect.intersect(token_rect).area
+        if overlap > max_overlap:
+            max_overlap = overlap
+            max_overlap_cell = cell
+
+    if max_overlap_cell:
+        max_overlap_cell["cell text"] = max_overlap_cell.get("cell text", "") + extract_text_from_spans([token])
+        return True
+
     return False
 
 


### PR DESCRIPTION
Previous Errors
- Dropped tokens were incorrectly assigned to wrong columns
- Mismatched row/column dimensions when inserting new rows/columns, row bboxs were not updated when inserting columns and vice versa
- Invalid bounding boxes [0, 0, 0, 0] caused by mismatched row/column dimensions

Changes Made
- Refactored logic into separate helper functions
- Fixed row/column intersection logic to properly handle tokens outside existing table boundaries
- Fixed row/column dimension mismatch by extending rows/columns to cover new dimensions
- Re-enabled and updated test for the function
