### PR TITLE
Serialize set value attributes as a list.

### DIFF
--- a/lib/sycamore/sycamore/schema.py
+++ b/lib/sycamore/sycamore/schema.py
@@ -10,6 +10,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    field_serializer,
     TypeAdapter,
     ValidatorFunctionWrapHandler,
     WrapValidator,
@@ -134,6 +135,12 @@ class PropertyValidator(BaseModel, ABC):
     @abstractmethod
     def validate_property(self, propval: Any) -> tuple[bool, Any]:
         pass
+
+    # Not all consumers of this class handle sets well, so we convert to list
+    # on the way out.
+    @field_serializer("allowable_types")
+    def serialize_allowable_types(self, allowable_types: set[DataType]) -> list[DataType]:
+        return list(allowable_types)
 
 
 class RegexValidator(PropertyValidator):

--- a/lib/sycamore/sycamore/tests/unit/test_schema.py
+++ b/lib/sycamore/sycamore/tests/unit/test_schema.py
@@ -1,4 +1,5 @@
-from sycamore.schema import SchemaV2, make_property, make_named_property, NamedProperty
+import json
+from sycamore.schema import SchemaV2, make_property, make_named_property, NamedProperty, RegexValidator
 
 single_property_dict_old = {
     "name": "state",
@@ -347,3 +348,15 @@ def test_ziptraverse():
         if v.name in ("start", "end"):
             assert p.name == "years_resident"
             continue
+
+
+def test_validator_json_serialize():
+    r = RegexValidator(regex=r"[0-9]{3}")
+    res, _ = r.validate_property("123")
+    assert res
+
+    js = json.dumps(r.model_dump())
+    r2 = RegexValidator.model_validate_json(js)
+
+    assert r.regex == r2.regex
+    assert r.allowable_types == r2.allowable_types


### PR DESCRIPTION
Sets don't get handled correctly by libraries like httpx, so we convert to lists during serialization. Pydantic will automatically convert from list back to set during validation.