### PR TITLE
Improve extract_json and rendered prompts

### DIFF
--- a/lib/sycamore/sycamore/llms/prompts/prompts.py
+++ b/lib/sycamore/sycamore/llms/prompts/prompts.py
@@ -50,6 +50,9 @@ class RenderedPrompt:
             return 0
         return sum(len(tokenizer.tokenize(m.content)) for m in self.messages)
 
+    def to_human_readable(self) -> str:
+        return "\n".join(f"------------------------\n{m.role}\n-----------------------\n{m.content}\n" for m in self.messages)
+
 
 class SycamorePrompt:
     """Base class/API for all Sycamore LLM Prompt objects. Sycamore Prompts

--- a/lib/sycamore/sycamore/llms/prompts/prompts.py
+++ b/lib/sycamore/sycamore/llms/prompts/prompts.py
@@ -51,7 +51,9 @@ class RenderedPrompt:
         return sum(len(tokenizer.tokenize(m.content)) for m in self.messages)
 
     def to_human_readable(self) -> str:
-        return "\n".join(f"------------------------\n{m.role}\n-----------------------\n{m.content}\n" for m in self.messages)
+        return "\n".join(
+            f"------------------------\n{m.role}\n-----------------------\n{m.content}\n" for m in self.messages
+        )
 
 
 class SycamorePrompt:

--- a/lib/sycamore/sycamore/tests/unit/utils/test_extract_json.py
+++ b/lib/sycamore/sycamore/tests/unit/utils/test_extract_json.py
@@ -23,14 +23,26 @@ def test_bad_escape():
 
 def test_code_block():
     want = {"a": 5, "x": "y"}
-    # Note extract_json does not tolerate any leading whitespace
+    # Test without and with leading whitespce
     input = """```json
 { "a": 5, "x": "y" }
 ```
 """
     assert extract_json(input) == want
+    assert extract_json("\n" + input) == want
 
+def test_nested_code_block():
+    want = {"a": 5, "x": "```json ... ```"}
+    input = """
+I am so helpful, the json you want is:
+```json
+{ "a": 5, "x": "```json ... ```" }
+```
+That is some perfect json."""
 
+    got = extract_json(input, verbose=True)
+    assert got == want
+    
 def test_fails():
     with pytest.raises(ValueError):
         extract_json("1-2")

--- a/lib/sycamore/sycamore/tests/unit/utils/test_extract_json.py
+++ b/lib/sycamore/sycamore/tests/unit/utils/test_extract_json.py
@@ -31,6 +31,7 @@ def test_code_block():
     assert extract_json(input) == want
     assert extract_json("\n" + input) == want
 
+
 def test_nested_code_block():
     want = {"a": 5, "x": "```json ... ```"}
     input = """
@@ -42,7 +43,8 @@ That is some perfect json."""
 
     got = extract_json(input, verbose=True)
     assert got == want
-    
+
+
 def test_fails():
     with pytest.raises(ValueError):
         extract_json("1-2")

--- a/lib/sycamore/sycamore/utils/extract_json.py
+++ b/lib/sycamore/sycamore/utils/extract_json.py
@@ -4,28 +4,42 @@ from json import JSONDecodeError
 from typing import Any
 
 
-def extract_json(payload: str) -> Any:
+def extract_json(payload: str, verbose=False) -> Any:
     """Given the provided payload, extract the JSON block from it."""
 
+    orig_payload = payload
+    if verbose:
+        print(f"--------------------Extract Json--------------------\n{payload}\n")
+    # It is possible that the LLM response includes a code block with JSON data.
+    # Pull the JSON content out from it.
+    pattern = r"(^|.*\n)```json\n([\s\S]*?\n)```"
+    match = re.match(pattern, payload, re.DOTALL)
+    if match:
+        payload = match.group(2)
+        if verbose:
+            print(f"  ----------------------remove ```json ``` wrapper -----------\n{payload}\n")
+    elif verbose and "```json" in payload:
+        print(f"  --------------------did not remove ```json from payload")
+            
     # Replace Python's None with JSON's null, being careful to not replace
     # strings that might contain "None" as part of their content
-    payload = re.sub(r":\s*None\b", ": null", payload)
-
+    p2 = re.sub(r":\s*None\b", ": null", payload)
+    if p2 != payload:
+        payload = p2
+        if verbose:
+            print(f"  ----------------------replace Python None -----------------\n{payload}\n")
+            
     try:
         return json.loads(payload)
-    except (ValueError, TypeError, JSONDecodeError) as exc:
+    except JSONDecodeError as exc:
         # Sometimes the LLM makes up an escape code. In that case,
         # replace the escape char with its representation (e.g. \\x07)
         # and recurse.
-        if isinstance(exc, JSONDecodeError) and "Invalid \\escape" in exc.msg:
+        if "Invalid \\escape" in exc.msg:
             c = payload[exc.pos]
             payload = payload[: exc.pos] + repr(c)[1:-1] + payload[exc.pos + 1 :]
-            return extract_json(payload)
-        # It is possible that the LLM response includes a code block with JSON data.
-        # Pull the JSON content out from it.
-        pattern = r"```json([\s\S]*?)```"
-        match = re.match(pattern, payload)
-        if match:
-            return json.loads(match.group(1))
+            if verbose:
+                print(f"  --------------------------replace invalid escape {c} --------\n{payload}")
+            return extract_json(payload, verbose=verbose)
         else:
-            raise ValueError("JSON block not found in LLM response: " + str(payload)) from exc
+            raise ValueError("JSON block not found in LLM response: " + str(orig_payload)) from exc

--- a/lib/sycamore/sycamore/utils/extract_json.py
+++ b/lib/sycamore/sycamore/utils/extract_json.py
@@ -19,8 +19,8 @@ def extract_json(payload: str, verbose=False) -> Any:
         if verbose:
             print(f"  ----------------------remove ```json ``` wrapper -----------\n{payload}\n")
     elif verbose and "```json" in payload:
-        print(f"  --------------------did not remove ```json from payload")
-            
+        print("  --------------------did not remove ```json from payload")
+
     # Replace Python's None with JSON's null, being careful to not replace
     # strings that might contain "None" as part of their content
     p2 = re.sub(r":\s*None\b", ": null", payload)
@@ -28,7 +28,7 @@ def extract_json(payload: str, verbose=False) -> Any:
         payload = p2
         if verbose:
             print(f"  ----------------------replace Python None -----------------\n{payload}\n")
-            
+
     try:
         return json.loads(payload)
     except JSONDecodeError as exc:


### PR DESCRIPTION
Handle ```json ``` inside of a string in the returned JSON.
add to_human_readable for rendered prompts.
