### PR TITLE
Add a hack so we can disable the automatic detr retry.  Add a hack to help debug LLM prompts and results.

### DIFF
--- a/lib/sycamore/sycamore/llms/llms.py
+++ b/lib/sycamore/sycamore/llms/llms.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 import copy
 from enum import Enum
 import logging
+from pathlib import Path
 import pickle
 import base64
 from PIL import Image

--- a/lib/sycamore/sycamore/llms/llms.py
+++ b/lib/sycamore/sycamore/llms/llms.py
@@ -3,7 +3,6 @@ from abc import ABC, abstractmethod
 import copy
 from enum import Enum
 import logging
-from pathlib import Path
 import pickle
 import base64
 from PIL import Image

--- a/lib/sycamore/sycamore/transforms/base_llm.py
+++ b/lib/sycamore/sycamore/transforms/base_llm.py
@@ -42,6 +42,7 @@ def _infer_prompts(
                 if all_prompt_dir := os.environ.get("LLM_DEBUG_DIR"):
                     from datetime import datetime
                     from pathlib import Path
+
                     now = datetime.now().isoformat()
                     path = Path(all_prompt_dir) / f"{now}.txt"
                     logger.info(f"Saving prompt and result to {path}")

--- a/lib/sycamore/sycamore/transforms/base_llm.py
+++ b/lib/sycamore/sycamore/transforms/base_llm.py
@@ -39,6 +39,16 @@ def _infer_prompts(
             try:
                 s = llm.generate(prompt=p)
                 res.append(s)
+                if all_prompt_dir := os.environ.get("LLM_DEBUG_DIR"):
+                    from datetime import datetime
+                    from pathlib import Path
+                    now = datetime.now().isoformat()
+                    path = Path(all_prompt_dir) / f"{now}.txt"
+                    logger.info(f"Saving prompt and result to {path}")
+                    with open(path, "w") as f:
+                        f.write(p.to_human_readable())
+                        f.write("\n\n--------------------------------------------\n\n")
+                        f.write(s)
             except Exception:
                 bad_prompt_path = os.environ.get("BAD_PROMPT_PATH", "/tmp/bad_prompt.txt")
                 with open(bad_prompt_path, "w") as f:

--- a/lib/sycamore/sycamore/transforms/detr_partitioner.py
+++ b/lib/sycamore/sycamore/transforms/detr_partitioner.py
@@ -44,9 +44,12 @@ _TEN_MINUTES = 600
 # The retry logic is controlled by a decorator. Unclear how we could pass in
 # a flag to indicate we don't want retry.
 ENABLE_RETRY = True
+
+
 def disable_retry():
     global ENABLE_RETRY
     ENABLE_RETRY = False
+
 
 class ArynPDFPartitionerException(Exception):
     def __init__(self, message, can_retry=False):

--- a/lib/sycamore/sycamore/transforms/detr_partitioner.py
+++ b/lib/sycamore/sycamore/transforms/detr_partitioner.py
@@ -41,6 +41,12 @@ _VERSION = "0.2024.07.24"
 
 _TEN_MINUTES = 600
 
+# The retry logic is controlled by a decorator. Unclear how we could pass in
+# a flag to indicate we don't want retry.
+ENABLE_RETRY = True
+def disable_retry():
+    global ENABLE_RETRY
+    ENABLE_RETRY = False
 
 class ArynPDFPartitionerException(Exception):
     def __init__(self, message, can_retry=False):
@@ -49,18 +55,22 @@ class ArynPDFPartitionerException(Exception):
 
 
 def _can_retry(e: BaseException) -> bool:
-    def make_mypy_happy(e: BaseException):
+    def make_mypy_happy(msg: str, e: BaseException):
         import traceback
 
         # type(e), value=e needed for compatibility before 3.10; after that, just e should work
-        logger.warning(f"Automatically retrying because of error: {traceback.format_exception_only(type(e), value=e)}")
+        logger.warning(f"{msg}: {traceback.format_exception_only(type(e), value=e)}")
+
+    if not ENABLE_RETRY:
+        make_mypy_happy("Retry disabled, not retrying after", e)
+        return False
 
     if isinstance(e, ArynPDFPartitionerException):
         # make mypy happy, unneeded with mypy 1.15 + python 3.12
         ex: Optional[BaseException] = None
         assert isinstance(e, BaseException)
         ex = e
-        make_mypy_happy(ex)
+        make_mypy_happy("Automatically retrying because of error", ex)
         return e.can_retry
     else:
         return False


### PR DESCRIPTION
We found a file which currently causes persistent errors and want to use fallback parameters which work don't get persistent errors but may have lower quality.

The llm hack lets us see the exact prompts and replies we are sending/getting from an LLM.