### PR TITLE
Torch speedups from benchmarking: low hanging fruit.

### DIFF
--- a/lib/sycamore/sycamore/transforms/detr_partitioner.py
+++ b/lib/sycamore/sycamore/transforms/detr_partitioner.py
@@ -699,7 +699,10 @@ class DeformableDetr(SycamoreObjectDetection):
         results = []
         device = self._get_device()
         inputs = self.processor(images=images, return_tensors="pt").to(device)
-        with (torch.no_grad(), torch.autocast(device)):
+        with (
+            torch.no_grad(),
+            torch.autocast(device),
+        ):
             outputs = self.model(**inputs)
         target_sizes = torch.tensor([image.size[::-1] for image in images])
         results.extend(

--- a/lib/sycamore/sycamore/transforms/similarity.py
+++ b/lib/sycamore/sycamore/transforms/similarity.py
@@ -182,7 +182,10 @@ class HuggingFaceTransformersSimilarityScorer(SimilarityScorer):
         assert self._tokenizer is not None
 
         scores = []
-        with (torch.no_grad(), torch.autocast(self.device)):
+        with (
+            torch.no_grad(),
+            torch.autocast(self.device),
+        ):
             for i in range(0, len(inputs), self.model_batch_size):
                 input_batch = inputs[i : i + self.model_batch_size]
 

--- a/lib/sycamore/sycamore/transforms/similarity.py
+++ b/lib/sycamore/sycamore/transforms/similarity.py
@@ -176,6 +176,7 @@ class HuggingFaceTransformersSimilarityScorer(SimilarityScorer):
 
             self._tokenizer = AutoTokenizer.from_pretrained(self.model_name)
             self._model = AutoModelForSequenceClassification.from_pretrained(self.model_name).to(self.device)
+            assert self._model
             self._model.eval()
 
         assert self._model is not None

--- a/lib/sycamore/sycamore/transforms/similarity.py
+++ b/lib/sycamore/sycamore/transforms/similarity.py
@@ -176,12 +176,13 @@ class HuggingFaceTransformersSimilarityScorer(SimilarityScorer):
 
             self._tokenizer = AutoTokenizer.from_pretrained(self.model_name)
             self._model = AutoModelForSequenceClassification.from_pretrained(self.model_name).to(self.device)
+            self._model.eval()
 
         assert self._model is not None
         assert self._tokenizer is not None
 
         scores = []
-        with torch.no_grad():
+        with (torch.no_grad(), torch.autocast(self.device)):
             for i in range(0, len(inputs), self.model_batch_size):
                 input_batch = inputs[i : i + self.model_batch_size]
 

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -223,7 +223,10 @@ class TableTransformerStructureExtractor(TableStructureExtractor):
 
         import torch
 
-        with (torch.no_grad(), torch.autocast(self._get_device())):
+        with (
+            torch.no_grad(),
+            torch.autocast(self._get_device()),
+        ):
             outputs = self.structure_model(pixel_values)
 
         structure_id2label = self.structure_model.config.id2label

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -223,7 +223,7 @@ class TableTransformerStructureExtractor(TableStructureExtractor):
 
         import torch
 
-        with (torch.no_grad(), torch.autocast(self._get_device()):
+        with (torch.no_grad(), torch.autocast(self._get_device())):
             outputs = self.structure_model(pixel_values)
 
         structure_id2label = self.structure_model.config.id2label

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -223,7 +223,7 @@ class TableTransformerStructureExtractor(TableStructureExtractor):
 
         import torch
 
-        with torch.no_grad():
+        with (torch.no_grad(), torch.autocast(self._get_device()):
             outputs = self.structure_model(pixel_values)
 
         structure_id2label = self.structure_model.config.id2label

--- a/lib/sycamore/sycamore/transforms/table_structure/extract.py
+++ b/lib/sycamore/sycamore/transforms/table_structure/extract.py
@@ -223,10 +223,8 @@ class TableTransformerStructureExtractor(TableStructureExtractor):
 
         import torch
 
-        with (
-            torch.no_grad(),
-            torch.autocast(self._get_device()),
-        ):
+        # We tried torch.autocast() here, but it introduced errors...
+        with torch.no_grad():
             outputs = self.structure_model(pixel_values)
 
         structure_id2label = self.structure_model.config.id2label


### PR DESCRIPTION
These dropped the naive case for DETR partitioning from ~18 seconds to ~14.

Using torch.autocast() with the DETR table model caused wrong answers; so, we don't use it there.