### PR TITLE
Make file extension comparison case insensitive in local mode.

### DIFF
--- a/lib/sycamore/sycamore/connectors/file/file_scan.py
+++ b/lib/sycamore/sycamore/connectors/file/file_scan.py
@@ -185,7 +185,7 @@ class BinaryScan(FileScan):
             filesystem=filesystem,
             **resource_args,
         )
-        self._binary_format = binary_format.lower()
+        self._binary_format = binary_format.lower() if binary_format is not None else None
         self._metadata_provider = metadata_provider
         self._filter_paths_by_extension = filter_paths_by_extension
         self._path_filter = None

--- a/lib/sycamore/sycamore/connectors/file/file_scan.py
+++ b/lib/sycamore/sycamore/connectors/file/file_scan.py
@@ -185,7 +185,7 @@ class BinaryScan(FileScan):
             filesystem=filesystem,
             **resource_args,
         )
-        self._binary_format = binary_format
+        self._binary_format = binary_format.lower()
         self._metadata_provider = metadata_provider
         self._filter_paths_by_extension = filter_paths_by_extension
         self._path_filter = None
@@ -258,7 +258,7 @@ class BinaryScan(FileScan):
     def process_file(self, info) -> list[Document]:
         if not info.is_file:
             return []
-        if self._filter_paths_by_extension and not info.path.endswith(self.format()):
+        if self._filter_paths_by_extension and not info.path.lower().endswith(self.format()):
             return []
         if self._path_filter is not None and not self._path_filter(info.path, True):
             return []


### PR DESCRIPTION
When you specify a binary_format to BinaryScan, it restricts the files to only those of the specified format. Previously there was an inconsistency in behavior between Ray and local modes. In Ray mode, the extensions were specified in a case-insensitive way, whereas in local mode they were case sensitive.

This commit makes both case insensitive.