### PR TITLE
Update bbox_sort and xycut to support an optional reading order.

### DIFF
--- a/lib/sycamore/sycamore/tests/unit/utils/test_bbox_sort.py
+++ b/lib/sycamore/sycamore/tests/unit/utils/test_bbox_sort.py
@@ -74,6 +74,18 @@ def test_page_basic() -> None:
     assert elems == answer
 
 
+def test_page_basic_rtl() -> None:
+    e0 = mkElem(0.52, 0.21, 0.90, 0.45)
+    e1 = mkElem(0.10, 0.21, 0.48, 0.46)
+    e2 = mkElem(0.10, 0.58, 0.48, 0.90)
+    e3 = mkElem(0.58, 0.51, 0.90, 0.85)
+    e4 = mkElem(0.15, 0.10, 0.85, 0.15)
+    elems = [e0, e1, e2, e3, e4]
+    bbox_sort_page(elems, reading_direction="rtl")
+    answer = [e4, e0, e3, e1, e2]
+    assert elems == answer
+
+
 def test_elements_basic() -> None:
     # e1.top < e0.top = e2.top, e0.left < e2.left both on left
     e0 = mkElem(0.20, 0.50, 0.45, 0.70, 3)
@@ -99,6 +111,18 @@ def test_elements_basic() -> None:
     assert_element_index_sorted(elems)
 
 
+def test_sort_elements_rtl_bbox() -> None:
+    e0 = mkElem(0.70, 0.10, 0.90, 0.30, 1)
+    e1 = mkElem(0.10, 0.10, 0.30, 0.30, 1)
+    e2 = mkElem(0.70, 0.35, 0.90, 0.55, 1)
+    e3 = mkElem(0.10, 0.35, 0.30, 0.55, 1)
+    elems = [e1, e2, e3, e0]
+    sort_elements(elems, mode="bbox", reading_direction="rtl")
+    answer = [e0, e2, e1, e3]
+    assert elems == answer
+    assert_element_index_sorted(elems)
+
+
 def test_document_basic() -> None:
     e0 = mkElem(0.1, 0.5, 0.9, 0.2, 3)
     e1 = mkElem(0.1, 0.1, 0.9, 0.2, 3)
@@ -110,6 +134,19 @@ def test_document_basic() -> None:
     doc.elements = [e0, e1, e2, e3, e4, e5]
     sort_document(doc, mode="bbox")
     answer = [e3, e2, e5, e4, e1, e0]
+    assert doc.elements == answer
+    assert_element_index_sorted(doc.elements)
+
+
+def test_document_rtl_bbox() -> None:
+    doc = Document()
+    e0 = mkElem(0.65, 0.15, 0.90, 0.30, 1)
+    e1 = mkElem(0.15, 0.15, 0.35, 0.30, 1)
+    e2 = mkElem(0.65, 0.55, 0.90, 0.70, 2)
+    e3 = mkElem(0.15, 0.55, 0.35, 0.70, 2)
+    doc.elements = [e1, e3, e0, e2]
+    sort_document(doc, mode="bbox", reading_direction="rtl")
+    answer = [e0, e1, e2, e3]
     assert doc.elements == answer
     assert_element_index_sorted(doc.elements)
 

--- a/lib/sycamore/sycamore/tests/unit/utils/test_xycut_sort.py
+++ b/lib/sycamore/sycamore/tests/unit/utils/test_xycut_sort.py
@@ -4,6 +4,9 @@ from sycamore.data import Document, Element
 from sycamore.utils.xycut import xycut_sort_page
 from sycamore.utils.element_sort import sort_elements, sort_document
 
+from sycamore.utils.image_utils import try_draw_boxes
+from PIL import Image
+
 
 def mkElem(
     left: float, top: float, right: float, bot: float, page: Optional[int] = None, type: str = "Text"
@@ -12,6 +15,26 @@ def mkElem(
     if page is not None:
         d["properties"] = {"page_number": page}
     return Element(d)
+
+
+def text_fn_offset(offset: int):
+    def text_fn(box, index) -> str:
+        return str(index + offset)
+
+    return text_fn
+
+
+def show_res(sorted):
+    from itertools import groupby
+
+    offset = 0
+
+    for k, g in groupby(sorted, key=lambda e: e.data.get("properties", {}).get("page_number", 0)):
+        lst = list(g)
+        img = Image.new("RGB", (1000, 1000), "white")
+        try_draw_boxes(img, lst)
+        offset += len(lst)
+        img.show()
 
 
 def test_page_basic() -> None:
@@ -24,9 +47,13 @@ def test_page_basic() -> None:
     e3 = mkElem(0.60, 0.65, 0.90, 0.85)
     e4 = mkElem(0.15, 0.10, 0.85, 0.15)
     elems = [e0, e1, e2, e3, e4]
-    xycut_sort_page(elems)
+    xycut_sort_page(elems, reading_direction="ltr")
     answer = [e4, e1, e2, e0, e3]
     assert elems == answer
+
+    xycut_sort_page(elems, reading_direction="rtl")
+    rtl_answer = [e4, e0, e3, e1, e2]
+    assert elems == rtl_answer
 
 
 def test_elements_basic() -> None:
@@ -48,9 +75,17 @@ def test_elements_basic() -> None:
     e9 = mkElem(0.20, 0.21, 0.90, 0.41, 2)
 
     elems = [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9]
+
     sort_elements(elems, mode="xycut")
     answer = [e4, e5, e3, e6, e7, e8, e9, e1, e0, e2]
+
     assert elems == answer
+    assert_element_index_sorted(elems)
+
+    sort_elements(elems, mode="xycut", reading_direction="rtl")
+    answer_rtl = [e3, e6, e4, e5, e7, e8, e9, e1, e2, e0]
+
+    assert elems == answer_rtl
     assert_element_index_sorted(elems)
 
 
@@ -68,6 +103,11 @@ def test_document_basic() -> None:
     assert doc.elements == answer
     assert_element_index_sorted(doc.elements)
 
+    sort_document(doc, mode=xycut_sort_page, reading_direction="rtl")
+    answer_rtl = [e3, e2, e5, e4, e1, e0]
+    assert doc.elements == answer_rtl
+    assert_element_index_sorted(doc.elements)
+
 
 def test_page_footer() -> None:
     # e1, e2 in left  column, e1.top < e2.top
@@ -81,9 +121,14 @@ def test_page_footer() -> None:
     e4 = mkElem(0.15, 0.10, 0.85, 0.15)
     e5 = mkElem(0.25, 0.95, 0.75, 1.0, type="Page-footer")
     elems = [e0, e1, e2, e3, e4, e5]
+
     xycut_sort_page(elems)
     answer = [e4, e1, e2, e0, e3, e5]
     assert elems == answer
+
+    xycut_sort_page(elems, reading_direction="rtl")
+    answer_rtl = [e4, e0, e3, e1, e2, e5]
+    assert elems == answer_rtl
 
 
 def test_no_cut() -> None:
@@ -92,9 +137,53 @@ def test_no_cut() -> None:
     e2 = mkElem(0.70, 0.10, 0.90, 0.60)
     e3 = mkElem(0.10, 0.10, 0.60, 0.30)
     elems = [e0, e1, e2, e3]
+
     xycut_sort_page(elems)
     answer = [e3, e1, e0, e2]  # what bbox_sort gives
     assert elems == answer
+
+    xycut_sort_page(elems, reading_direction="rtl")
+    answer = [e2, e0, e3, e1]  # what bbox_sort gives
+    assert elems == answer
+
+
+def test_page_basic_rtl() -> None:
+    e0 = mkElem(0.59, 0.25, 0.90, 0.60)
+    e1 = mkElem(0.10, 0.26, 0.40, 0.51)
+    e2 = mkElem(0.10, 0.58, 0.40, 0.90)
+    e3 = mkElem(0.60, 0.65, 0.90, 0.85)
+    e4 = mkElem(0.15, 0.10, 0.85, 0.15)
+    elems = [e0, e1, e2, e3, e4]
+    xycut_sort_page(elems, reading_direction="rtl")
+    answer = [e4, e0, e3, e1, e2]
+    assert elems == answer
+
+
+def test_no_cut_rtl() -> None:
+    e0 = mkElem(0.40, 0.70, 0.90, 0.90)
+    e1 = mkElem(0.10, 0.40, 0.30, 0.90)
+    e2 = mkElem(0.70, 0.10, 0.90, 0.60)
+    e3 = mkElem(0.10, 0.10, 0.60, 0.30)
+    elems = [e0, e1, e2, e3]
+    xycut_sort_page(elems, reading_direction="rtl")
+    answer = [e2, e0, e3, e1]
+    assert elems == answer
+
+
+def test_sort_elements_rtl() -> None:
+    e0 = mkElem(0.70, 0.15, 0.90, 0.35, 1)
+    e1 = mkElem(0.10, 0.15, 0.30, 0.35, 1)
+    e2 = mkElem(0.70, 0.40, 0.90, 0.60, 1)
+    e3 = mkElem(0.10, 0.40, 0.30, 0.60, 1)
+    e4 = mkElem(0.10, 0.05, 0.90, 0.10, 2)
+    e5 = mkElem(0.65, 0.20, 0.90, 0.40, 2)
+    e6 = mkElem(0.10, 0.20, 0.35, 0.40, 2)
+
+    elems = [e3, e6, e1, e2, e5, e4, e0]
+    sort_elements(elems, mode="xycut", reading_direction="rtl")
+    answer = [e0, e2, e1, e3, e4, e5, e6]
+    assert elems == answer
+    assert_element_index_sorted(elems)
 
 
 # bbox coordinates and reading order from page 9 of

--- a/lib/sycamore/sycamore/utils/xycut.py
+++ b/lib/sycamore/sycamore/utils/xycut.py
@@ -5,13 +5,14 @@ Best to access this through element_sort.py
 """
 
 from io import StringIO
-from typing import Generator, Optional
+from typing import Generator, Literal, Optional
 
 from sycamore.data import Element
 from sycamore.utils.bbox_sort import bbox_sort_page  # for fallback
 
 ElemList = list[Element]
 BeginEndList = list[tuple[float, int, Element]]
+ReadingDirection = Literal["ltr", "rtl"]
 
 XAXIS = 0  # bbox[0] and bbox[2] are x
 YAXIS = 1  # bbox[1] and bbox[3] are y
@@ -194,7 +195,7 @@ def widest_cut(order: BeginEndList) -> tuple[float, Element]:
     return rv
 
 
-def choose_axis(elems: ElemList) -> Optional[tuple[BeginEndList, Element]]:
+def choose_axis(elems: ElemList) -> Optional[tuple[int, BeginEndList, Element]]:
     """Note that coordinate system is square, but pages are not."""
     xorder = make_begin_end(elems, XAXIS)
     yorder = make_begin_end(elems, YAXIS)
@@ -207,61 +208,66 @@ def choose_axis(elems: ElemList) -> Optional[tuple[BeginEndList, Element]]:
             yval = get_bbox(ye)[3]
             s = elem_to_str(ye)
             print(f"Horiz cut y={yval:.3f} {s}")
-        return (yorder, ye)
+        return (YAXIS, yorder, ye)
     else:
         if DEBUG:
             xval = get_bbox(xe)[2]
             s = elem_to_str(xe)
             print(f"Vert cut x={xval:.3f} {s}")
-        return (xorder, xe)
+        return (XAXIS, xorder, xe)
 
 
-def cleave_elems(elems: ElemList) -> NodeLeaf:
+def cleave_elems(elems: ElemList, reading_direction: ReadingDirection) -> NodeLeaf:
     """Binary split across widest gap."""
     node = NodeLeaf()
+    split_axis: Optional[int] = None
     if len(elems) < 2:
         node.extend(elems)
     elif (choice := choose_axis(elems)) is None:
         node.extend(elems)
     else:
-        order, cut_after = choice
+        split_axis, order, cut_after = choice
         for _, isopen, elem, cnt, width in gen_overlap(order):
             if not isopen:
                 node.append(elem)
                 if elem == cut_after:
                     node.advance()
-    return node.finalize()
+    node = node.finalize()
+    if (split_axis == XAXIS) and (reading_direction == "rtl") and (len(node.elists) > 1):
+        node.elists.reverse()
+    return node
 
 
-def divide_node(node: NodeLeaf) -> NodeInner:
+def divide_node(node: NodeLeaf, reading_direction: ReadingDirection) -> NodeInner:
     """Return replacement Node.  Assume input is leaf."""
     inner = NodeInner()
     for elist in node.elists:
-        subnode = cleave_elems(elist)
+        subnode = cleave_elems(elist, reading_direction)
         if DEBUG:
             print("....................")
             print(subnode)
             print("^^^^^^^^^^^^^^^^^^^^")
         if subnode.cansplit():
-            inner.append(divide_node(subnode))  # recursive step
+            inner.append(divide_node(subnode, reading_direction))  # recursive step
         else:
             inner.append(subnode)
     return inner
 
 
-def xycut_sort_page(elems: ElemList) -> None:
+def xycut_sort_page(elems: ElemList, *, reading_direction: ReadingDirection = "ltr") -> None:
     if len(elems) < 2:
         return
-    flat = NodeLeaf().extend(elems)
+    flat = NodeLeaf()
+    flat.extend(elems)
     if DEBUG:
         print("VVVVVVVVVVVVVVVVVVVV")
         print(flat)
         print("AAAAAAAAAAAAAAAAAAAA")
-    tree = divide_node(flat)
+    tree = divide_node(flat, reading_direction)
     if (len(tree.nodes) == 1) and isinstance(tree.nodes[0], NodeLeaf) and (len(tree.nodes[0].elists) == 1):
         # If we didn't make any cuts, fall back to old algorithm
         if DEBUG:
             print("Falling back to bbox_sort")
-        bbox_sort_page(elems)
+        bbox_sort_page(elems, reading_direction=reading_direction)
         return
     elems[:] = tree.to_elems()  # replace contents of list


### PR DESCRIPTION
The default remains "ltr", but if you pass "rtl", it will sort elements. based on that reading order.